### PR TITLE
Set seed when calling future::future

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -115,7 +115,8 @@ fit_model <- function(model, backend, ...) {
         }
         futures[[i]] <- future::future(
           brms::do_call(rstan::sampling, args), 
-          packages = "rstan"
+          packages = "rstan",
+          seed = TRUE
         )
       }
       for (i in seq_len(chains)) {


### PR DESCRIPTION
Dear @paul-buerkner ,

Many thanks for your great brms package! 

Since a few days, I encounter following warning:

```
Warning: UNRELIABLE VALUE: Future ('<none>') unexpectedly generated random
numbers without specifying argument '[future.]seed'. There is a risk that those
random numbers are not statistically sound and the overall results might be
invalid. To fix this, specify argument '[future.]seed', e.g. 'seed=TRUE'. This
ensures that proper, parallel-safe random numbers are produced via the L'Ecuyer-
CMRG method. To disable this check, use [future].seed=NULL, or set option
'future.rng.onMisuse' to "ignore".
```

I use the future package to run chains concurrently. This PR fixes this warning. This is the relevant news entry of the future package:

> Version: 1.19.0 [2020-09-19]
> 
> SIGNIFICANT CHANGES:
> 
>  * Futures detect when random number generation (RNG) was used to resolve them.
>    If a future uses RNG without parallel RNG was requested, then an informative
>    warning is produced. To request parallel RNG, specify argument 'seed', e.g.
>    'f <- future(rnorm(3), seed=TRUE)' or 'y %<-% { rnorm(3) } %seed% TRUE'.
>    Higher-level map-reduce APIs provide similarly named "seed" arguments to
>    achieve the same.  To, escalate these warning to errors, set option
>    'future.rng.onMisuse' to "error".  To silence them, set it to "ignore".

Again, many thanks for your nice package and all your work!

Best