### PR TITLE
Fix a bug: as.mcmc(inc_warmup = TRUE)

### DIFF
--- a/R/brmsfit-methods.R
+++ b/R/brmsfit-methods.R
@@ -557,11 +557,14 @@ as.mcmc.brmsfit <- function(x, pars = NA, exact_match = FALSE,
     attr(out, "mcpar") <- mcpar
     class(out) <- "mcmc"
   } else {
+    thin <- x$fit@sim$thin
+    if (inc_warmup && thin >= 2) {
+      stop2("Cannot include warmup samples when 'thin' >= 2.")
+    }
     ps <- rstan::extract(x$fit, pars, permuted = FALSE, inc_warmup = inc_warmup)
     ndraws <- dim(ps)[1]
     end <- x$fit@sim$iter
-    thin <- x$fit@sim$thin
-    start <- if (inc_warmup) thin else end - (ndraws - 1) * thin
+    start <- end - (ndraws - 1) * thin
     mcpar <- c(start, end, thin)
     out <- vector("list", length = dim(ps)[2])
     for (i in seq_along(out)) {


### PR DESCRIPTION
Hi.
This PR is a continuation of the pull request #811.

Your change is not perfect.
For instance, the same error occurs when the following code runs.

```r
library(brms)
fit <- brm(dist ~ speed, cars, thin = 3)
mcmc_list <- as.mcmc(fit, inc_warmup = TRUE)
head(mcmc_list)
```

The cause is that warmup samples and real MCMC samples are thinned separately.
It is difficult to connect them well into one `mcmc` object.
I suggest prohibiting `inc_warmup = TRUE` if `thin >= 2`.
