### PR TITLE
projpred: Pass `cvfun` to `init_refmodel`

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -253,6 +253,20 @@ compiled_model <- function(x) {
   out
 }
 
+# extract the elapsed time during model fitting
+# @param x brmsfit object
+elapsed_time <- function(x) {
+  stopifnot(is.brmsfit(x))
+  backend <- x$backend %||% "rstan"
+  if (backend == "rstan") {
+    out <- rstan::get_elapsed_time(x$fit)
+  } else if (backend == "cmdstanr") {
+    # TODO: is this stored somewhere?
+    out <- NA
+  }
+  out
+}
+
 # supported Stan backends
 backend_choices <- function() {
   c("rstan", "cmdstanr")

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -73,6 +73,10 @@ cv_varsel.brmsfit <- function(object, ...) {
 #' @export
 get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL, 
                                  folds = NULL, cvfun = NULL, ...) {
+  if (is.null(object$elapsed_time)) {
+    object$elapsed_time <- rstan::get_elapsed_time(object$fit)
+  }
+
   resp <- validate_resp(resp, object, multiple = FALSE)
   formula <- formula(object)
   if (!is.null(resp)) {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -121,21 +121,11 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     .extract_model_data(object, newdata = newdata, resp = resp, ...)
   }
   
-  # extract a list of K-fold sub-models
-  cvfun <- function(folds) {
-    cvres <- kfold(
-      object, K = max(folds),
-      save_fits = TRUE, folds = folds
-    )
-    fits <- cvres$fits[, "fit"]
-    return(fits)
-  }
-  
   # using default prediction functions from projpred is fine
   args <- nlist(
     object, data, formula, family, folds, dis,
     ref_predfun = NULL, proj_predfun = NULL, div_minimizer = NULL, 
-    cvfun = cvfun, extract_model_data = extract_model_data, ...
+    extract_model_data = extract_model_data, ...
   )
   do_call(projpred::init_refmodel, args)
 }

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -72,7 +72,7 @@ cv_varsel.brmsfit <- function(object, ...) {
 #' @export get_refmodel
 #' @export
 get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL, 
-                                 folds = NULL, ...) {
+                                 folds = NULL, cvfun = NULL, ...) {
   resp <- validate_resp(resp, object, multiple = FALSE)
   formula <- formula(object)
   if (!is.null(resp)) {
@@ -122,13 +122,15 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   
   # extract a list of K-fold sub-models
-  cvfun <- function(folds) {
-    cvres <- kfold(
-      object, K = max(folds),
-      save_fits = TRUE, folds = folds
-    )
-    fits <- cvres$fits[, "fit"]
-    return(fits)
+  if (is.null(cvfun)) {
+    cvfun <- function(folds) {
+      cvres <- kfold(
+        object, K = max(folds),
+        save_fits = TRUE, folds = folds
+      )
+      fits <- cvres$fits[, "fit"]
+      return(fits)
+    }
   }
   
   # using default prediction functions from projpred is fine

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -73,10 +73,6 @@ cv_varsel.brmsfit <- function(object, ...) {
 #' @export
 get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL, 
                                  folds = NULL, cvfun = NULL, ...) {
-  if (is.null(object$elapsed_time)) {
-    object$elapsed_time <- rstan::get_elapsed_time(object$fit)
-  }
-
   resp <- validate_resp(resp, object, multiple = FALSE)
   formula <- formula(object)
   if (!is.null(resp)) {
@@ -142,7 +138,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   args <- nlist(
     object, data, formula, family, folds, dis,
     ref_predfun = NULL, proj_predfun = NULL, div_minimizer = NULL, 
-    cvfun = cvfun, extract_model_data = extract_model_data, ...
+    cvfun = cvfun, extract_model_data = extract_model_data,
+    fit_elapsed_time = elapsed_time(object), ...
   )
   do_call(projpred::init_refmodel, args)
 }

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -138,8 +138,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   args <- nlist(
     object, data, formula, family, folds, dis,
     ref_predfun = NULL, proj_predfun = NULL, div_minimizer = NULL, 
-    cvfun = cvfun, extract_model_data = extract_model_data,
-    fit_elapsed_time = elapsed_time(object), ...
+    cvfun = cvfun, extract_model_data = extract_model_data, ...
   )
   do_call(projpred::init_refmodel, args)
 }

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -123,10 +123,11 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   
   # extract a list of K-fold sub-models
   if (!inherits(cvfun, "function")) {
-    cvfun <- function(folds) {
+    cvfun <- function(folds, ...) {
       cvres <- kfold(
         object, K = max(folds),
-        save_fits = TRUE, folds = folds
+        save_fits = TRUE, folds = folds,
+        ...
       )
       fits <- cvres$fits[, "fit"]
       return(fits)

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -122,7 +122,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   
   # extract a list of K-fold sub-models
-  if (!inherits(cvfun, "function")) {
+  if (is.null(cvfun)) {
     cvfun <- function(folds, ...) {
       cvres <- kfold(
         object, K = max(folds),
@@ -131,6 +131,10 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
       )
       fits <- cvres$fits[, "fit"]
       return(fits)
+    }
+  } else {
+    if (!is.function(cvfun)) {
+      stop2("'cvfun' should be a function.")
     }
   }
   

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -122,7 +122,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   
   # extract a list of K-fold sub-models
-  if (is.null(cvfun)) {
+  if (!inherits(cvfun, "function")) {
     cvfun <- function(folds) {
       cvres <- kfold(
         object, K = max(folds),

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -121,11 +121,21 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     .extract_model_data(object, newdata = newdata, resp = resp, ...)
   }
   
+  # extract a list of K-fold sub-models
+  cvfun <- function(folds) {
+    cvres <- kfold(
+      object, K = max(folds),
+      save_fits = TRUE, folds = folds
+    )
+    fits <- cvres$fits[, "fit"]
+    return(fits)
+  }
+  
   # using default prediction functions from projpred is fine
   args <- nlist(
     object, data, formula, family, folds, dis,
     ref_predfun = NULL, proj_predfun = NULL, div_minimizer = NULL, 
-    extract_model_data = extract_model_data, ...
+    cvfun = cvfun, extract_model_data = extract_model_data, ...
   )
   do_call(projpred::init_refmodel, args)
 }

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -5,7 +5,14 @@
 \alias{get_refmodel}
 \title{Get Reference Models}
 \usage{
-\method{get_refmodel}{brmsfit}(object, newdata = NULL, resp = NULL, folds = NULL, ...)
+\method{get_refmodel}{brmsfit}(
+  object,
+  newdata = NULL,
+  resp = NULL,
+  folds = NULL,
+  cvfun = NULL,
+  ...
+)
 }
 \arguments{
 \item{object}{An object of class \code{brmsfit}.}


### PR DESCRIPTION
The `cvfun` function is hardcoded here while a variant of it is maintained in `projpred::init_refmodel`. For example, a change like https://github.com/stan-dev/projpred/commit/6310b19a96c1e85ffbc89ff56a051bc2dadbcb95 breaks the hardcoded function here. This PR lets `projpred::init_refmodel` defines `cvfun` from `brmsfit` objects if it isn't passed in `...` (i.e., `cvfun = NULL` by default). Moreover, it will pass a custom function if set by the user.