### PR TITLE
Check if `rstan` supports `threads_per_chain`

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -49,7 +49,7 @@ compile_model <- function(model, backend, ...) {
   args$model_code <- model
   message("Compiling Stan program...")
   if (use_threading(threads)) {
-    if (rstan::stan_version() >= 2.25) {
+    if (utils::packageVersion("rstan") >= 2.26) {
       threads_per_chain_def <- rstan::rstan_options("threads_per_chain")
       on.exit(rstan::rstan_options(threads_per_chain = threads_per_chain_def))
       rstan::rstan_options(threads_per_chain = threads$threads)
@@ -93,7 +93,7 @@ fit_model <- function(model, backend, ...) {
   
   # some input checks and housekeeping
   if (use_threading(threads)) {
-    if (rstan::stan_version() >= 2.25) {
+    if (utils::packageVersion("rstan") >= 2.26) {
       threads_per_chain_def <- rstan::rstan_options("threads_per_chain")
       on.exit(rstan::rstan_options(threads_per_chain = threads_per_chain_def))
       rstan::rstan_options(threads_per_chain = threads$threads)


### PR DESCRIPTION
Closes #1091. May also need to catch the development versions that don't support `threads_per_chain` (e.g., by checking if the option exists), but that's ok since they're likely used by experienced users, especially with threading and/or OpenCL.