### PR TITLE
fix small typo in `hypothesis` help page.

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -99,7 +99,7 @@ brmssummary <- function(formula = NULL, family = "", link = "",
 #'  When interpreting Bayes factors, make sure 
 #'  that your priors are reasonable and carefully chosen,
 #'  as the result will depend heavily on the priors. 
-#'  It particular, avoid using default priors.
+#'  In particular, avoid using default priors.
 #'  
 #'  The argument \code{alpha} specifies the size of the credible interval
 #'  (i.e., Bayesian confidence interval).


### PR DESCRIPTION
Just a small typo fix in `hypothesis.brmsfit` help page.