### PR TITLE
docs: Fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,7 +43,7 @@ to Isaac Petersen. (#1014)
 
 ### New Features
 
-* Experimentally support within-chain parallelizaion via `reduce_sum`
+* Experimentally support within-chain parallelization via `reduce_sum`
 using argument `threads` in `brm` thanks to Sebastian Weber. (#892)
 * Add algorithm `fixed_param` to sample from fixed parameter values. (#973)
 * No longer remove `NA` values in `data` if there are unused because of
@@ -117,7 +117,7 @@ distribution functions thanks to the help of Henrik Singmann. (#385)
 
 * Fix generated Stan Code of models with improper global priors and
 `constant` priors on some coefficients thanks to Frank Weber. (#919)
-* Fix a bug in `conditional_effects` occuring for categorical
+* Fix a bug in `conditional_effects` occurring for categorical
 models with matrix predictors thanks to Jamie Cranston. (#933)
 
 ### Other Changes
@@ -246,7 +246,7 @@ thanks to Andrew Milne. (#830)
 argument `resp_thres`. (#675)
 * Support method `loo_subsample` for performing approximate
 leave-one-out cross-validation for large data.
-* Allow storing more model fit critera via `add_criterion`. (#793)
+* Allow storing more model fit criteria via `add_criterion`. (#793)
 
 ### Bug Fixes
 
@@ -353,7 +353,7 @@ improve their interpretability. (#578)
 * No longer support the `cor_arr` and `cor_bsts` correlation 
 structures after a year of deprecation.
 * Refactor internal evaluation of special predictor terms.
-* Improve penality of splines thanks to Ben Goodrich
+* Improve penalty of splines thanks to Ben Goodrich
 and Ruben Arslan.
 
 ### Bug Fixes
@@ -419,7 +419,7 @@ univariate models thanks to Vassilis Kehayas. (#589)
 * Fix Stan code for t-distributed varying effects 
 thanks to Ozgur Asar.
 * Fix an error in the post-processing of monotonic effects
-occuring for multivariate models thanks to James Rae. (#598)
+occurring for multivariate models thanks to James Rae. (#598)
 * Fix lower bounds in truncated discrete models.
 * Fix checks of the original data in `kfold` thanks to
 the GitHub user gcolitti. (#602)
@@ -817,13 +817,13 @@ Luedecke. (#393)
       and arguments from the package. (#278)
 * No longer support certain prior specifications,
       which were previously labeled as deprecated.
-* Remove the depreacted addition term 
+* Remove the deprecated addition term 
       `disp` from the package.
 * Remove old versions of methods `fixef`,
       `ranef`, `coef`, and `VarCorr`.
 * No longer support models fitted with `brms` < 1.0, 
       which used the multivariate `'trait'` syntax
-      orginally deprecated in `brms` 1.0.
+      originally deprecated in `brms` 1.0.
 * Make posterior sample extraction in the 
       `summary` method cleaner and less error prone.
 * No longer fix the seed for random number generation 
@@ -872,7 +872,7 @@ Luedecke. (#393)
       of `fitted` when returning linear predictors
       of ordinal models thanks to the GitHub user atrolle. (#274)
 * Fix problems in `marginal_smooths`
-      occuring for multi-membership models thanks to
+      occurring for multi-membership models thanks to
       Hans Tierens.
 
 
@@ -1048,7 +1048,7 @@ Luedecke. (#393)
       values for truncated discrete models based
       on new data thanks to Nathan Doogan.
 * Fix unexpected errors when passing
-      models, which did not properly initiliaze,
+      models, which did not properly initialize,
       to various post-processing methods.
 * Do not accidently drop the second 
       dimension of matrices in `summary.brmsfit` 
@@ -1098,9 +1098,9 @@ Luedecke. (#393)
 ### Bug fixes
     
 * Fix an unexpected error in `marginal_effects`
-      occuring for some models with autocorrelation terms 
+      occurring for some models with autocorrelation terms 
       thanks to Markus Gesmann.
-* Fix multiple problems occuring for models with  
+* Fix multiple problems occurring for models with  
       the `cor_bsts` structure thanks to Andrew Ellis.
 
 
@@ -1160,7 +1160,7 @@ Luedecke. (#393)
       all auxiliary parameters.
 * Introduce argument `negative_rt` in
       `predict` and `posterior_predict` to 
-      distinquish responses on the upper and lower 
+      distinguish responses on the upper and lower 
       boundary in `wiener` diffusion models
       thanks to Guido Biele.
 * Introduce method `control_params` to
@@ -1193,7 +1193,7 @@ Luedecke. (#393)
 ### Bug fixes
     
 * Fix problems with the inclusion of offsets
-      occuring for more complicated formulas thanks to 
+      occurring for more complicated formulas thanks to 
       Christian Stock.
 * Fix a bug that led to invalid Stan code when 
       sampling from priors in intercept only models thanks 
@@ -1486,7 +1486,7 @@ Luedecke. (#393)
      
 * Better mimic `mgcv` when parsing smooth terms
       to make sure all arguments are correctly handled.
-* Avoid an error occuring during the prediction 
+* Avoid an error occurring during the prediction 
       of new data when grouping factors with only a single 
       factor level were supplied thanks to Tom Wallis.
 * Fix `marginal_effects` to consistently 
@@ -1497,7 +1497,7 @@ Luedecke. (#393)
       is necessary thanks to Raphael P.H.
 * Allow to correctly `update` the `sample_prior`
       argument to value `"only"`.
-* Fix an unexpected error occuring in many S3 methods
+* Fix an unexpected error occurring in many S3 methods
       when the thinning rate is not a divisor of the total
       number of posterior samples thanks to Paul Zerr.
 
@@ -1558,7 +1558,7 @@ Luedecke. (#393)
 * Center design matrices inside the Stan code
       instead of inside `make_standata`.
 * Get rid of several warning messages
-      occuring on CRAN.
+      occurring on CRAN.
 
 
 
@@ -1628,7 +1628,7 @@ sampling from priors in non-linear models thanks to Tom Wallis.
 `logLik.brmsfit` thanks to Tom Wallis.
 * Ensure full compatibility of the `ranef` and `coef` methods with non-linear
 models.
-* Fix problems that occasionally occured when handling `dplyr` datasets thanks
+* Fix problems that occasionally occurred when handling `dplyr` datasets thanks
 to the GitHub user Atan1988.
 
 
@@ -1735,7 +1735,7 @@ model formulas thanks to Emmanuel Charpentier.
 parameters in non-linear models thanks to Emmanuel Charpentier.
 * Fix a bug that prohibited to use nested grouping factors in non-linear models
 thanks to Tom Wallis.
-* Fix a bug in the linear predictor computation within `R`, occuring for ordinal
+* Fix a bug in the linear predictor computation within `R`, occurring for ordinal
 models with multiple category specific effects. This could lead to incorrect
 outputs of `predict`, `fitted`, and `logLik` for these models.
 * Make sure that the global `"contrasts"` option is not used when
@@ -1851,7 +1851,7 @@ respective grouping factor levels.
 * Fix a bug in the `hypothesis` method that could cause valid model parameters
 to be falsely reported as invalid.
 * Fix a bug in the `prior_samples` method that could cause prior samples of
-parameters of the same class to be artifically correlated.
+parameters of the same class to be artificially correlated.
 * Fix `Stan` code of linear models with moving-average effects and non-identity
 link functions so that they no longer contain code related solely to
 autoregressive effects.
@@ -1904,7 +1904,7 @@ method.
 generated by `brms`.
 * Rename the `brmdata` function to `make_standata`. The former remains usable as
 a deprecated alias.
-* Improve documenation to better explain differences in autoregressive effects
+* Improve documentation to better explain differences in autoregressive effects
 across R packages.
 
 ### Bug fixes

--- a/R/brm_multiple.R
+++ b/R/brm_multiple.R
@@ -157,7 +157,7 @@ brm_multiple <- function(formula, data, family = gaussian(), prior = NULL,
 #' Combine Models fitted with \pkg{brms}
 #' 
 #' Combine multiple \code{brmsfit} objects, which fitted the same model.
-#' This is usefuly for instance when having manually run models in parallel.
+#' This is usefully for instance when having manually run models in parallel.
 #' 
 #' @param ... One or more \code{brmsfit} objects.
 #' @param mlist Optional list of one or more \code{brmsfit} objects.

--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -252,7 +252,7 @@
 #'   to \code{TRUE}.
 #'   
 #'   For log-linear models such as poisson models, \code{rate} may be used
-#'   in the \code{aterms} part to specify the denomintor of a response that
+#'   in the \code{aterms} part to specify the denominator of a response that
 #'   is expressed as a rate. The numerator is given by the actual response
 #'   variable and has a distribution according to the family as usual. Using
 #'   \code{rate(denom)} is equivalent to adding \code{offset(log(denom))} to
@@ -320,7 +320,7 @@
 #'   the variable passed to \code{dec} might also be a character vector 
 #'   consisting of \code{'lower'} and \code{'upper'}.
 #'
-#'   For custom families, it is possible to pass an abitrary number of real and
+#'   For custom families, it is possible to pass an arbitrary number of real and
 #'   integer vectors via the addition terms \code{vreal} and \code{vint},
 #'   respectively. An example is provided in
 #'   \code{vignette('brms_customfamilies')}.

--- a/R/data-predictor.R
+++ b/R/data-predictor.R
@@ -110,7 +110,7 @@ data_sm <- function(bterms, data, basis = NULL) {
     knots <- get_knots(data)
     basis <- named_list(smterms)
     for (i in seq_along(smterms)) {
-      # the spline penality has changed in 2.8.7 (#646)
+      # the spline penalty has changed in 2.8.7 (#646)
       diagonal.penalty <- !require_old_default("2.8.7")
       basis[[i]] <- smoothCon(
         eval2(smterms[i]), data = data, 

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1640,7 +1640,7 @@ pcox <- function(q, mu, bhaz, cbhaz, lower.tail = TRUE, log.p = FALSE) {
 #' @name ZeroInflated
 #' 
 #' @inheritParams StudentT
-#' @param zi zero-inflation propability
+#' @param zi zero-inflation probability
 #' @param mu,lambda location parameter
 #' @param shape,shape1,shape2 shape parameter
 #' @param size number of trials
@@ -1802,7 +1802,7 @@ pzero_inflated_asym_laplace <- function(q, mu, sigma, quantile, zi,
 #' @name Hurdle
 #' 
 #' @inheritParams StudentT
-#' @param hu hurdle propability
+#' @param hu hurdle probability
 #' @param mu,lambda location parameter
 #' @param shape shape parameter
 #' @param sigma,scale scale parameter
@@ -2093,7 +2093,7 @@ dacat <- function(x, eta, thres, disc = 1, link = "logit") {
 # @param disc samples of the discrimination parameter
 # @param family a character string naming the family
 # @param link a character string naming the link
-# @return a matrix of probabilites P(x <= q)
+# @return a matrix of probabilities P(x <= q)
 pordinal <- function(q, eta, thres, disc = 1, family = NULL, link = "logit") {
   family <- as_one_character(family)
   link <- as_one_character(link)

--- a/R/families.R
+++ b/R/families.R
@@ -91,7 +91,7 @@
 #'   ('generalized extreme value') allow for modeling extremes.}
 #'   
 #'   \item{Families \code{beta} and \code{dirichlet} can be used to model 
-#'   responses representing rates or propabilities.}
+#'   responses representing rates or probabilities.}
 #'   
 #'   \item{Family \code{asym_laplace} allows for quantile regression when fixing
 #'   the auxiliary \code{quantile} parameter to the quantile of interest.}
@@ -988,7 +988,7 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL) {
 #'   \code{\link[brms:log_lik.brmsfit]{log_lik}},
 #'   \code{\link[brms:posterior_predict.brmsfit]{posterior_predict}}, or
 #'   \code{\link[brms:posterior_epred.brmsfit]{posterior_epred}}.
-#'   By default, \code{env} is the enviroment from which 
+#'   By default, \code{env} is the environment from which 
 #'   \code{custom_family} is called.
 #'   
 #' @details The corresponding probability density or mass \code{Stan} 

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -170,7 +170,7 @@ mm <- function(..., weights = NULL, scale = TRUE, by = NULL, cor = TRUE,
 
 #' Multi-Membership Covariates
 #' 
-#' Specify covarariates that vary over different levels 
+#' Specify covariates that vary over different levels 
 #' of multi-membership grouping factors thus requiring
 #' special treatment. This function is almost solely useful,
 #' when called in combination with \code{\link{mm}}. 

--- a/R/formula-sp.R
+++ b/R/formula-sp.R
@@ -178,7 +178,7 @@ vars_keep_na.mvbrmsterms <- function(x, ...) {
     stop2(
       "Response models of variables in 'mi' terms require " ,
       "specification of the addition argument 'mi'. See ?mi. ", 
-      "Error occured for ", collapse_comma(miss_mi), "."
+      "Error occurred for ", collapse_comma(miss_mi), "."
     )
   }
   out
@@ -202,7 +202,7 @@ vars_keep_na.brmsterms <- function(x, responses = NULL, ...) {
       stop2(
         "Variables in 'mi' terms should also be specified " ,
         "as response variables in the model. See ?mi. ", 
-        "Error occured for ", collapse_comma(miss_mi), "."
+        "Error occurred for ", collapse_comma(miss_mi), "."
       )
     }
     attr(out, "vars_mi") <- vars_mi
@@ -501,7 +501,7 @@ get_mo_values <- function(term, data) {
   } else {
     stop2(
       "Monotonic predictors must be integers or ordered ",
-      "factors. Error occured for variable '", term$term, "'."
+      "factors. Error occurred for variable '", term$term, "'."
     )
   }
   as.array(x)

--- a/R/loo_predict.R
+++ b/R/loo_predict.R
@@ -14,7 +14,7 @@
 #' @param prob For \code{loo_predictive_interval}, a scalar in \eqn{(0,1)}
 #'   indicating the desired probability mass to include in the intervals. The
 #'   default is \code{prob = 0.9} (\eqn{90}\% intervals).
-#' @param psis_object An optional object returend by \code{\link[loo]{psis}}. 
+#' @param psis_object An optional object returned by \code{\link[loo]{psis}}. 
 #'   If \code{psis_object} is missing then \code{\link[loo]{psis}} is executed 
 #'   internally, which may be time consuming for models fit to very large datasets. 
 #' @param ... Optional arguments passed to the underlying methods that is 

--- a/R/make_standata.R
+++ b/R/make_standata.R
@@ -238,7 +238,7 @@ standata_basis_sm <- function(x, data, ...) {
   if (length(smterms)) {
     knots <- get_knots(data)
     data <- rm_attr(data, "terms")
-    # the spline penality has changed in 2.8.7 (#646)
+    # the spline penalty has changed in 2.8.7 (#646)
     diagonal.penalty <- !require_old_default("2.8.7")
     gam_args <- list(
       data = data, knots = knots, 

--- a/R/posterior_epred.R
+++ b/R/posterior_epred.R
@@ -205,7 +205,7 @@ posterior_epred.brmsprep <- function(object, scale, dpar, nlpar, sort,
 #'   \code{Est.Error} column contains uncertainty estimates (either standard
 #'   deviation or median absolute deviation depending on argument
 #'   \code{robust}). The remaining columns starting with \code{Q} contain
-#'   quantile estimates as specifed via argument \code{probs}.
+#'   quantile estimates as specified via argument \code{probs}.
 #'   
 #'   In multivariate models, an additional dimension is added to the output
 #'   which indexes along the different response variables.

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -195,14 +195,14 @@ posterior_predict.brmsprep <- function(object, transform = NULL, sort = FALSE,
 #'   If \code{summary = TRUE} the output depends on the family: For categorical
 #'   and ordinal families, the output is an N x C matrix, where N is the number
 #'   of observations, C is the number of categories, and the values are
-#'   predicted category probabilites. For all other families, the output is a N
+#'   predicted category probabilities. For all other families, the output is a N
 #'   x E matrix where E = \code{2 + length(probs)} is the number of summary
 #'   statistics: The \code{Estimate} column contains point estimates (either
 #'   mean or median depending on argument \code{robust}), while the
 #'   \code{Est.Error} column contains uncertainty estimates (either standard
 #'   deviation or median absolute deviation depending on argument
 #'   \code{robust}). The remaining columns starting with \code{Q} contain
-#'   quantile estimates as specifed via argument \code{probs}.  
+#'   quantile estimates as specified via argument \code{probs}.  
 #'   
 #' @seealso \code{\link{posterior_predict.brmsfit}} 
 #'  

--- a/R/rename_pars.R
+++ b/R/rename_pars.R
@@ -1,7 +1,7 @@
 #' Rename Parameters
 #' 
 #' Rename parameters within the \code{stanfit} object after model fitting to
-#' ensure reasonable parameter names. This function is usally called
+#' ensure reasonable parameter names. This function is usually called
 #' automatically by \code{\link{brm}} and users will rarely be required to call
 #' it themselves.
 #' 

--- a/R/stan-prior.R
+++ b/R/stan-prior.R
@@ -190,7 +190,7 @@ stan_prior <- function(prior, class, coef = NULL, group = NULL,
   if (prior_only && has_improper_prior) {
     stop2("Sampling from priors is not possible as ", 
           "some parameters have no proper priors. ",
-          "Error occured for parameter '", par, "'.")
+          "Error occurred for parameter '", par, "'.")
   }
   out
 }

--- a/R/stanvars.R
+++ b/R/stanvars.R
@@ -11,7 +11,7 @@
 #'   Only required if \code{block = 'data'} and ignored otherwise.
 #' @param name Optional character string providing the desired variable 
 #'  name of the object in \code{x}. If \code{NULL} (the default)
-#'  the variable name is directly infered from \code{x}.
+#'  the variable name is directly inferred from \code{x}.
 #' @param scode Line of Stan code to define the variable
 #'  in Stan language. If \code{block = 'data'}, the
 #'  Stan code is inferred based on the class of \code{x} by default.

--- a/README.Rmd
+++ b/README.Rmd
@@ -90,7 +90,7 @@ summary(fit1)
 
 On the top of the output, some general information on the model is given, such
 as family, formula, number of iterations and chains. Next, group-level effects
-are displayed seperately for each grouping factor in terms of standard
+are displayed separately for each grouping factor in terms of standard
 deviations and (in case of more than one group-level effect per grouping factor;
 not displayed here) correlations between group-level effects. On the bottom of
 the output, population-level effects (i.e. regression coefficients) are

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ summary(fit1)
 
 On the top of the output, some general information on the model is
 given, such as family, formula, number of iterations and chains. Next,
-group-level effects are displayed seperately for each grouping factor in
+group-level effects are displayed separately for each grouping factor in
 terms of standard deviations and (in case of more than one group-level
 effect per grouping factor; not displayed here) correlations between
 group-level effects. On the bottom of the output, population-level

--- a/doc/brms_threading.Rmd
+++ b/doc/brms_threading.Rmd
@@ -225,7 +225,7 @@ here as we assumed a fixed amount of 4 cores.
   parallelization and an empirical evaluation is in some cases
   advisable.
 - Enabling threading *usually* slows down any model to some extent and
-  this slowdown must be offset by sufficent cores per chain in order
+  this slowdown must be offset by sufficient cores per chain in order
   to really gain in execution speed.
 - Doubling the execution speed with few cores is a lot easier than
   obtaining larger speedups with even more cores.

--- a/man/Hurdle.Rd
+++ b/man/Hurdle.Rd
@@ -31,7 +31,7 @@ phurdle_lognormal(q, mu, sigma, hu, lower.tail = TRUE, log.p = FALSE)
 \arguments{
 \item{x}{Vector of quantiles.}
 
-\item{hu}{hurdle propability}
+\item{hu}{hurdle probability}
 
 \item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
 

--- a/man/ZeroInflated.Rd
+++ b/man/ZeroInflated.Rd
@@ -31,7 +31,7 @@ pzero_inflated_beta(q, shape1, shape2, zi, lower.tail = TRUE, log.p = FALSE)
 \arguments{
 \item{x}{Vector of quantiles.}
 
-\item{zi}{zero-inflation propability}
+\item{zi}{zero-inflation probability}
 
 \item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
 

--- a/man/brmsfamily.Rd
+++ b/man/brmsfamily.Rd
@@ -252,7 +252,7 @@ Below, we list common use cases for the different families.
   ('generalized extreme value') allow for modeling extremes.}
   
   \item{Families \code{beta} and \code{dirichlet} can be used to model 
-  responses representing rates or propabilities.}
+  responses representing rates or probabilities.}
   
   \item{Family \code{asym_laplace} allows for quantile regression when fixing
   the auxiliary \code{quantile} parameter to the quantile of interest.}

--- a/man/brmsformula.Rd
+++ b/man/brmsformula.Rd
@@ -281,7 +281,7 @@ models for all parameters of the assumed response distribution.
   to \code{TRUE}.
   
   For log-linear models such as poisson models, \code{rate} may be used
-  in the \code{aterms} part to specify the denomintor of a response that
+  in the \code{aterms} part to specify the denominator of a response that
   is expressed as a rate. The numerator is given by the actual response
   variable and has a distribution according to the family as usual. Using
   \code{rate(denom)} is equivalent to adding \code{offset(log(denom))} to
@@ -349,7 +349,7 @@ models for all parameters of the assumed response distribution.
   the variable passed to \code{dec} might also be a character vector 
   consisting of \code{'lower'} and \code{'upper'}.
 
-  For custom families, it is possible to pass an abitrary number of real and
+  For custom families, it is possible to pass an arbitrary number of real and
   integer vectors via the addition terms \code{vreal} and \code{vint},
   respectively. An example is provided in
   \code{vignette('brms_customfamilies')}.

--- a/man/combine_models.Rd
+++ b/man/combine_models.Rd
@@ -21,7 +21,7 @@ A \code{brmsfit} object.
 }
 \description{
 Combine multiple \code{brmsfit} objects, which fitted the same model.
-This is usefuly for instance when having manually run models in parallel.
+This is usefully for instance when having manually run models in parallel.
 }
 \details{
 This function just takes the first model and replaces 

--- a/man/custom_family.Rd
+++ b/man/custom_family.Rd
@@ -79,7 +79,7 @@ relevant if one wants to ensure compatibility with the methods
 \code{\link[brms:log_lik.brmsfit]{log_lik}},
 \code{\link[brms:posterior_predict.brmsfit]{posterior_predict}}, or
 \code{\link[brms:posterior_epred.brmsfit]{posterior_epred}}.
-By default, \code{env} is the enviroment from which 
+By default, \code{env} is the environment from which 
 \code{custom_family} is called.}
 }
 \value{

--- a/man/fitted.brmsfit.Rd
+++ b/man/fitted.brmsfit.Rd
@@ -92,7 +92,7 @@ An \code{array} of predicted \emph{mean} response values.
   \code{Est.Error} column contains uncertainty estimates (either standard
   deviation or median absolute deviation depending on argument
   \code{robust}). The remaining columns starting with \code{Q} contain
-  quantile estimates as specifed via argument \code{probs}.
+  quantile estimates as specified via argument \code{probs}.
   
   In multivariate models, an additional dimension is added to the output
   which indexes along the different response variables.

--- a/man/loo_predict.brmsfit.Rd
+++ b/man/loo_predict.brmsfit.Rd
@@ -39,7 +39,7 @@ Can by either \code{"mean"} (default), \code{"var"}, or
 \item{probs}{A vector of quantiles to compute. 
 Only used if \code{type = quantile}.}
 
-\item{psis_object}{An optional object returend by \code{\link[loo]{psis}}. 
+\item{psis_object}{An optional object returned by \code{\link[loo]{psis}}. 
 If \code{psis_object} is missing then \code{\link[loo]{psis}} is executed 
 internally, which may be time consuming for models fit to very large datasets.}
 

--- a/man/mmc.Rd
+++ b/man/mmc.Rd
@@ -14,7 +14,7 @@ corresponding to the grouping levels specified in \code{\link{mm}}.}
 A matrix with covariates as columns.
 }
 \description{
-Specify covarariates that vary over different levels 
+Specify covariates that vary over different levels 
 of multi-membership grouping factors thus requiring
 special treatment. This function is almost solely useful,
 when called in combination with \code{\link{mm}}. 

--- a/man/predict.brmsfit.Rd
+++ b/man/predict.brmsfit.Rd
@@ -90,14 +90,14 @@ An \code{array} of predicted response values.
   If \code{summary = TRUE} the output depends on the family: For categorical
   and ordinal families, the output is an N x C matrix, where N is the number
   of observations, C is the number of categories, and the values are
-  predicted category probabilites. For all other families, the output is a N
+  predicted category probabilities. For all other families, the output is a N
   x E matrix where E = \code{2 + length(probs)} is the number of summary
   statistics: The \code{Estimate} column contains point estimates (either
   mean or median depending on argument \code{robust}), while the
   \code{Est.Error} column contains uncertainty estimates (either standard
   deviation or median absolute deviation depending on argument
   \code{robust}). The remaining columns starting with \code{Q} contain
-  quantile estimates as specifed via argument \code{probs}.
+  quantile estimates as specified via argument \code{probs}.
 }
 \description{
 This method is an alias of \code{\link{posterior_predict.brmsfit}}

--- a/man/rename_pars.Rd
+++ b/man/rename_pars.Rd
@@ -14,7 +14,7 @@ A brmfit object with adjusted parameter names.
 }
 \description{
 Rename parameters within the \code{stanfit} object after model fitting to
-ensure reasonable parameter names. This function is usally called
+ensure reasonable parameter names. This function is usually called
 automatically by \code{\link{brm}} and users will rarely be required to call
 it themselves.
 }

--- a/man/stanvar.Rd
+++ b/man/stanvar.Rd
@@ -19,7 +19,7 @@ Only required if \code{block = 'data'} and ignored otherwise.}
 
 \item{name}{Optional character string providing the desired variable 
 name of the object in \code{x}. If \code{NULL} (the default)
-the variable name is directly infered from \code{x}.}
+the variable name is directly inferred from \code{x}.}
 
 \item{scode}{Line of Stan code to define the variable
 in Stan language. If \code{block = 'data'}, the

--- a/vignettes/brms_threading.Rmd
+++ b/vignettes/brms_threading.Rmd
@@ -225,7 +225,7 @@ here as we assumed a fixed amount of 4 cores.
   parallelization and an empirical evaluation is in some cases
   advisable.
 - Enabling threading *usually* slows down any model to some extent and
-  this slowdown must be offset by sufficent cores per chain in order
+  this slowdown must be offset by sufficient cores per chain in order
   to really gain in execution speed.
 - Doubling the execution speed with few cores is a lot easier than
   obtaining larger speedups with even more cores.


### PR DESCRIPTION
This fixes various typos after `devtools::spell_check`.