### PR TITLE
Move sratio & cratio functions to log-scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@ even if the required CDF or quantile functions are unavailable.
 via function `R2D2` to be used in `set_prior`.
 * Extend support for `arma` correlation structures in non-normal families.
 
+### Other Changes
+
+* Improve numerical stability of ordinal sequential models 
+(families `sratio` and `cratio`) thanks to Andrew Johnson. (#1087)
+
 ### Bug Fixes
 
 * Allow fitting `multinomial` models with the 

--- a/R/stan-response.R
+++ b/R/stan-response.R
@@ -551,23 +551,36 @@ stan_ordinal_lpmf <- function(family, link) {
     }
   } else if (family %in% c("sratio", "cratio")) {
     if (ilink == "inv_cloglog") {
-      qk <- (str_if(family == "sratio", "-exp({th('k')})",
-                         "log1m_exp(-exp({th('k')}))"))
+      qk <- str_if(
+        family == "sratio", 
+        "-exp({th('k')})",
+        "log1m_exp(-exp({th('k')}))"
+      )
     } else if (ilink == "inv_logit") {
-      qk <- str_if(family == "sratio", "log1m_inv_logit({th('k')})",
-                   "log_inv_logit({th('k')})")
+      qk <- str_if(
+        family == "sratio", 
+        "log1m_inv_logit({th('k')})",
+        "log_inv_logit({th('k')})"
+      )
     } else if (ilink == "Phi") {
       # TODO: replace with more stable std_normal_lcdf once rstan >= 2.25
-      qk <- str_if(family == "sratio", "normal_lccdf({th('k')}|0,1)",
-                   "normal_lcdf({th('k')}|0,1)")
+      qk <- str_if(
+        family == "sratio", 
+        "normal_lccdf({th('k')}|0,1)",
+        "normal_lcdf({th('k')}|0,1)"
+      )
     } else if (ilink == "Phi_approx") {
-      qk <- str_if(family == "sratio",
-                   "log1m_inv_logit(0.07056 * pow({th('k')}, 3.0) + 1.5976 * {th('k')})",
-                   "log_inv_logit(0.07056 * pow({th('k')}, 3.0) + 1.5976 * {th('k')})")
+      qk <- str_if(
+        family == "sratio",
+        "log1m_inv_logit(0.07056 * pow({th('k')}, 3.0) + 1.5976 * {th('k')})",
+        "log_inv_logit(0.07056 * pow({th('k')}, 3.0) + 1.5976 * {th('k')})"
+      )
     } else if (ilink == "inv_cauchit") {
-      qk <- str_if(family == "sratio",
-                   "cauchy_lccdf({th('k')}|0,1)",
-                   "cauchy_lcdf({th('k')}|0,1)")
+      qk <- str_if(
+        family == "sratio",
+        "cauchy_lccdf({th('k')}|0,1)",
+        "cauchy_lcdf({th('k')}|0,1)"
+      )
     }
     qk <- glue(qk)
     str_add(out) <- glue(


### PR DESCRIPTION
This PR moves the calculations in the ```cratio``` and ```sratio``` families to the log-scale for numerical stability. All link functions are updated:

 - ```cloglog```
 - ```logit```
 - ```probit```
 - ```probit_approx```
 - ```cauchit```

There is (currently) no benefit for the ```probit``` family, but this will improve when ```rstan``` is updated and the ```std_normal_lcdf``` function is available, as that is coded for much more stable behaviour in the tails. There is also no benefit for the ```cauchit``` family.

Tests showing the improved stability (and equality with current implementation):

  - [cloglog](https://gist.github.com/andrjohns/ef72bd1f9a4b6d9d0812a9df700fb3db)
  - [logit](https://gist.github.com/andrjohns/52ba8ec20e4b2099dd3c974ef5cbb4ef)
  - [probit](https://gist.github.com/andrjohns/1a4a2091c60da249805aa35f85547952)
  - [probit_approx](https://gist.github.com/andrjohns/63201b375f49100f3d82aa771afe1a3a)
  - [cauchit](https://gist.github.com/andrjohns/3ddbef3a6faba9e41f7819a74a3c3bf0)