### PR TITLE
CmdStanR updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
 Suggests: 
     testthat (>= 0.9.1),
     emmeans (>= 1.4.2),
-    cmdstanr,
+    cmdstanr (>= 0.0.0.9008),
     RWiener,
     rtdists,
     mice,

--- a/R/backends.R
+++ b/R/backends.R
@@ -163,7 +163,6 @@ fit_model <- function(model, backend, ...) {
   }
   args <- nlist(data = sdata, seed, init = inits)
   # TODO: exclude variables via 'exclude'
-  # TODO: silence messages via 'silent'
   dots <- list(...)
   args[names(dots)] <- dots
   args[names(control)] <- control
@@ -174,7 +173,7 @@ fit_model <- function(model, backend, ...) {
     c(args) <- nlist(
       iter_sampling = iter - warmup,
       iter_warmup = warmup, 
-      chains, cores, thin
+      show_messages = !silent
     )
     out <- do_call(model$sample, args)
   } else if (algorithm %in% c("fullrank", "meanfield")) {

--- a/R/backends.R
+++ b/R/backends.R
@@ -25,8 +25,7 @@ parse_model <- function(model, backend, ...) {
 # @return validated Stan model code
 .parse_model_cmdstanr <- function(model, silent = TRUE, ...) {
   require_package("cmdstanr")
-  temp_file <- tempfile(fileext = ".stan")
-  cat(model, file = temp_file) 
+  temp_file <- cmdstanr::write_stan_tempfile(model)
   out <- eval_silent(
     cmdstanr::cmdstan_model(temp_file, compile = FALSE, ...),
     type = "message", 
@@ -66,9 +65,7 @@ compile_model <- function(model, backend, ...) {
   require_package("cmdstanr")
   args <- list(...)
   silent <- !length(args)
-  temp_file <- tempfile(fileext = ".stan")
-  cat(model, file = temp_file) 
-  args$stan_file <- temp_file
+  args$stan_file <- cmdstanr::write_stan_tempfile(model)
   eval_silent(
     do_call(cmdstanr::cmdstan_model, args),
     silent = silent, type = "message"

--- a/R/backends.R
+++ b/R/backends.R
@@ -173,6 +173,8 @@ fit_model <- function(model, backend, ...) {
     c(args) <- nlist(
       iter_sampling = iter - warmup,
       iter_warmup = warmup, 
+      chains, thin, 
+      parallel_chains = cores,
       show_messages = !silent
     )
     out <- do_call(model$sample, args)

--- a/R/brm.R
+++ b/R/brm.R
@@ -134,7 +134,7 @@
 #'   distribution. Can be set globally for the current \R session via the
 #'   \code{"stan_algorithm"} option (see \code{\link{options}}).
 #' @param backend Character string naming the package to use as the backend for
-#'   fiting the Stan model. Options are \code{"rstan"} (the default) or
+#'   fitting the Stan model. Options are \code{"rstan"} (the default) or
 #'   \code{"cmdstanr"}. Can be set globally for the current \R session via the
 #'   \code{"stan_backend"} option (see \code{\link{options}}).
 #' @param control A named \code{list} of parameters to control the sampler's

--- a/R/brm.R
+++ b/R/brm.R
@@ -140,7 +140,10 @@
 #' @param backend Character string naming the package to use as the backend for
 #'   fitting the Stan model. Options are \code{"rstan"} (the default) or
 #'   \code{"cmdstanr"}. Can be set globally for the current \R session via the
-#'   \code{"stan_backend"} option (see \code{\link{options}}).
+#'   \code{"stan_backend"} option (see \code{\link{options}}). Details on the
+#'   \pkg{rstan} and \pkg{cmdstanr} packages are available at
+#'   \url{https://mc-stan.org/rstan} and \url{https://mc-stan.org/cmdstanr},
+#'   respectively.
 #' @param control A named \code{list} of parameters to control the sampler's
 #'   behavior. It defaults to \code{NULL} so all the default values are used.
 #'   The most important control parameters are discussed in the 'Details'
@@ -151,11 +154,11 @@
 #'   \code{cores} will be ignored. Can be set globally for the current \R
 #'   session via the \code{future} option. The execution type is controlled via
 #'   \code{\link[future:plan]{plan}} (see the examples section below).
-#' @param silent logical; If \code{TRUE} (the default), most of the
+#' @param silent Logical; If \code{TRUE} (the default), most of the
 #'   informational messages of compiler and sampler are suppressed. The actual
 #'   sampling progress is still printed. Set \code{refresh = 0} to turn this off
-#'   as well. To stop Stan from opening additional progress bars, set
-#'   \code{open_progress = FALSE}.
+#'   as well. If using \code{backend = "rstan"} you can also set
+#'   \code{open_progress = FALSE} to prevent opening additional progress bars.
 #' @param seed The seed for random number generation to make results
 #'   reproducible. If \code{NA} (the default), \pkg{Stan} will set the seed
 #'   randomly.
@@ -177,8 +180,12 @@
 #' @param rename For internal use only. 
 #' @param stan_model_args A \code{list} of further arguments passed to
 #'   \code{\link[rstan:stan_model]{stan_model}}.
-#' @param ... Further arguments passed to Stan that is to
+#' @param ... Further arguments passed to Stan. 
+#'   For \code{backend = "rstan"} the arguments are passed to
 #'   \code{\link[rstan:sampling]{sampling}} or \code{\link[rstan:vb]{vb}}.
+#'   For \code{backend = "cmdstanr"} the arguments are passed to the
+#'   \code{\link[cmdstanr:model-method-sample]{sample}} or 
+#'   \code{\link[cmdstanr:model-method-variational]{variational}} method.
 #' 
 #' @return An object of class \code{brmsfit}, which contains the posterior
 #'   samples along with many other useful information about the model. Use

--- a/R/brm.R
+++ b/R/brm.R
@@ -111,7 +111,11 @@
 #'   do not behave well. Alternatively, \code{inits} can be a list of lists
 #'   containing the initial values, or a function (or function name) generating
 #'   initial values. The latter options are mainly implemented for internal
-#'   testing.
+#'   testing but are available to users if necessary. If specifying initial 
+#'   values using a list or a function then currently the parameter names must
+#'   correspond to the names used in the generated Stan code (not the names
+#'   used in \R). For more details on specifying initial values you can consult 
+#'   the documentation of the selected \code{backend}.
 #' @param chains Number of Markov chains (defaults to 4).
 #' @param iter Number of total iterations per chain (including warmup; defaults
 #'   to 2000).

--- a/man/brm.Rd
+++ b/man/brm.Rd
@@ -155,7 +155,11 @@ constant. Generally, setting \code{inits = "0"} is worth a try, if chains
 do not behave well. Alternatively, \code{inits} can be a list of lists
 containing the initial values, or a function (or function name) generating
 initial values. The latter options are mainly implemented for internal
-testing.}
+testing but are available to users if necessary. If specifying initial 
+values using a list or a function then currently the parameter names must
+correspond to the names used in the generated Stan code (not the names
+used in \R). For more details on specifying initial values you can consult 
+the documentation of the selected \code{backend}.}
 
 \item{chains}{Number of Markov chains (defaults to 4).}
 

--- a/man/brm.Rd
+++ b/man/brm.Rd
@@ -191,7 +191,7 @@ distribution. Can be set globally for the current \R session via the
 \code{"stan_algorithm"} option (see \code{\link{options}}).}
 
 \item{backend}{Character string naming the package to use as the backend for
-fiting the Stan model. Options are \code{"rstan"} (the default) or
+fitting the Stan model. Options are \code{"rstan"} (the default) or
 \code{"cmdstanr"}. Can be set globally for the current \R session via the
 \code{"stan_backend"} option (see \code{\link{options}}).}
 

--- a/man/brm.Rd
+++ b/man/brm.Rd
@@ -197,7 +197,10 @@ distribution. Can be set globally for the current \R session via the
 \item{backend}{Character string naming the package to use as the backend for
 fitting the Stan model. Options are \code{"rstan"} (the default) or
 \code{"cmdstanr"}. Can be set globally for the current \R session via the
-\code{"stan_backend"} option (see \code{\link{options}}).}
+\code{"stan_backend"} option (see \code{\link{options}}). Details on the
+\pkg{rstan} and \pkg{cmdstanr} packages are available at
+\url{https://mc-stan.org/rstan} and \url{https://mc-stan.org/cmdstanr},
+respectively.}
 
 \item{future}{Logical; If \code{TRUE}, the \pkg{\link[future:future]{future}}
 package is used for parallel execution of the chains and argument
@@ -205,11 +208,11 @@ package is used for parallel execution of the chains and argument
 session via the \code{future} option. The execution type is controlled via
 \code{\link[future:plan]{plan}} (see the examples section below).}
 
-\item{silent}{logical; If \code{TRUE} (the default), most of the
+\item{silent}{Logical; If \code{TRUE} (the default), most of the
 informational messages of compiler and sampler are suppressed. The actual
 sampling progress is still printed. Set \code{refresh = 0} to turn this off
-as well. To stop Stan from opening additional progress bars, set
-\code{open_progress = FALSE}.}
+as well. If using \code{backend = "rstan"} you can also set
+\code{open_progress = FALSE} to prevent opening additional progress bars.}
 
 \item{seed}{The seed for random number generation to make results
 reproducible. If \code{NA} (the default), \pkg{Stan} will set the seed
@@ -238,8 +241,12 @@ Stan model outside of \pkg{brms} and want to feed it back into the package.}
 
 \item{rename}{For internal use only.}
 
-\item{...}{Further arguments passed to Stan that is to
-\code{\link[rstan:sampling]{sampling}} or \code{\link[rstan:vb]{vb}}.}
+\item{...}{Further arguments passed to Stan. For \code{backend = "rstan"}
+the arguments are passed to
+\code{\link[rstan:sampling]{sampling}} or \code{\link[rstan:vb]{vb}}.
+For \code{backend = "cmdstanr"} the arguments are passed to the
+\code{\link[cmdstanr:model-method-sample]{sample}} or 
+\code{\link[cmdstanr:model-method-variational]{variational}} method.}
 }
 \value{
 An object of class \code{brmsfit}, which contains the posterior


### PR DESCRIPTION
* Adds usage of new `show_messages` argument in CmdStanR's `$sample()` method
* Gets rid of deprecation warning from `cores` changing to `parallel_chains` in CmdStanR
* Use `cmdstanr::write_stan_tempfile()` for convenience
* Adds version requirement for CmdStanR (alternatively if you prefer we could add logic in the R code to not try to use `show_messages` for earlier versions of CmdStanR but that seemed messier) 

#### Example

```r
# no more informational messages from cmdstanr since silent defaults to TRUE
# and no deprecation warning from cores=4 (uses parallel_chains internally)
fit <- brm(count ~ zAge, data = epilepsy, backend = "cmdstanr", refresh = 0, cores = 4)

Start sampling
Running MCMC with 4 parallel chains...

Chain 1 finished in 0.2 seconds.
Chain 2 finished in 0.2 seconds.
Chain 3 finished in 0.1 seconds.
Chain 4 finished in 0.1 seconds.

All 4 chains finished successfully.
Mean chain execution time: 0.2 seconds.
Total execution time: 0.2 seconds.
```