### PR TITLE
Update to emmeans support: dpar = "mean"

### DIFF
--- a/R/emmeans.R
+++ b/R/emmeans.R
@@ -5,11 +5,16 @@
 #' they will be called automatically by the \code{emmeans} function
 #' of the \pkg{emmeans} package.
 #' 
+#' In addition to the usual choices for \code{dpar}, the special value
+#' \code{dpar = "mean"} requests that we use the expected values of the posterior 
+#' predictive distribution, obtained via \code{\link{posterior_epred.brmsfit}}.
+#' 
 #' @name emmeans-brms-helpers
 #' 
 #' @inheritParams posterior_epred.brmsfit
 #' @param data,trms,xlev,grid,vcov. Arguments required by \pkg{emmeans}.
 #' @param ... Additional arguments passed to \pkg{emmeans}.
+#' 
 #' 
 #' @examples 
 #' \dontrun{
@@ -22,42 +27,66 @@
 #' rg <- ref_grid(fit)
 #' em <- emmeans(rg, "disease")
 #' summary(em, point.est = mean)
+#' 
+#' epred <- emmeans(fit, "disease", dpar = "mean")
+#' summary(epred, point.est = mean)
 #' }
 NULL
 
 # recover the predictors used in the population-level part of the model
 #' @rdname emmeans-brms-helpers
-recover_data.brmsfit <- function(object, data, resp = NULL, dpar = NULL, 
-                                 nlpar = NULL, ...) {
-  bterms <- .extract_par_terms(object, resp, dpar, nlpar)
-  trms <- attr(model.frame(bterms$fe, data = object$data), "terms")
-  # brms has no call component so the call is just a dummy
+recover_data.brmsfit <- function (object, data, resp = NULL, dpar = NULL, nlpar = NULL, 
+                                  ...) 
+{
+  if(is.character(dpar) && dpar == "mean") {
+    preds <- all.vars(.extract_par_terms(object, resp, NULL, nlpar)$fe)
+    for (pf in object$formula$pforms)
+      preds <- union(preds, all.vars(pf[-2]))
+    bterms <- list(fe = reformulate(preds))
+  }
+  else {
+    bterms <- .extract_par_terms(object, resp, dpar, nlpar)
+  }
+  trms <- attr(model.frame(bterms$fe, data = object$data), 
+               "terms")
+  
   emmeans::recover_data(call("brms"), trms, "na.omit", object$data, ...)
 }
+
 
 # Calculate the basis for making predictions. This is essentially the
 # inside of the predict() function with new data on the link scale. 
 # Transforming to response scale, if desired, is handled by emmeans.
 #' @rdname emmeans-brms-helpers
-emm_basis.brmsfit <- function(object, trms, xlev, grid, vcov., resp = NULL,
-                              dpar = NULL, nlpar = NULL, ...) {
-  bterms <- .extract_par_terms(object, resp, dpar, nlpar)
-  m <- model.frame(trms, grid, na.action = na.pass, xlev = xlev)
-  contr <- lapply(object$data, function(x) attr(x, "contrasts"))
-  contr <- contr[!ulapply(contr, is.null)]
-  p <- combine_prefix(bterms)
-  cols2remove <- if (is_ordinal(bterms)) "(Intercept)"
-  X <- get_model_matrix(trms, m, cols2remove, contrasts.arg = contr)
-  nm <- paste0(usc(p, "suffix"), colnames(X))
-  V <- vcov(object)[nm, nm, drop = FALSE]
-  # we are assuming no rank deficiency
+emm_basis.brmsfit <- function (object, trms, xlev, grid, vcov., resp = NULL, dpar = NULL, 
+                               nlpar = NULL, ...) 
+{
+  if (is.character(dpar) && dpar == "mean") {
+    post.beta <- posterior_epred(object, newdata = grid, re_formula = NA, ...)
+    bhat <- apply(post.beta, 2, mean)
+    V <- cov(post.beta)
+    X <- diag(length(bhat))
+    misc <- list()
+  }
+  else {
+    bterms <- .extract_par_terms(object, resp, dpar, nlpar)
+    m <- model.frame(trms, grid, na.action = na.pass, xlev = xlev)
+    contr <- lapply(object$data, function(x) attr(x, "contrasts"))
+    contr <- contr[!ulapply(contr, is.null)]
+    p <- combine_prefix(bterms)
+    cols2remove <- if (is_ordinal(bterms)) 
+      "(Intercept)"
+    X <- get_model_matrix(trms, m, cols2remove, contrasts.arg = contr)
+    nm <- paste0(usc(p, "suffix"), colnames(X))
+    V <- vcov(object)[nm, nm, drop = FALSE]
+    misc <- emmeans::.std.link.labels(bterms$family, list())
+    post.beta <- as.matrix(object, pars = paste0("b_", nm), 
+                           fixed = TRUE)
+    bhat <- apply(post.beta, 2, mean)
+  }
   nbasis <- matrix(NA)
   dfargs <- list()
   dffun <- function(k, dfargs) Inf
-  misc <- emmeans::.std.link.labels(bterms$family, list())
-  post.beta <- as.matrix(object, pars = paste0("b_", nm), fixed = TRUE)
-  attr(post.beta, "n.chains") = object$fit@sim$chains
-  bhat <- apply(post.beta, 2, mean)
   nlist(X, bhat, nbasis, V, dffun, dfargs, misc, post.beta)
 }
 

--- a/man/emmeans-brms-helpers.Rd
+++ b/man/emmeans-brms-helpers.Rd
@@ -6,9 +6,9 @@
 \alias{emm_basis.brmsfit}
 \title{Support Functions for \pkg{emmeans}}
 \usage{
-recover_data.brmsfit(object, data, resp = NULL, dpar = NULL, nlpar = NULL, ...)
+\method{recover_data}{brmsfit}(object, data, resp = NULL, dpar = NULL, nlpar = NULL, ...)
 
-emm_basis.brmsfit(
+\method{emm_basis}{brmsfit}(
   object,
   trms,
   xlev,
@@ -42,6 +42,11 @@ Users are not required to call these functions themselves. Instead,
 they will be called automatically by the \code{emmeans} function
 of the \pkg{emmeans} package.
 }
+\details{
+In addition to the usual choices for \code{dpar}, the special value
+\code{dpar = "mean"} requests that we use the expected values of the posterior 
+predictive distribution, obtained via \code{\link{posterior_epred.brmsfit}}.
+}
 \examples{
 \dontrun{
 fit <- brm(time | cens(censored) ~ age * sex + disease + (1|patient),
@@ -53,5 +58,8 @@ library(emmeans)
 rg <- ref_grid(fit)
 em <- emmeans(rg, "disease")
 summary(em, point.est = mean)
+
+epred <- emmeans(fit, "disease", dpar = "mean")
+summary(epred, point.est = mean)
 }
 }

--- a/vignettes/brms_nonlinear.Rmd
+++ b/vignettes/brms_nonlinear.Rmd
@@ -221,7 +221,8 @@ plot(me_loss, ncol = 5, points = TRUE)
 It is evident that there is some variation in cumulative loss across accident
 years, for instance due to natural disasters happening only in certain years.
 Further, we see that the uncertainty in the predicted cumulative loss is larger
-for later years with fewer available data points.
+for later years with fewer available data points. For a more detailed discussion
+of this data set, see Section 4.5 in Gesmann & Morris (2020).
 
 ## Advanced Item-Response Models
 
@@ -323,3 +324,8 @@ that accounting for item and person variability (e.g., using a multilevel model
 with varying intercepts) becomes necessary as we have multiple observations per
 item and person. Luckily, this can all be done within the non-linear framework
 of **brms** and I hope that this vignette serves as a good starting point.
+
+## References 
+
+Gesmann M. & Morris J. (2020). Hierarchical Compartmental Reserving Models.
+*CAS Research Papers*.


### PR DESCRIPTION
This PR adds the option `dpar = "mean"` to the support methods for the **emmeans** package. When `emmeans()` or other package function is called with `dpar = "mean"`, we obtain the expectation of the posterior predictive distribution at each grid point, rather than one of the model parameters.

The implementation has two basic parts:

  * In `recover_data.brmsfit`, we combine all the predictors involved in modeling all fixed-effect parameters, so that
    the reference grid includes reference levels for all these predictors.
  * In `emm_basis.brmsfit`, the posterior sample (`post.beta` slot) is obtained using `posterior_epred()`. 
    The `bhat` and `V` slots are the column means and covariance matrix, and the `X` matrix is the identity.

Note that I also added a detail to the documentation, and extendsd the example that was in place. 
That example serves as a good illustration for `dpar = "mean"` because the family is lognormal, making for
a stark difference between the estimated `mu` parameter and the `posterior_epred` values of 
`exp(mu + sigma^2/2)`.