### PR TITLE
write_stan_tempfile -> write_stan_file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
 Suggests: 
     testthat (>= 0.9.1),
     emmeans (>= 1.4.2),
-    cmdstanr (>= 0.1.0),
+    cmdstanr (>= 0.1.2),
     RWiener,
     rtdists,
     mice,

--- a/R/backends.R
+++ b/R/backends.R
@@ -25,7 +25,7 @@ parse_model <- function(model, backend, ...) {
 # @return validated Stan model code
 .parse_model_cmdstanr <- function(model, silent = TRUE, ...) {
   require_package("cmdstanr")
-  temp_file <- cmdstanr::write_stan_tempfile(model)
+  temp_file <- cmdstanr::write_stan_file(model)
   out <- eval_silent(
     cmdstanr::cmdstan_model(temp_file, compile = FALSE, ...),
     type = "message", 
@@ -60,7 +60,7 @@ compile_model <- function(model, backend, ...) {
 .compile_model_cmdstanr <- function(model, ...) {
   require_package("cmdstanr")
   args <- list(...)
-  args$stan_file <- cmdstanr::write_stan_tempfile(model)
+  args$stan_file <- cmdstanr::write_stan_file(model)
   do_call(cmdstanr::cmdstan_model, args)
 }
 


### PR DESCRIPTION
closes #981

* Bump cmdstanr version to 0.1.2 (now available via mc-stan.org/r-packages)
* Replace deprecated `write_stan_tempfile()` with `write_stan_file()`