### PR TITLE
Replace deprecated cov_exp_quad

### DIFF
--- a/inst/chunks/fun_gaussian_process.stan
+++ b/inst/chunks/fun_gaussian_process.stan
@@ -13,12 +13,12 @@
     matrix[N, N] cov;
     if (Dls == 1) {
       // one dimensional or isotropic GP
-      cov = cov_exp_quad(x, sdgp, lscale[1]);
+      cov = gp_exp_quad_cov(x, sdgp, lscale[1]);
     } else {
       // multi-dimensional non-isotropic GP
-      cov = cov_exp_quad(x[, 1], sdgp, lscale[1]);
+      cov = gp_exp_quad_cov(x[, 1], sdgp, lscale[1]);
       for (d in 2:Dls) {
-        cov = cov .* cov_exp_quad(x[, d], 1, lscale[d]);
+        cov = cov .* gp_exp_quad_cov(x[, d], 1, lscale[d]);
       }
     }
     for (n in 1:N) {


### PR DESCRIPTION
Replace cov_exp_quad with gp_exp_quad_cov. Fixes #1089 This is safe to use with the cran version of rstan as well (https://github.com/stan-dev/stan/blob/StanHeaders_2.21/src/stan/lang/function_signatures.h#L543).

I checked the rest of the deprecated language features/functions and I did not find any additional ones.

There is a use of deprecated increment_log_prob and normal_log in one of the tests, but those are just part of tests and dont actually compile.