### PR TITLE
Fix minor mistakes in the cor_ar() and cor_ma() documentation

### DIFF
--- a/R/correlations.R
+++ b/R/correlations.R
@@ -105,6 +105,8 @@ cor_arma <- function(formula = ~ 1, p = 0, q = 0, r = 0, cov = FALSE) {
 
 #' 
 #' @inheritParams cor_arma
+#' @param p A non-negative integer specifying the autoregressive (AR) 
+#'   order of the ARMA structure. Default is 1.  
 #' 
 #' @return An object of class \code{cor_arma} containing solely autoregression terms.
 #' 
@@ -133,6 +135,8 @@ cor_ar <- function(formula = ~ 1, p = 1, cov = FALSE) {
 #' @inheritParams cor_arma
 #' 
 #' @return An object of class \code{cor_arma} containing solely moving average terms.
+#' @param q A non-negative integer specifying the moving average (MA) 
+#'   order of the ARMA structure. Default is 1.  
 #' 
 #' @author Paul-Christian Buerkner \email{paul.buerkner@@gmail.com}
 #' 

--- a/man/cor_ar.Rd
+++ b/man/cor_ar.Rd
@@ -17,7 +17,7 @@ Defaults to \code{~ 1}, which corresponds to using the order of the observations
 in the data as a covariate, and no groups.}
 
 \item{p}{A non-negative integer specifying the autoregressive (AR) 
-order of the ARMA structure. Default is 0.}
+order of the ARMA structure. Default is 1.}
 
 \item{cov}{A flag indicating whether ARMA effects should be estimated 
 by means of residual covariance matrices

--- a/man/cor_ma.Rd
+++ b/man/cor_ma.Rd
@@ -17,7 +17,7 @@ Defaults to \code{~ 1}, which corresponds to using the order of the observations
 in the data as a covariate, and no groups.}
 
 \item{q}{A non-negative integer specifying the moving average (MA) 
-order of the ARMA structure. Default is 0.}
+order of the ARMA structure. Default is 1.}
 
 \item{cov}{A flag indicating whether ARMA effects should be estimated 
 by means of residual covariance matrices


### PR DESCRIPTION
Hi Paul,

the default value for `p` in `cor_ar()` and for `q` in `cor_ma()` is 1.  The documentation inherited the defaults from `cor_arma()` although they are different.

With kind regards,
Peter.
