### PR TITLE
Improve efficiency of the `inv_link_<ordinal_family>()` functions

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -2096,8 +2096,10 @@ inv_link_sratio <- function(x, link) {
   dim_noncat <- dim(x)[-ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
-  Sx_cumprod <- aperm(apply(1 - x, marg_othdim, cumprod),
-                      perm = c(marg_othdim + 1, 1))
+  Sx_cumprod <- aperm(
+    apply(1 - x, marg_othdim, cumprod),
+    perm = c(marg_othdim + 1, 1)
+  )
   abind::abind(x, ones_arr) * abind::abind(ones_arr, Sx_cumprod)
 }
 
@@ -2146,8 +2148,10 @@ inv_link_cratio <- function(x, link) {
   dim_noncat <- dim(x)[-ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
-  x_cumprod <- aperm(apply(x, marg_othdim, cumprod),
-                     perm = c(marg_othdim + 1, 1))
+  x_cumprod <- aperm(
+    apply(x, marg_othdim, cumprod),
+    perm = c(marg_othdim + 1, 1)
+  )
   abind::abind(1 - x, ones_arr) * abind::abind(ones_arr, x_cumprod)
 }
 
@@ -2193,18 +2197,25 @@ inv_link_acat <- function(x, link) {
   ones_arr <- array(1, dim = c(dim_noncat, 1))
   if (link == "logit") { 
     # faster evaluation in this case
-    exp_x_cumprod <- aperm(apply(exp(x), marg_othdim, cumprod),
-                           perm = c(marg_othdim + 1, 1))
+    exp_x_cumprod <- aperm(
+      apply(exp(x), marg_othdim, cumprod),
+      perm = c(marg_othdim + 1, 1)
+    )
     out <- abind::abind(ones_arr, exp_x_cumprod)
   } else {
     x <- ilink(x, link)
-    x_cumprod <- aperm(apply(x, marg_othdim, cumprod),
-                       perm = c(marg_othdim + 1, 1))
+    x_cumprod <- aperm(
+      apply(x, marg_othdim, cumprod),
+      perm = c(marg_othdim + 1, 1)
+    )
     nthres <- dim(x)[ndim]
-    Sx_cumprod_rev <- aperm(apply(
-      1 - slice(x, ndim, rev(seq_len(nthres)), drop = FALSE),
-      marg_othdim, cumprod
-    ), perm = c(marg_othdim + 1, 1))
+    Sx_cumprod_rev <- aperm(
+      apply(
+        1 - slice(x, ndim, rev(seq_len(nthres)), drop = FALSE),
+        marg_othdim, cumprod
+      ), 
+      perm = c(marg_othdim + 1, 1)
+    )
     Sx_cumprod_rev <- slice(
       Sx_cumprod_rev, ndim, rev(seq_len(nthres)), drop = FALSE
     )

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -2097,8 +2097,9 @@ inv_link_sratio <- function(x, link) {
   dim_thres <- dim(x)[ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
+  dim_t <- c(dim_thres, dim_noncat)
   Sx_cumprod <- aperm(
-    array(apply(1 - x, marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
+    array(apply(1 - x, marg_othdim, cumprod), dim = dim_t),
     perm = c(marg_othdim + 1, 1)
   )
   abind::abind(x, ones_arr) * abind::abind(ones_arr, Sx_cumprod)
@@ -2150,8 +2151,9 @@ inv_link_cratio <- function(x, link) {
   dim_thres <- dim(x)[ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
+  dim_t <- c(dim_thres, dim_noncat)
   x_cumprod <- aperm(
-    array(apply(x, marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
+    array(apply(x, marg_othdim, cumprod), dim = dim_t),
     perm = c(marg_othdim + 1, 1)
   )
   abind::abind(1 - x, ones_arr) * abind::abind(ones_arr, x_cumprod)
@@ -2198,25 +2200,27 @@ inv_link_acat <- function(x, link) {
   dim_thres <- dim(x)[ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
+  dim_t <- c(dim_thres, dim_noncat)
   if (link == "logit") { 
     # faster evaluation in this case
     exp_x_cumprod <- aperm(
-      array(apply(exp(x), marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
+      array(apply(exp(x), marg_othdim, cumprod), dim = dim_t),
       perm = c(marg_othdim + 1, 1)
     )
     out <- abind::abind(ones_arr, exp_x_cumprod)
   } else {
     x <- ilink(x, link)
     x_cumprod <- aperm(
-      array(apply(x, marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
+      array(apply(x, marg_othdim, cumprod), dim = dim_t),
       perm = c(marg_othdim + 1, 1)
     )
     nthres <- dim(x)[ndim]
+    Sx_cumprod_rev <- apply(
+      1 - slice(x, ndim, rev(seq_len(nthres)), drop = FALSE),
+      marg_othdim, cumprod
+    )
     Sx_cumprod_rev <- aperm(
-      array(apply(
-        1 - slice(x, ndim, rev(seq_len(nthres)), drop = FALSE),
-        marg_othdim, cumprod
-      ), dim = c(dim_thres, dim_noncat)), 
+      array(Sx_cumprod_rev, dim = dim_t), 
       perm = c(marg_othdim + 1, 1)
     )
     Sx_cumprod_rev <- slice(

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -2094,10 +2094,11 @@ inv_link_sratio <- function(x, link) {
   x <- ilink(x, link)
   ndim <- length(dim(x))
   dim_noncat <- dim(x)[-ndim]
+  dim_thres <- dim(x)[ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
   Sx_cumprod <- aperm(
-    apply(1 - x, marg_othdim, cumprod),
+    array(apply(1 - x, marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
     perm = c(marg_othdim + 1, 1)
   )
   abind::abind(x, ones_arr) * abind::abind(ones_arr, Sx_cumprod)
@@ -2146,10 +2147,11 @@ inv_link_cratio <- function(x, link) {
   x <- ilink(x, link)
   ndim <- length(dim(x))
   dim_noncat <- dim(x)[-ndim]
+  dim_thres <- dim(x)[ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
   x_cumprod <- aperm(
-    apply(x, marg_othdim, cumprod),
+    array(apply(x, marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
     perm = c(marg_othdim + 1, 1)
   )
   abind::abind(1 - x, ones_arr) * abind::abind(ones_arr, x_cumprod)
@@ -2193,27 +2195,28 @@ dacat <- function(x, eta, thres, disc = 1, link = "logit") {
 inv_link_acat <- function(x, link) {
   ndim <- length(dim(x))
   dim_noncat <- dim(x)[-ndim]
+  dim_thres <- dim(x)[ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
   ones_arr <- array(1, dim = c(dim_noncat, 1))
   if (link == "logit") { 
     # faster evaluation in this case
     exp_x_cumprod <- aperm(
-      apply(exp(x), marg_othdim, cumprod),
+      array(apply(exp(x), marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
       perm = c(marg_othdim + 1, 1)
     )
     out <- abind::abind(ones_arr, exp_x_cumprod)
   } else {
     x <- ilink(x, link)
     x_cumprod <- aperm(
-      apply(x, marg_othdim, cumprod),
+      array(apply(x, marg_othdim, cumprod), dim = c(dim_thres, dim_noncat)),
       perm = c(marg_othdim + 1, 1)
     )
     nthres <- dim(x)[ndim]
     Sx_cumprod_rev <- aperm(
-      apply(
+      array(apply(
         1 - slice(x, ndim, rev(seq_len(nthres)), drop = FALSE),
         marg_othdim, cumprod
-      ), 
+      ), dim = c(dim_thres, dim_noncat)), 
       perm = c(marg_othdim + 1, 1)
     )
     Sx_cumprod_rev <- slice(

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -2045,18 +2045,10 @@ dcumulative <- function(x, eta, thres, disc = 1, link = "logit") {
 inv_link_cumulative <- function(x, link) {
   x <- ilink(x, link)
   ndim <- length(dim(x))
-  ncat <- dim(x)[ndim] + 1
-  out <- vector("list", ncat)
-  out[[1]] <- slice(x, ndim, 1)
-  if (ncat > 2) {
-    .diff <- function(k) {
-      slice(x, ndim, k) - slice(x, ndim, k - 1)
-    }
-    mid_cats <- 2:(ncat - 1)
-    out[mid_cats] <- lapply(mid_cats, .diff)
-  }
-  out[[ncat]] <- 1 - slice(x, ndim, ncat - 1)
-  abind::abind(out, along = ndim)
+  dim_noncat <- dim(x)[-ndim]
+  ones_arr <- array(1, dim = c(dim_noncat, 1))
+  zeros_arr <- array(0, dim = c(dim_noncat, 1))
+  abind::abind(x, ones_arr) - abind::abind(zeros_arr, x)
 }
 
 # density of the sratio distribution
@@ -2101,20 +2093,12 @@ dsratio <- function(x, eta, thres, disc = 1, link = "logit") {
 inv_link_sratio <- function(x, link) {
   x <- ilink(x, link)
   ndim <- length(dim(x))
-  ncat <- dim(x)[ndim] + 1
+  dim_noncat <- dim(x)[-ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
-  out <- vector("list", ncat)
-  out[[1]] <- slice(x, ndim, 1)
-  if (ncat > 2) {
-    .condprod <- function(k) {
-      slice(x, ndim, k) *
-        apply(1 - slice(x, ndim, 1:(k - 1), drop = FALSE), marg_othdim, prod)
-    }
-    mid_cats <- 2:(ncat - 1)
-    out[mid_cats] <- lapply(mid_cats, .condprod)
-  }
-  out[[ncat]] <- apply(1 - x, marg_othdim, prod)
-  abind::abind(out, along = ndim)
+  ones_arr <- array(1, dim = c(dim_noncat, 1))
+  Sx_cumprod <- aperm(apply(1 - x, marg_othdim, cumprod),
+                      perm = c(marg_othdim + 1, 1))
+  abind::abind(x, ones_arr) * abind::abind(ones_arr, Sx_cumprod)
 }
 
 # density of the cratio distribution
@@ -2159,20 +2143,12 @@ dcratio <- function(x, eta, thres, disc = 1, link = "logit") {
 inv_link_cratio <- function(x, link) {
   x <- ilink(x, link)
   ndim <- length(dim(x))
-  ncat <- dim(x)[ndim] + 1
+  dim_noncat <- dim(x)[-ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
-  out <- vector("list", ncat)
-  out[[1]] <- 1 - slice(x, ndim, 1)
-  if (ncat > 2) {
-    .condprod <- function(k) {
-      (1 - slice(x, ndim, k)) *
-        apply(slice(x, ndim, 1:(k - 1), drop = FALSE), marg_othdim, prod)
-    }
-    mid_cats <- 2:(ncat - 1)
-    out[mid_cats] <- lapply(mid_cats, .condprod)
-  }
-  out[[ncat]] <- apply(x, marg_othdim, prod)
-  abind::abind(out, along = ndim)
+  ones_arr <- array(1, dim = c(dim_noncat, 1))
+  x_cumprod <- aperm(apply(x, marg_othdim, cumprod),
+                     perm = c(marg_othdim + 1, 1))
+  abind::abind(1 - x, ones_arr) * abind::abind(ones_arr, x_cumprod)
 }
 
 # density of the acat distribution
@@ -2212,34 +2188,29 @@ dacat <- function(x, eta, thres, disc = 1, link = "logit") {
 #   of the inverse-link function applied to `x`.
 inv_link_acat <- function(x, link) {
   ndim <- length(dim(x))
-  ncat <- dim(x)[ndim] + 1
+  dim_noncat <- dim(x)[-ndim]
   marg_othdim <- seq_along(dim(x))[-ndim]
-  out <- vector("list", ncat)
+  ones_arr <- array(1, dim = c(dim_noncat, 1))
   if (link == "logit") { 
     # faster evaluation in this case
-    out[[1]] <- array(1, dim = dim(x)[-ndim])
-    out[[2]] <- exp(slice(x, ndim, 1))
-    if (ncat > 2) {
-      .catsum <- function(k) {
-        exp(apply(slice(x, ndim, 1:(k - 1), drop = FALSE), marg_othdim, sum))
-      }
-      remaincats <- 3:ncat
-      out[remaincats] <- lapply(remaincats, .catsum)
-    }
+    exp_x_cumprod <- aperm(apply(exp(x), marg_othdim, cumprod),
+                           perm = c(marg_othdim + 1, 1))
+    out <- abind::abind(ones_arr, exp_x_cumprod)
   } else {
     x <- ilink(x, link)
-    out[[1]] <- apply(1 - x, marg_othdim, prod)
-    if (ncat > 2) {
-      .othercatprod <- function(k) {
-        apply(slice(x, ndim, 1:(k - 1), drop = FALSE), marg_othdim, prod) * 
-          apply(slice(1 - x, ndim, k:(ncat - 1), drop = FALSE), marg_othdim, prod)
-      }
-      mid_cats <- 2:(ncat - 1)
-      out[mid_cats] <- lapply(mid_cats, .othercatprod)
-    }
-    out[[ncat]] <- apply(x, marg_othdim, prod)
+    x_cumprod <- aperm(apply(x, marg_othdim, cumprod),
+                       perm = c(marg_othdim + 1, 1))
+    nthres <- dim(x)[ndim]
+    Sx_cumprod_rev <- aperm(apply(
+      1 - slice(x, ndim, rev(seq_len(nthres)), drop = FALSE),
+      marg_othdim, cumprod
+    ), perm = c(marg_othdim + 1, 1))
+    Sx_cumprod_rev <- slice(
+      Sx_cumprod_rev, ndim, rev(seq_len(nthres)), drop = FALSE
+    )
+    out <- abind::abind(ones_arr, x_cumprod) *
+      abind::abind(Sx_cumprod_rev, ones_arr)
   }
-  out <- abind::abind(out, along = ndim)
   catsum <- apply(out, marg_othdim, sum)
   sweep(out, marg_othdim, catsum, "/")
 }

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -2225,7 +2225,7 @@ inv_link_acat <- function(x, link) {
     out <- abind::abind(ones_arr, x_cumprod) *
       abind::abind(Sx_cumprod_rev, ones_arr)
   }
-  catsum <- apply(out, marg_othdim, sum)
+  catsum <- array(apply(out, marg_othdim, sum), dim = dim_noncat)
   sweep(out, marg_othdim, catsum, "/")
 }
 

--- a/tests/testthat/helpers/d_ordinal_sim.R
+++ b/tests/testthat/helpers/d_ordinal_sim.R
@@ -1,12 +1,4 @@
 # This test corresponds to a single observation.
 set.seed(1234)
 ndraws <- 5
-ncat <- 3
-thres_test <- matrix(rnorm(ndraws * (ncat - 1)), nrow = ndraws)
-# Emulate no category-specific effects (i.e., only a single vector of linear
-# predictors) as well as category-specific effects (i.e., a matrix of linear
-# predictors):
-eta_test_list <- list(
-  rnorm(ndraws),
-  matrix(rnorm(ndraws * (ncat - 1)), nrow = ndraws)
-)
+ncat_vec <- c(2, 3)

--- a/tests/testthat/helpers/d_ordinal_sim.R
+++ b/tests/testthat/helpers/d_ordinal_sim.R
@@ -1,4 +1,4 @@
 # This test corresponds to a single observation.
 set.seed(1234)
-ndraws <- 5
+ndraws_vec <- c(1, 5)
 ncat_vec <- c(2, 3)

--- a/tests/testthat/helpers/inv_link_ordinal_sim.R
+++ b/tests/testthat/helpers/inv_link_ordinal_sim.R
@@ -1,9 +1,4 @@
 set.seed(1234)
 ndraws <- 5
 nobsv <- 4
-ncat <- 3
-x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
-                dim = c(ndraws, nobsv, ncat - 1))
-nx_test <- -x_test
-exp_nx_cumprod <- aperm(apply(exp(nx_test), c(1, 2), cumprod),
-                        perm = c(2, 3, 1))
+ncat_vec <- c(2, 3)

--- a/tests/testthat/helpers/inv_link_ordinal_sim.R
+++ b/tests/testthat/helpers/inv_link_ordinal_sim.R
@@ -1,4 +1,4 @@
 set.seed(1234)
-ndraws <- 5
+ndraws_vec <- c(1, 5)
 nobsv <- 4
 ncat_vec <- c(2, 3)

--- a/tests/testthat/helpers/inv_link_ordinal_sim.R
+++ b/tests/testthat/helpers/inv_link_ordinal_sim.R
@@ -1,4 +1,4 @@
 set.seed(1234)
 ndraws_vec <- c(1, 5)
-nobsv <- 4
+nobsv_vec <- c(1, 4)
 ncat_vec <- c(2, 3)

--- a/tests/testthat/tests.distributions.R
+++ b/tests/testthat/tests.distributions.R
@@ -261,33 +261,35 @@ test_that("inv_link_<ordinal_family>() works correctly for arrays", {
   source(testthat::test_path(file.path("helpers", "inv_link_ordinal_fun.R")))
   source(testthat::test_path(file.path("helpers", "inv_link_ordinal_sim.R")))
   for (ndraws in ndraws_vec) {
-    for (ncat in ncat_vec) {
-      x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
-                      dim = c(ndraws, nobsv, ncat - 1))
-      nx_test <- -x_test
-      exp_nx_cumprod <- aperm(array(apply(exp(nx_test), c(1, 2), cumprod),
-                                    dim = c(ncat - 1, ndraws, nobsv)),
-                              perm = c(2, 3, 1))
-      for (link in c("logit", "probit", "cauchit", "cloglog")) {
-        # cumulative():
-        il_cumul <- inv_link_cumulative(x_test, link = link)
-        il_cumul_ch <- inv_link_cumulative_ch(x_test, link = link)
-        expect_equivalent(il_cumul, il_cumul_ch)
-        
-        # sratio():
-        il_sratio <- inv_link_sratio(x_test, link = link)
-        il_sratio_ch <- inv_link_sratio_ch(x_test, link = link)
-        expect_equivalent(il_sratio, il_sratio_ch)
-        
-        # cratio():
-        il_cratio <- inv_link_cratio(nx_test, link = link)
-        il_cratio_ch <- inv_link_cratio_ch(nx_test, link = link)
-        expect_equivalent(il_cratio, il_cratio_ch)
-        
-        # acat():
-        il_acat <- inv_link_acat(nx_test, link = link)
-        il_acat_ch <- inv_link_acat_ch(nx_test, link = link)
-        expect_equivalent(il_acat, il_acat_ch)
+    for (nobsv in nobsv_vec) {
+      for (ncat in ncat_vec) {
+        x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
+                        dim = c(ndraws, nobsv, ncat - 1))
+        nx_test <- -x_test
+        exp_nx_cumprod <- aperm(array(apply(exp(nx_test), c(1, 2), cumprod),
+                                      dim = c(ncat - 1, ndraws, nobsv)),
+                                perm = c(2, 3, 1))
+        for (link in c("logit", "probit", "cauchit", "cloglog")) {
+          # cumulative():
+          il_cumul <- inv_link_cumulative(x_test, link = link)
+          il_cumul_ch <- inv_link_cumulative_ch(x_test, link = link)
+          expect_equivalent(il_cumul, il_cumul_ch)
+          
+          # sratio():
+          il_sratio <- inv_link_sratio(x_test, link = link)
+          il_sratio_ch <- inv_link_sratio_ch(x_test, link = link)
+          expect_equivalent(il_sratio, il_sratio_ch)
+          
+          # cratio():
+          il_cratio <- inv_link_cratio(nx_test, link = link)
+          il_cratio_ch <- inv_link_cratio_ch(nx_test, link = link)
+          expect_equivalent(il_cratio, il_cratio_ch)
+          
+          # acat():
+          il_acat <- inv_link_acat(nx_test, link = link)
+          il_acat_ch <- inv_link_acat_ch(nx_test, link = link)
+          expect_equivalent(il_acat, il_acat_ch)
+        }
       }
     }
   }
@@ -331,20 +333,22 @@ test_that(paste(
 ), {
   source(testthat::test_path(file.path("helpers", "inv_link_ordinal_sim.R")))
   for (ndraws in ndraws_vec) {
-    for (ncat in ncat_vec) {
-      x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
-                      dim = c(ndraws, nobsv, ncat - 1))
-      nx_test <- -x_test
-      exp_nx_cumprod <- aperm(array(apply(exp(nx_test), c(1, 2), cumprod),
-                                    dim = c(ncat - 1, ndraws, nobsv)),
-                              perm = c(2, 3, 1))
-      for (link in c("logit", "probit", "cauchit", "cloglog")) {
-        il_sratio <- inv_link_sratio(x_test, link = link)
-        il_cratio <- inv_link_cratio(nx_test, link = link)
-        if (link != "cloglog") {
-          expect_equal(il_sratio, il_cratio)
-        } else {
-          expect_false(isTRUE(all.equal(il_sratio, il_cratio)))
+    for (nobsv in nobsv_vec) {
+      for (ncat in ncat_vec) {
+        x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
+                        dim = c(ndraws, nobsv, ncat - 1))
+        nx_test <- -x_test
+        exp_nx_cumprod <- aperm(array(apply(exp(nx_test), c(1, 2), cumprod),
+                                      dim = c(ncat - 1, ndraws, nobsv)),
+                                perm = c(2, 3, 1))
+        for (link in c("logit", "probit", "cauchit", "cloglog")) {
+          il_sratio <- inv_link_sratio(x_test, link = link)
+          il_cratio <- inv_link_cratio(nx_test, link = link)
+          if (link != "cloglog") {
+            expect_equal(il_sratio, il_cratio)
+          } else {
+            expect_false(isTRUE(all.equal(il_sratio, il_cratio)))
+          }
         }
       }
     }

--- a/tests/testthat/tests.distributions.R
+++ b/tests/testthat/tests.distributions.R
@@ -202,45 +202,55 @@ test_that("wiener distribution functions run without errors", {
 test_that("d<ordinal_family>() works correctly", {
   source(testthat::test_path(file.path("helpers", "inv_link_ordinal_fun.R")))
   source(testthat::test_path(file.path("helpers", "d_ordinal_sim.R")))
-  for (eta_test in eta_test_list) {
-    thres_eta <- if (is.matrix(eta_test)) {
-      stopifnot(identical(dim(eta_test), dim(thres_test)))
-      thres_test - eta_test
-    } else {
-      # Just to try something different:
-      sweep(thres_test, 1, as.array(eta_test))
-    }
-    eta_thres <- if (is.matrix(eta_test)) {
-      stopifnot(identical(dim(eta_test), dim(thres_test)))
-      eta_test - thres_test
-    } else {
-      # Just to try something different:
-      sweep(-thres_test, 1, as.array(eta_test), FUN = "+")
-    }
-    for (link in c("logit", "probit", "cauchit", "cloglog")) {
-      # cumulative():
-      d_cumul <- dcumulative(seq_len(ncat),
-                             eta_test, thres_test, link = link)
-      d_cumul_ch <- inv_link_cumulative_ch(thres_eta, link = link)
-      expect_equivalent(d_cumul, d_cumul_ch)
-      
-      # sratio():
-      d_sratio <- dsratio(seq_len(ncat),
-                          eta_test, thres_test, link = link)
-      d_sratio_ch <- inv_link_sratio_ch(thres_eta, link = link)
-      expect_equivalent(d_sratio, d_sratio_ch)
-      
-      # cratio():
-      d_cratio <- dcratio(seq_len(ncat),
-                          eta_test, thres_test, link = link)
-      d_cratio_ch <- inv_link_cratio_ch(eta_thres, link = link)
-      expect_equivalent(d_cratio, d_cratio_ch)
-      
-      # acat():
-      d_acat <- dacat(seq_len(ncat),
-                      eta_test, thres_test, link = link)
-      d_acat_ch <- inv_link_acat_ch(eta_thres, link = link)
-      expect_equivalent(d_acat, d_acat_ch)
+  for (ncat in ncat_vec) {
+    thres_test <- matrix(rnorm(ndraws * (ncat - 1)), nrow = ndraws)
+    # Emulate no category-specific effects (i.e., only a single vector of linear
+    # predictors) as well as category-specific effects (i.e., a matrix of linear
+    # predictors):
+    eta_test_list <- list(
+      rnorm(ndraws),
+      matrix(rnorm(ndraws * (ncat - 1)), nrow = ndraws)
+    )
+    for (eta_test in eta_test_list) {
+      thres_eta <- if (is.matrix(eta_test)) {
+        stopifnot(identical(dim(eta_test), dim(thres_test)))
+        thres_test - eta_test
+      } else {
+        # Just to try something different:
+        sweep(thres_test, 1, as.array(eta_test))
+      }
+      eta_thres <- if (is.matrix(eta_test)) {
+        stopifnot(identical(dim(eta_test), dim(thres_test)))
+        eta_test - thres_test
+      } else {
+        # Just to try something different:
+        sweep(-thres_test, 1, as.array(eta_test), FUN = "+")
+      }
+      for (link in c("logit", "probit", "cauchit", "cloglog")) {
+        # cumulative():
+        d_cumul <- dcumulative(seq_len(ncat),
+                               eta_test, thres_test, link = link)
+        d_cumul_ch <- inv_link_cumulative_ch(thres_eta, link = link)
+        expect_equivalent(d_cumul, d_cumul_ch)
+        
+        # sratio():
+        d_sratio <- dsratio(seq_len(ncat),
+                            eta_test, thres_test, link = link)
+        d_sratio_ch <- inv_link_sratio_ch(thres_eta, link = link)
+        expect_equivalent(d_sratio, d_sratio_ch)
+        
+        # cratio():
+        d_cratio <- dcratio(seq_len(ncat),
+                            eta_test, thres_test, link = link)
+        d_cratio_ch <- inv_link_cratio_ch(eta_thres, link = link)
+        expect_equivalent(d_cratio, d_cratio_ch)
+        
+        # acat():
+        d_acat <- dacat(seq_len(ncat),
+                        eta_test, thres_test, link = link)
+        d_acat_ch <- inv_link_acat_ch(eta_thres, link = link)
+        expect_equivalent(d_acat, d_acat_ch)
+      }
     }
   }
 })
@@ -248,26 +258,34 @@ test_that("d<ordinal_family>() works correctly", {
 test_that("inv_link_<ordinal_family>() works correctly for arrays", {
   source(testthat::test_path(file.path("helpers", "inv_link_ordinal_fun.R")))
   source(testthat::test_path(file.path("helpers", "inv_link_ordinal_sim.R")))
-  for (link in c("logit", "probit", "cauchit", "cloglog")) {
-    # cumulative():
-    il_cumul <- inv_link_cumulative(x_test, link = link)
-    il_cumul_ch <- inv_link_cumulative_ch(x_test, link = link)
-    expect_equivalent(il_cumul, il_cumul_ch)
-    
-    # sratio():
-    il_sratio <- inv_link_sratio(x_test, link = link)
-    il_sratio_ch <- inv_link_sratio_ch(x_test, link = link)
-    expect_equivalent(il_sratio, il_sratio_ch)
-    
-    # cratio():
-    il_cratio <- inv_link_cratio(nx_test, link = link)
-    il_cratio_ch <- inv_link_cratio_ch(nx_test, link = link)
-    expect_equivalent(il_cratio, il_cratio_ch)
-    
-    # acat():
-    il_acat <- inv_link_acat(nx_test, link = link)
-    il_acat_ch <- inv_link_acat_ch(nx_test, link = link)
-    expect_equivalent(il_acat, il_acat_ch)
+  for (ncat in ncat_vec) {
+    x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
+                    dim = c(ndraws, nobsv, ncat - 1))
+    nx_test <- -x_test
+    exp_nx_cumprod <- aperm(array(apply(exp(nx_test), c(1, 2), cumprod),
+                                  dim = c(ncat - 1, ndraws, nobsv)),
+                            perm = c(2, 3, 1))
+    for (link in c("logit", "probit", "cauchit", "cloglog")) {
+      # cumulative():
+      il_cumul <- inv_link_cumulative(x_test, link = link)
+      il_cumul_ch <- inv_link_cumulative_ch(x_test, link = link)
+      expect_equivalent(il_cumul, il_cumul_ch)
+      
+      # sratio():
+      il_sratio <- inv_link_sratio(x_test, link = link)
+      il_sratio_ch <- inv_link_sratio_ch(x_test, link = link)
+      expect_equivalent(il_sratio, il_sratio_ch)
+      
+      # cratio():
+      il_cratio <- inv_link_cratio(nx_test, link = link)
+      il_cratio_ch <- inv_link_cratio_ch(nx_test, link = link)
+      expect_equivalent(il_cratio, il_cratio_ch)
+      
+      # acat():
+      il_acat <- inv_link_acat(nx_test, link = link)
+      il_acat_ch <- inv_link_acat_ch(nx_test, link = link)
+      expect_equivalent(il_acat, il_acat_ch)
+    }
   }
 })
 
@@ -276,16 +294,26 @@ test_that(paste(
   "functions"
 ), {
   source(testthat::test_path(file.path("helpers", "d_ordinal_sim.R")))
-  for (eta_test in eta_test_list) {
-    for (link in c("logit", "probit", "cauchit", "cloglog")) {
-      d_sratio <- dsratio(seq_len(ncat),
-                          eta_test, thres_test, link = link)
-      d_cratio <- dcratio(seq_len(ncat),
-                          eta_test, thres_test, link = link)
-      if (link != "cloglog") {
-        expect_equal(d_sratio, d_cratio)
-      } else {
-        expect_false(isTRUE(all.equal(d_sratio, d_cratio)))
+  for (ncat in ncat_vec) {
+    thres_test <- matrix(rnorm(ndraws * (ncat - 1)), nrow = ndraws)
+    # Emulate no category-specific effects (i.e., only a single vector of linear
+    # predictors) as well as category-specific effects (i.e., a matrix of linear
+    # predictors):
+    eta_test_list <- list(
+      rnorm(ndraws),
+      matrix(rnorm(ndraws * (ncat - 1)), nrow = ndraws)
+    )
+    for (eta_test in eta_test_list) {
+      for (link in c("logit", "probit", "cauchit", "cloglog")) {
+        d_sratio <- dsratio(seq_len(ncat),
+                            eta_test, thres_test, link = link)
+        d_cratio <- dcratio(seq_len(ncat),
+                            eta_test, thres_test, link = link)
+        if (link != "cloglog") {
+          expect_equal(d_sratio, d_cratio)
+        } else {
+          expect_false(isTRUE(all.equal(d_sratio, d_cratio)))
+        }
       }
     }
   }
@@ -296,13 +324,21 @@ test_that(paste(
   "results for symmetric distribution functions"
 ), {
   source(testthat::test_path(file.path("helpers", "inv_link_ordinal_sim.R")))
-  for (link in c("logit", "probit", "cauchit", "cloglog")) {
-    il_sratio <- inv_link_sratio(x_test, link = link)
-    il_cratio <- inv_link_cratio(nx_test, link = link)
-    if (link != "cloglog") {
-      expect_equal(il_sratio, il_cratio)
-    } else {
-      expect_false(isTRUE(all.equal(il_sratio, il_cratio)))
+  for (ncat in ncat_vec) {
+    x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
+                    dim = c(ndraws, nobsv, ncat - 1))
+    nx_test <- -x_test
+    exp_nx_cumprod <- aperm(array(apply(exp(nx_test), c(1, 2), cumprod),
+                                  dim = c(ncat - 1, ndraws, nobsv)),
+                            perm = c(2, 3, 1))
+    for (link in c("logit", "probit", "cauchit", "cloglog")) {
+      il_sratio <- inv_link_sratio(x_test, link = link)
+      il_cratio <- inv_link_cratio(nx_test, link = link)
+      if (link != "cloglog") {
+        expect_equal(il_sratio, il_cratio)
+      } else {
+        expect_false(isTRUE(all.equal(il_sratio, il_cratio)))
+      }
     }
   }
 })


### PR DESCRIPTION
This PR is based on PR #1154, so it's better to merge #1154 first.

As suspected [here](https://github.com/paul-buerkner/brms/pull/1137#issuecomment-832596346) (enumeration point 2), the current unit tests for the `inv_link_<ordinal_family>()` functions do indeed provide a more efficient implementation of these `inv_link_<ordinal_family>()` functions. Here is my requested speed comparison:
```r
library(brms)
options(mc.cores = parallel::detectCores(logical = FALSE))
data(inhaler, package = "brms")
bfit_cumul <- brm(
  formula = rating ~ period + carry + treat + (1 | subject),
  data = inhaler,
  family = cumulative(),
  seed = 475064792
)
library(microbenchmark)
microbenchmark(epred_cumul <- posterior_epred(bfit_cumul),
               times = 25)
### Old:
# Unit: seconds
#                                       expr      min       lq     mean   median      uq      max neval
# epred_cumul <- posterior_epred(bfit_cumul) 1.206015 1.415697 1.525062 1.429557 1.68592 2.037138    25
### 
### New:
# Unit: seconds
#                                       expr      min       lq    mean   median       uq      max neval
# epred_cumul <- posterior_epred(bfit_cumul) 1.322469 1.329213 1.35928 1.336847 1.343451 1.615867    25
### 

bfit_sratio <- update(bfit_cumul, family = sratio())
microbenchmark(epred_sratio <- posterior_epred(bfit_sratio),
               times = 25)
### Old:
# Unit: seconds
#                                         expr      min       lq     mean   median       uq      max neval
# epred_sratio <- posterior_epred(bfit_sratio) 13.98803 14.29517 14.40808 14.38126 14.58076 14.65054    25
### 
### New:
# Unit: seconds
#                                         expr      min       lq     mean   median       uq      max neval
# epred_sratio <- posterior_epred(bfit_sratio) 8.475701 8.635784 8.723748 8.690884 8.795831 9.093068    25
### 

bfit_cratio <- update(bfit_cumul, family = cratio())
microbenchmark(epred_cratio <- posterior_epred(bfit_cratio),
               times = 25)
### Old:
# Unit: seconds
#                                         expr      min       lq     mean   median       uq      max neval
# epred_cratio <- posterior_epred(bfit_cratio) 13.97217 14.32164 14.39963 14.34807 14.47658 14.70686    25
### 
### New:
# Unit: seconds
#                                         expr      min       lq    mean   median       uq      max neval
# epred_cratio <- posterior_epred(bfit_cratio) 8.169052 8.572888 8.62483 8.597578 8.634792 8.878164    25
### 

bfit_acat <- update(bfit_cumul, family = acat())
microbenchmark(epred_acat <- posterior_epred(bfit_acat),
               times = 25)
### Old:
# Unit: seconds
#                                     expr      min       lq     mean   median       uq      max neval
# epred_acat <- posterior_epred(bfit_acat) 13.73694 13.88184 13.94854 13.92991 13.95867 14.17641    25
### 
### New:
# Unit: seconds
#                                     expr      min       lq    mean   median       uq      max neval
# epred_acat <- posterior_epred(bfit_acat) 12.32044 12.65225 12.7692 12.72448 12.90858 13.42917    25
### 

bfit_acat_probit <- update(bfit_cumul, family = acat(link = "probit"))
microbenchmark(epred_acat_probit <- posterior_epred(bfit_acat_probit),
               times = 25)
### Old:
# Unit: seconds
#                                                   expr      min      lq     mean   median       uq      max neval
# epred_acat_probit <- posterior_epred(bfit_acat_probit) 31.17294 31.3034 31.45372 31.49983 31.55278 31.70364    25
### 
### New:
# Unit: seconds
#                                                   expr      min       lq     mean   median       uq      max neval
# epred_acat_probit <- posterior_epred(bfit_acat_probit) 21.54279 22.21362 22.39333 22.48148 22.65841 23.15681    25
### 

```

Because of this speed improvement (which is sometimes smaller, sometimes larger, but always present), this PR swaps the two implementations of the `inv_link_<ordinal_family>()` functions (the original one and the one from the unit tests).

Of course, one could go one step further and achieve another speed improvement by using arrays when calling `d<ordinal_family>()` in `posterior_epred_ordinal()`, i.e. by not iterating over the observations, but instead including them as an additional array dimension. But that probably requires larger changes.
