### PR TITLE
backends: rstan: Support within-chain threading with Stan >= 2.25

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 to increase sampling efficiency thanks to Andrew Johnson. (#1017, #1053)
 * Enable `posterior_predict` for truncated continuous models
 even if the required CDF or quantile functions are unavailable.
+* Add support for within-chain threading with `rstan (Stan >= 2.25)` backend.
 
 ### Bug Fixes
 

--- a/R/backends.R
+++ b/R/backends.R
@@ -50,16 +50,6 @@ compile_model <- function(model, backend, ...) {
   message("Compiling Stan program...")
   if (use_threading(threads)) {
     if (rstan::stan_version() >= 2.25) {
-      if (!exists("rstan_threading")) {
-        message("\nrstan version ",
-                utils::packageVersion("rstan"),
-                " (Stan version ",
-                rstan::stan_version(), ")\n",
-                "Using threads_per_chain = ",
-                threads$threads,
-                " for within-chain threading.\n")
-        rstan_threading <<- TRUE
-      }
       threads_per_chain_def <- rstan::rstan_options("threads_per_chain")
       on.exit(rstan::rstan_options(threads_per_chain = threads_per_chain_def))
       rstan::rstan_options(threads_per_chain = threads$threads)
@@ -104,16 +94,6 @@ fit_model <- function(model, backend, ...) {
   # some input checks and housekeeping
   if (use_threading(threads)) {
     if (rstan::stan_version() >= 2.25) {
-      if (!exists("rstan_threading")) {
-        message("\nrstan version ",
-                utils::packageVersion("rstan"),
-                " (Stan version ",
-                rstan::stan_version(), ")\n",
-                "Using threads_per_chain = ",
-                threads$threads,
-                " for within-chain threading.\n")
-        rstan_threading <<- TRUE
-      }
       threads_per_chain_def <- rstan::rstan_options("threads_per_chain")
       on.exit(rstan::rstan_options(threads_per_chain = threads_per_chain_def))
       rstan::rstan_options(threads_per_chain = threads$threads)

--- a/R/backends.R
+++ b/R/backends.R
@@ -60,6 +60,8 @@ compile_model <- function(model, backend, ...) {
                 " for within-chain threading.\n")
         rstan_threading <<- TRUE
       }
+      threads_per_chain_def <- rstan::rstan_options("threads_per_chain")
+      on.exit(rstan::rstan_options(threads_per_chain = threads_per_chain_def))
       rstan::rstan_options(threads_per_chain = threads$threads)
     } else {
       stop2("Threading is not supported by backend 'rstan' version ",
@@ -112,6 +114,8 @@ fit_model <- function(model, backend, ...) {
                 " for within-chain threading.\n")
         rstan_threading <<- TRUE
       }
+      threads_per_chain_def <- rstan::rstan_options("threads_per_chain")
+      on.exit(rstan::rstan_options(threads_per_chain = threads_per_chain_def))
       rstan::rstan_options(threads_per_chain = threads$threads)
     } else {
       stop2("Threading is not supported by backend 'rstan' version ",

--- a/R/backends.R
+++ b/R/backends.R
@@ -48,6 +48,24 @@ compile_model <- function(model, backend, ...) {
   args <- list(...)
   args$model_code <- model
   message("Compiling Stan program...")
+  if (use_threading(threads)) {
+    if (rstan::stan_version() >= 2.25) {
+      if (!exists("rstan_threading")) {
+        message("\nrstan version ",
+                utils::packageVersion("rstan"),
+                " (Stan version ",
+                rstan::stan_version(), ")\n",
+                "Using threads_per_chain = ",
+                threads$threads,
+                " for within-chain threading.\n")
+        rstan_threading <<- TRUE
+      }
+      rstan::rstan_options(threads_per_chain = threads$threads)
+    } else {
+      stop2("Threading is not supported by backend 'rstan' version ",
+            utils::packageVersion("rstan"), ".")
+    }
+  }
   do_call(rstan::stan_model, args)
 }
 
@@ -83,7 +101,22 @@ fit_model <- function(model, backend, ...) {
   
   # some input checks and housekeeping
   if (use_threading(threads)) {
-    stop2("Threading is not yet supported by backend 'rstan'.")
+    if (rstan::stan_version() >= 2.25) {
+      if (!exists("rstan_threading")) {
+        message("\nrstan version ",
+                utils::packageVersion("rstan"),
+                " (Stan version ",
+                rstan::stan_version(), ")\n",
+                "Using threads_per_chain = ",
+                threads$threads,
+                " for within-chain threading.\n")
+        rstan_threading <<- TRUE
+      }
+      rstan::rstan_options(threads_per_chain = threads$threads)
+    } else {
+      stop2("Threading is not supported by backend 'rstan' version ",
+            utils::packageVersion("rstan"), ".")
+    }
   }
   if (is.character(inits) && !inits %in% c("random", "0")) {
     inits <- get(inits, mode = "function", envir = parent.frame())


### PR DESCRIPTION
This adds support for within-chain threading in the new version of `rstan >= 2.25 | Stan >= 2.25`. It has been tested with https://github.com/stan-dev/rstan/pull/887 and https://github.com/stan-dev/math/pull/2261.

A new `rsran` option `threads_per_chain` has been added to control the within-chain number of threads (`threads$threads`):
```r
rstan::rstan_options(threads_per_chain = threads$threads)
```

If the model is compiled with threading support, the number of threads to use in parallelized sections _within_ an MCMC chain (e.g., when using the `Stan` functions `reduce_sum()` or `map_rect()`). The actual number of CPU cores used is `chains * threads_per_chain` where `chains` is the number of parallel chains. For an example of using threading, see [Reduce Sum: A Minimal Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html)