### PR TITLE
add number of chains to emmeans method

### DIFF
--- a/R/emmeans.R
+++ b/R/emmeans.R
@@ -56,6 +56,7 @@ emm_basis.brmsfit <- function(object, trms, xlev, grid, vcov., resp = NULL,
   dffun <- function(k, dfargs) Inf
   misc <- emmeans::.std.link.labels(bterms$family, list())
   post.beta <- as.matrix(object, pars = paste0("b_", nm), fixed = TRUE)
+  attr(post.beta, "n.chains") = object$fit@sim$chains
   bhat <- apply(post.beta, 2, mean)
   nlist(X, bhat, nbasis, V, dffun, dfargs, misc, post.beta)
 }


### PR DESCRIPTION
Hi Paul,

The small commit adds the number of chains to the `emmeans` method. This automatically propagates chain number to `emmeans` in case one requests the samples. The result is that the `emmeans` method behaves more similar than the other `emmeans` methods for MCMC samples.

As an example, take the following code:
```r
library("brms")
fit_warp <- brm(breaks ~ wool * tension, data = warpbreaks, 
                chains = 2, iter = 1000)

library(emmeans)
str(as.mcmc(emmeans(fit_warp, "wool")))
```

The result from the current version gives an output without chain information.
```
NOTE: Results may be misleading due to involvement in interactions
 'mcmc' num [1:1000, 1:2] 30.5 26.5 31.7 32 30.4 ...
 - attr(*, "dimnames")=List of 2
  ..$ : chr [1:1000] "1" "2" "3" "4" ...
  ..$ : chr [1:2] "wool A" "wool B"
 - attr(*, "mcpar")= num [1:3] 1 1000 1
```

With the fix we get the information separately by chain:
```
NOTE: Results may be misleading due to involvement in interactions
List of 2
 $ : 'mcmc' num [1:500, 1:2] 30.5 26.5 31.7 32 30.4 ...
  ..- attr(*, "dimnames")=List of 2
  .. ..$ : chr [1:500] "1" "2" "3" "4" ...
  .. ..$ : chr [1:2] "wool A" "wool B"
  ..- attr(*, "mcpar")= num [1:3] 1 500 1
 $ : 'mcmc' num [1:500, 1:2] 29.5 34.3 34.1 35.1 29.9 ...
  ..- attr(*, "dimnames")=List of 2
  .. ..$ : chr [1:500] "501" "502" "503" "504" ...
  .. ..$ : chr [1:2] "wool A" "wool B"
  ..- attr(*, "mcpar")= num [1:3] 1 500 1
 - attr(*, "class")= chr "mcmc.list"
```

This is in line with the behaviour for `rstanarm` which also gives information separately by chain:
```
library("rstanarm")
fit_warp2 <- stan_glm(breaks ~ wool * tension, data = warpbreaks, 
                      family = "gaussian", 
                      chains = 2, iter = 1000)
str(as.mcmc(emmeans(fit_warp2, "wool")))
NOTE: Results may be misleading due to involvement in interactions
List of 2
 $ : 'mcmc' num [1:500, 1:2] 32.2 31.5 30.5 29.8 32 ...
  ..- attr(*, "dimnames")=List of 2
  .. ..$ : chr [1:500] "1" "2" "3" "4" ...
  .. ..$ : chr [1:2] "wool A" "wool B"
  ..- attr(*, "mcpar")= num [1:3] 1 500 1
 $ : 'mcmc' num [1:500, 1:2] 32.2 32.4 33.7 32.3 30.6 ...
  ..- attr(*, "dimnames")=List of 2
  .. ..$ : chr [1:500] "501" "502" "503" "504" ...
  .. ..$ : chr [1:2] "wool A" "wool B"
  ..- attr(*, "mcpar")= num [1:3] 1 500 1
 - attr(*, "class")= chr "mcmc.list"
```

Cheers,
Henrik