### PR TITLE
Fix a bug: as.mcmc(combine_chains = TRUE)

### DIFF
--- a/R/brmsfit-methods.R
+++ b/R/brmsfit-methods.R
@@ -550,7 +550,7 @@ as.mcmc.brmsfit <- function(x, pars = NA, exact_match = FALSE,
     }
     out <- as.matrix(x$fit, pars)
     mcpar <- c(
-      x$fit@sim$warmup * x$fit@sim$chain + 1, 
+      x$fit@sim$iter * x$fit@sim$chain - (nrow(out) - 1) * x$fit@sim$thin,
       x$fit@sim$iter * x$fit@sim$chain, x$fit@sim$thin
     )
     attr(out, "mcpar") <- mcpar


### PR DESCRIPTION
Thank you for the great package.

Now, I've encountered the following error.
```r
library(brms)
fit <- brm(dist ~ speed, cars, thin = 2)
mcmc <- as.mcmc(fit, combine_chains = TRUE)
head(mcmc)
```
```
Error in attr(data, "tsp") <- c(start, end, frequency) : 
  invalid time series parameters specified
```
When I execute with `thin = 1`, the error does not occur.
The cause is in `brms:::as.mcmc.brmsfit()`.
The `mcmc` class object has the start property as `attr("mcpar")[1]`.
The property must count from the end.
Please refer to `rstan:::as.mcmc.list.stanfit`.
https://github.com/stan-dev/rstan/blob/develop/rstan/rstan/R/stanfit-class.R#L845
```r
    x <- as.matrix(x)
    end <- object@sim$iter
    thin <- object@sim$thin
    start <- end - (nrow(x) - 1) * thin
    class(x) <- 'mcmc'
    attr(x, "mcpar") <- c(start, end, thin)
```
So I've fixed the line for setting `mcpar[1]` in this PR.
And checked the above code runs well.

However, I've changed no codes for `as.mcmc.brmsfit(combine_chains = FALSE)` where it has the same bug.
To resolve it, you may need to change behavior of the function.
The simplest solution is to use `rstan::As.mcmc.list()`.
But the function cannot take the `inc_warmup` argument.