### PR TITLE
Correct minor errors in missing values vignette

### DIFF
--- a/vignettes/brms_missings.Rmd
+++ b/vignettes/brms_missings.Rmd
@@ -59,8 +59,8 @@ head(nhanes)
 There are many approaches allowing us to impute missing data before the actual
 model fitting takes place. From a statistical perspective, multiple imputation
 is one of the best solutions. Each missing value is not imputed once but
-\code{m} times leading to a total of \code{m} fully imputed data sets. The model
-can then be fitted to each of those data sets separetely and results are pooled
+`m` times leading to a total of `m` fully imputed data sets. The model
+can then be fitted to each of those data sets separately and results are pooled
 across models, afterwards. One widely applied package for multiple imputation is
 **mice** (Buuren & Groothuis-Oudshoorn, 2010) and we will use it in the
 following in combination with **brms**. Here, we apply the default settings of
@@ -120,7 +120,7 @@ round(fit_imp1$rhats, 2)
 ```
 
 The convergence of each of the submodels looks good. Accordingly, we can proceed
-with further post-processing and interpreation of the results. For instance, we
+with further post-processing and interpretation of the results. For instance, we
 could investigate the combined effect of `age` and `chl`.
 
 ```{r}
@@ -171,7 +171,7 @@ rather than excluded by adding `| mi()` on the left-hand side of the
 formulas[^2]. We write `mi(chl)` on the right-hand side of the formula for `bmi`
 to ensure that the estimated missing values of `chl` will be used in the
 prediction of `bmi`. The summary is a bit more cluttered as we get coefficients
-for both response variables, but apart from that we can interprete coefficients
+for both response variables, but apart from that we can interpret coefficients
 in the usual way.
 
 ```{r}


### PR DESCRIPTION
Correct typos, and `\code{m}` was not displaying.