### PR TITLE
Added emmeans support

### DIFF
--- a/R/emmeans-support.R
+++ b/R/emmeans-support.R
@@ -1,0 +1,42 @@
+### Rudimentary support for brms objects in emmeans package. 
+### Obviously this is way less than is needed, but it does support simpler models
+
+# These are NOT exported here. They are dynamically exported if emmeans is installed.
+# See code in zzz.R
+
+# Note from RVL: It may be desirable to add optional arguments, especially to
+# the emm_basis method, to allow special options -- e.g., for hurdle
+# models, which part of the model to estimate. If you do that, obviously
+# you will want to document it in some way.
+
+
+# Recover the predictors used in the fixed-effects part of the model
+recover_data.brmsfit <- function(object, data, ...) {
+    bt <- brmsterms(formula(object))
+    if (class(bt) != "brmsterms")
+        stop("This model is currently not supported.")
+    mt <- attr(model.frame(bt$dpars$mu$fe, data = object$data), "terms")
+    ### we don't have a call component so I'll just put in a dummy
+    emmeans::recover_data(call("brms"), mt, "na.omit", data = object$data, ...)
+}
+
+# Calculate the basis for making predictions. This is essentially the
+# inside of the predict() function with new data on the linkm scale. 
+# Transforming to response scale, if desired, is handled by emmeans
+emm_basis.brmsfit <- function(object, trms, xlev, grid, vcov., ...) {
+    m <- model.frame(trms, grid, na.action = na.pass, xlev = xlev)
+    contr <- lapply(object$data, function(.) attr(., "contrasts"))
+    contr <- contr[!sapply(contr, is.null)]
+    X <- model.matrix(trms, m, contrasts.arg = contr)
+    nm <- rename(colnames(X))
+    V <- vcov(object)[nm, nm, drop = FALSE]
+    nbasis <- estimability::all.estble  # we're assuming no rank deficiency
+    dfargs <- list()
+    dffun <- function(k, dfargs) Inf
+    misc <- .std.link.labels(brmsterms(formula(object))$dpars$mu$family, list())
+    post.beta <- as.matrix(object, pars = paste0("b_", nm), fixed = TRUE)
+    bhat <- apply(post.beta, 2, mean)
+    
+    list(X = X, bhat = bhat, nbasis = nbasis, V = V, dffun = dffun, dfargs = dfargs, 
+         misc = misc, post.beta = post.beta)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,3 +19,14 @@
 #   rstan::stan_model(stanc_ret = model)
 # }
 # new_stan_functions <- new_stan_functions()
+
+
+# The following code dynamically registers the recover_data and emm_basis
+# methods needed by emmeans, if that package is installed.
+
+.onLoad <- function(libname, pkgname) {
+    if (requireNamespace("emmeans", quietly = TRUE)) {
+        emmeans::.emm_register(c("brmsfit"), pkgname)
+    }
+    invisible()
+}

--- a/tests/testthat/tests.emmeans.R
+++ b/tests/testthat/tests.emmeans.R
@@ -1,0 +1,15 @@
+context("Tests for emmeans support")
+
+set.seed(2020.0515)
+fit3 <- brm(time | cens(censored) ~ age * sex + disease + (1|patient),
+            data = kidney, family = lognormal())
+
+rg <- ref_grid(fit3)
+smry <- summary(emmeans(rg, "disease"), point.est = mean)
+
+test_that("We can get basic emmeans estimates", {
+    expect_equal(rg@levels$age, 43.697, tolerance = 0.002)
+    expect_equal(rg@levels$sex, c("male", "female"))
+    expect_equal(smry$emmean, c(4.12, 3.68, 3.58, 4.70), tolerance = 0.02)
+})
+


### PR DESCRIPTION
This adds support for the **emmeans** package to the package code for **brms**. Because of the way it is dispatched, this code will override what already exists in the **emmeans** package.

This added code is essentially what is already provided in the **emmeans** package, but updated to avoid warnings, e.g., it uses `brmsterms` rather than `parse_bf`. It provides basic support for rather standard models, but not fancier ones, e.g. hurdle models. I would hope that by having this in your own package, you can add features to support those models too. I'd be happy to answer questions.

The contributed code consists of methods `recover_data.brmsfit` and `emm_basis.brmsfit`; added code in `zzz.R` to register these methods when **emmeans** is installed on the user's system; and a few tests on basic functionality.