### PR TITLE
Collapse adjacent loops over same ranges

### DIFF
--- a/R/make_stancode.R
+++ b/R/make_stancode.R
@@ -271,7 +271,7 @@ make_stancode <- function(formula, data, family = gaussian(),
     scode_generated_quantities
   )
   
-  scode <- expand_include_statements(scode)
+  scode <- collapse_loops(expand_include_statements(scode))
   if (parse) {
     scode <- parse_model(scode, backend, silent = silent)
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -1083,5 +1083,9 @@ collapse_loops = function(model_code) {
   nn_inds = grep("int nn = n + start - 1;", code_split, fixed=T)
   
   # Return code with those lines removed
-  return(paste0(code_split[-c(unlist(inds),nn_inds[-1])], collapse = "\n"))
+  if(length(nn_inds) < 2) {
+    return(paste0(code_split[-unlist(inds)], collapse = "\n"))
+  } else {
+    return(paste0(code_split[-c(unlist(inds),nn_inds[-1])], collapse = "\n"))
+  }
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -1018,7 +1018,7 @@ get_loop_pars = function(loop_arg) {
   ind_mnr = gsub("\\s*for \\(","\\1", spl1[1])
   ind_mjr = gsub("\\) \\{","\\1", spl2[2])
   
-  return(c(ind_mnr,strt_ind,ind_mjr))
+  return(c(trimws(ind_mnr),trimws(strt_ind),trimws(ind_mjr)))
 }
 
 # Find line number of closing brace of loop, given starting line number


### PR DESCRIPTION
A consequence of model generation in ```brms``` is that the models can generate with multiple loops that each iterate over the same indexes/ranges. This could become costly with larger datasets, and so there would be a (hopefully) decent benefit to collapsing these multiple loops into one.

This PR introduces a post-processing of the generated Stan model that collapses loops that iterate over the same indexes/ranges. The collapse only happens with loops that immediately follow one-another, so that there are no intermediate computations that subsequent loops depend on.

For example,  if we generate the Stan code from one of the models in the vignette:
```
make_stancode(formula = time | cens(censored) ~ age * sex + disease 
                    + (1 + age|patient), 
                    data = kidney, family = lognormal(),
                    prior = c(set_prior("normal(0,5)", class = "b"),
                              set_prior("cauchy(0,2)", class = "sd"),
                              set_prior("lkj(2)", class = "cor")))
```

It contains this set of adjacent loops over the same range:
```
    for (n in 1:N) {
      // add more terms to the linear predictor
      mu[n] += r_1_1[J_1[n]] * Z_1_1[n] + r_1_2[J_1[n]] * Z_1_2[n];
    }
    for (n in 1:N) {
    // special treatment of censored data
      if (cens[n] == 0) {
        target += lognormal_lpdf(Y[n] | mu[n], sigma);
      } else if (cens[n] == 1) {
        target += lognormal_lccdf(Y[n] | mu[n], sigma);
      } else if (cens[n] == -1) {
        target += lognormal_lcdf(Y[n] | mu[n], sigma);
      }
    }
  }
```

With the proposed changes, the code would instead generate to:
```
    for (n in 1:N) {
      // add more terms to the linear predictor
      mu[n] += r_1_1[J_1[n]] * Z_1_1[n] + r_1_2[J_1[n]] * Z_1_2[n];
    // special treatment of censored data
      if (cens[n] == 0) {
        target += lognormal_lpdf(Y[n] | mu[n], sigma);
      } else if (cens[n] == 1) {
        target += lognormal_lccdf(Y[n] | mu[n], sigma);
      } else if (cens[n] == -1) {
        target += lognormal_lcdf(Y[n] | mu[n], sigma);
      }
    }
  }
```