### PR TITLE
projpred: get_refmodel: Support smooth terms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,12 @@ Authors@R:
       person("Jonah", "Gabry", role = c("ctb")),
       person("Sebastian", "Weber", role = c("ctb")),
       person("Andrew", "Johnson", role = c("ctb")),
-      person("Martin", "Modrak", role = c("ctb")))
+      person("Martin", "Modrak", role = c("ctb")),
+      person(given = "Hamada S.",
+             family = "Badr",
+             email = "badr@jhu.edu",
+             role = c("ctb"),
+             comment = c(ORCID = "0000-0002-9808-2344")))
 Depends: 
     R (>= 3.5.0),
     Rcpp (>= 0.12.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,11 +11,7 @@ Authors@R:
       person("Sebastian", "Weber", role = c("ctb")),
       person("Andrew", "Johnson", role = c("ctb")),
       person("Martin", "Modrak", role = c("ctb")),
-      person(given = "Hamada S.",
-             family = "Badr",
-             email = "badr@jhu.edu",
-             role = c("ctb"),
-             comment = c(ORCID = "0000-0002-9808-2344")))
+      person("Hamada S.", "Badr", c("ctb")))
 Depends: 
     R (>= 3.5.0),
     Rcpp (>= 0.12.0),

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -87,7 +87,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   if (length(bterms$nlpars) > 0L) {
     stop2("Projpred does not support non-linear models.")
   }
-  not_ok_term_types <- setdiff(all_term_types(), c("fe", "re", "offset"))
+  not_ok_term_types <- setdiff(all_term_types(), c("fe", "re", "offset", "sm"))
   if (any(not_ok_term_types %in% names(bterms$dpars$mu))) {
     stop2("Projpred only supports standard multilevel terms and offsets.")
   }


### PR DESCRIPTION
Smooth terms (`"sm"`; splines via `s()` and `t2()`) are already supported in `projpred`. This PR allows `get_refmodel()` to get the reference model structure with those terms.

The following simple example works fine:
```r
library(brms)
library(projpred)

dat <- mgcv::gamSim(1, n = 400, scale = 2)
fit0 <- brm(y ~ s(x0) + x1 + s(x2), data = dat)

refmod0 <- get_refmodel(fit0)
vs0 <- varsel(refmod0)

plot(vs0)
```
But, when combining smooth terms in an interaction term via `t2()`, `get_refmodel()` works fine but `varsel()` fails:
```r
fit1 <- brm(y ~ x1 + t2(x0, x2), data = dat)

refmod1 <- get_refmodel(fit1)
vs1 <- varsel(refmod1)
```
>Error in str2lang(x) : <text>:1:29: unexpected ','
1: . ~ 1 + t2(x0, x2) + x1 + x0,
                                ^

Here's the traceback:
```
> traceback()
9: str2lang(x)
8: formula.character(object, env = baseenv())
7: formula(object, env = baseenv())
6: as.formula(paste0(". ~ ", paste(terms_, collapse = " + "))) at formula.R#595
5: make_formula(list_of_terms) at formula.R#729
4: count_terms_chosen(search_terms, duplicates = TRUE) at varsel.R#327
3: parse_args_varsel(refmodel, method, cv_search, intercept, nterms_max,
       nclusters, ndraws, nclusters_pred, ndraws_pred, search_terms) at varsel.R#118
2: varsel.refmodel(refmod1) at varsel.R#93
1: varsel(refmod1)
```

This looks like it expects to have a term for each variable; so, it uses `t2(x0, x2)` as term and adds an empty one (or extra comma) that causes the (formula parsing) failure. I'll debug this in `projpred`.

A quick debug reveals that `projpred:::make_formula()` uses a term (`"x0, x2"`) generated by `projpred:::split_formula()` that includes the two variables (`x0` and `x2`) separated by a comma, which causes the failure:
```r
> projpred:::split_formula(refmod1$formula)
[1] "1"          "t2(x0, x2)" "x1"         "x0, x2"

> paste0(". ~ ", paste(projpred:::split_formula(refmod1$formula), collapse = " + "))
[1] ". ~ 1 + t2(x0, x2) + x1 + x0, x2"
```

Either the added term (`"x0, x2"`) needs to be removed or the comma replaced by `+`.