### PR TITLE
Fix CRAN NOTEs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,6 +58,8 @@ Suggests:
     digest,
     diffobj,
     R.rsp,
+    gtable,
+    shiny,
     knitr,
     rmarkdown
 Description: Fit Bayesian generalized (non-)linear multivariate multilevel models


### PR DESCRIPTION
Here's the list of current NOTEs:
```r
Check: Rd cross-references
Result: NOTE
    Undeclared packages ‘shiny’, ‘gtable’ in Rd xrefs
```
```r
Check: package dependencies
Result: NOTE
    Package suggested but not available for checking: 'cmdstanr'
```
```r
Check: installed package size
Result: NOTE
     installed size is 6.5Mb
     sub-directories of 1Mb or more:
     R 3.1Mb
     doc 2.4Mb
```

The 1st one should be fixed by this PR.

@paul-buerkner Do you really need to suggest `cmdstanr` before it's released to CRAN?
I think the installed package size is hard to resolve.