### PR TITLE
add test that non-looped non-linear models 

### DIFF
--- a/tests/local/tests.models_new.R
+++ b/tests/local/tests.models_new.R
@@ -27,7 +27,7 @@ test_that("Poisson model from brm doc works correctly", {
   ## investigate model fit
   expect_range(WAIC(fit1)$estimates[3, 1], 1120, 1160)
   expect_ggplot(pp_check(fit1))
-  
+
   # test kfold
   kfold1 <- kfold(fit1, chains = 1, iter = 1000, save_fits = TRUE)
   expect_range(kfold1$estimates[3, 1], 1210, 1260)
@@ -40,7 +40,7 @@ test_that("Poisson model from brm doc works correctly", {
   kfp1 <- kfold_predict(kfold1)
   rmse1 <- rmse(y = kfp1$y, yrep = kfp1$yrep)
   expect_range(rmse1, 6, 7)
-  
+
   # test loo_moment_match
   loo1 <- loo(fit1)
   mmloo1 <- loo_moment_match(fit1, loo1, k_threshold = 1, cores = 1)
@@ -112,7 +112,7 @@ test_that("ARMA models work correctly", {
   N <- 100
   y <- arima.sim(list(ar = c(0.7, -0.5, 0.04, 0.2, -0.4)), N)
   dat <- list(y = y, x = rnorm(N), g = sample(1:5, N, TRUE))
-  
+
   fit_ar <- brm(
     y ~ x + ar(p = 5), data = dat,
     prior = prior(normal(0, 5), class = "ar"),
@@ -124,12 +124,12 @@ test_that("ARMA models work correctly", {
   expect_range(ar[3], -0.2, 0.25)
   expect_range(ar[5], -0.6, -0.1)
   expect_ggplot(plot(conditional_effects(fit_ar))[[1]])
-  
+
   fit_ma <- brm(y ~ x + ma(q = 1), data = dat,
                 chains = 2, refresh = 0)
   print(fit_ma)
   expect_gt(LOO(fit_ma)$estimates[3, 1], LOO(fit_ar)$estimates[3, 1])
-  
+
   fit_arma <- brm(
     y ~ x + (1|g) + arma(gr = g, cov = TRUE), data = dat,
     prior = prior(normal(0, 5), class = "ar") +
@@ -140,7 +140,7 @@ test_that("ARMA models work correctly", {
   expect_range(waic(fit_arma)$estimates[3, 1], 250, 350)
   expect_equal(dim(predict(fit_arma)), c(nobs(fit_arma), 4))
   expect_ggplot(plot(conditional_effects(fit_arma), plot = FALSE)[[1]])
-  
+
   fit_arma_pois <- brm(
     count ~ Trt + (1 | patient) + arma(visit, patient, cov = TRUE),
     data = epilepsy, family = poisson(),
@@ -156,7 +156,7 @@ test_that("Models from hypothesis doc work correctly", {
   prior <- c(set_prior("normal(0,2)", class = "b"),
              set_prior("student_t(10,0,1)", class = "sigma"),
              set_prior("student_t(10,0,1)", class = "sd"))
-  
+
   ## fit a linear mixed effects models
   fit <- brm(time ~ age + sex + disease + (1 + age|patient),
              data = kidney, family = lognormal(),
@@ -164,17 +164,17 @@ test_that("Models from hypothesis doc work correctly", {
              control = list(adapt_delta = 0.95),
              refresh = 0)
   print(fit)
-  
+
   ## perform two-sided hypothesis testing
   hyp1 <- hypothesis(fit, "sexfemale = age + diseasePKD")
   expect_range(hyp1$hypothesis$Estimate, 0.6, 0.74)
   expect_range(hyp1$hypothesis$Evid.Ratio, 1, 5)
   expect_true(is(plot(hyp1)[[1]], "ggplot"))
-  
+
   ## perform one-sided hypothesis testing
   hyp2 <- hypothesis(fit, "diseasePKD + diseaseGN - 3 < 0")
   expect_range(hyp2$hypothesis$Evid.Ratio, 300)
-  
+
   ## test more than one hypothesis at once
   hyp3 <- c("diseaseGN = diseaseAN", "2 * diseaseGN - diseasePKD = 0")
   hyp3 <- hypothesis(fit, hyp3)
@@ -194,12 +194,12 @@ test_that("categorical models work correctly", {
   expect_equal(dim(fitted(fit2)), c(nobs(fit2), 4, ncat))
   expect_equal(dim(fitted(fit2, scale = "linear")),
                c(nobs(fit2), 4, ncat - 1))
-  
+
   # tests with new data
   newd <- inhaler[1:10, ]
   newd$rating <- NULL
   expect_equal(dim(predict(fit2, newdata = newd)), c(10, ncat))
-  
+
   ce <- conditional_effects(fit2, categorical = TRUE)
   expect_ggplot(plot(ce, plot = FALSE)[[1]])
 })
@@ -223,7 +223,7 @@ test_that("bridgesampling methods work correctly", {
     backend = "rstan"
   )
   print(fit2)
-  
+
   # compute the bayes factor
   expect_gt(bayes_factor(fit2, fit1)$bf, 1)
   # compute the posterior model probabilities
@@ -248,16 +248,16 @@ test_that("varying slopes without overall effects work", {
   expect_range(reloo1$estimates[3, 1], 1600, 1700)
   reloo2 <- LOO(fit1, reloo = TRUE, chains = 1, iter = 100)
   expect_range(reloo2$estimates[3, 1], 1600, 1700)
-  
+
   conditions <- data.frame(zAge = 0, zBase = 0, Trt = 0)
   ce <- conditional_effects(fit1, conditions = conditions)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
-  
+
   conditions <- data.frame(zAge = 0, zBase = 0,
                            Trt = 0, visit = c(1:4, NA))
   ce <- conditional_effects(fit1, conditions = conditions, re_formula = NULL)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
-  
+
   expect_range(WAIC(fit1)$estimates[3, 1], 1500, 1600)
   expect_equal(dim(predict(fit1)), c(nobs(fit1), 4))
 })
@@ -272,8 +272,8 @@ test_that("multivariate normal models work correctly", {
   id <- sample(1:10, N, replace = TRUE)
   tim <- sample(1:N, N)
   data <- data.frame(y1, y2, x, month, id, tim)
-  
-  fit_mv1 <- brm(mvbind(y1, y2) ~ s(x) + poly(month, 3) + 
+
+  fit_mv1 <- brm(mvbind(y1, y2) ~ s(x) + poly(month, 3) +
                    (1|x|id) + arma(tim, id, q = 0),
                  data = data,
                  prior = c(prior_(~normal(0,5), resp = "y1"),
@@ -282,7 +282,7 @@ test_that("multivariate normal models work correctly", {
                  sample_prior = TRUE,
                  iter = 1000, chains = 2, refresh = 0)
   print(fit_mv1)
-  
+
   expect_equal(dim(predict(fit_mv1)), c(300, 4, 2))
   expect_equal(dim(fitted(fit_mv1)), c(300, 4, 2))
   newdata <- data.frame(month = 1, y1 = 0, y2 = 0, x = 0, id = 1, tim = 1)
@@ -290,7 +290,7 @@ test_that("multivariate normal models work correctly", {
   cs <- conditional_smooths(fit_mv1, nsamples = 750)
   expect_equal(length(cs), 2)
   expect_ggplot(plot(cs, ask = FALSE)[[2]])
-  
+
   fit_mv2 <- brm(mvbind(y1, y2) ~ 1, data = data,
                  prior = prior_(~lkj(5), class = "rescor"),
                  sample_prior = TRUE, iter = 1000, refresh = 0)
@@ -304,7 +304,7 @@ test_that("generalized multivariate models work correctly", {
   bform <- (bf(tarsus ~ sex + (1|p|fosternest)) + skew_normal()) +
     (bf(back ~ s(tarsus, by = sex) + (1|p|fosternest)) + gaussian())
   fit_mv <- brm(bform, BTdata, chains = 2, iter = 1000, refresh = 0)
-  
+
   print(fit_mv)
   expect_ggplot(pp_check(fit_mv, resp = "back"))
   expect_range(waic(fit_mv)$estimates[3, 1], 4300, 4400)
@@ -325,7 +325,7 @@ test_that("ZI and HU models work correctly", {
   print(fit_hu)
   expect_equal(dim(predict(fit_hu)), c(nobs(fit_hu), 4))
   expect_ggplot(plot(conditional_effects(fit_hu), ask = FALSE)[[2]])
-  
+
   fit_zi <- brm(
     bf(count ~ zAge + zBase * Trt + (1|patient), zi ~ Trt),
     data = epilepsy, family = zero_inflated_negbinomial(),
@@ -340,7 +340,7 @@ test_that("ZI and HU models work correctly", {
   expect_ggplot(plot(conditional_effects(fit_zi), ask = FALSE)[[2]])
   waic_zi <- WAIC(fit_hu, fit_zi, nsamples = 100)
   expect_equal(dim(waic_zi$ic_diffs__), c(1, 2))
-  
+
   ## zero_inflated beta model
   data("GasolineYield", package = "betareg")
   dat <- GasolineYield
@@ -404,7 +404,7 @@ test_that("Nested non-linear models work correctly", {
     prior(normal(0, 1), nlpar = "b")
   fit <- brm(bform, dat, prior = bprior, family = Beta(), refresh = 0)
   print(fit)
-  
+
   ce <- conditional_effects(fit)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
   expect_range(bayes_R2(fit)[, 1], 0.2, 0.55)
@@ -420,20 +420,20 @@ test_that("Multivariate GAMMs work correctly", {
     control = list(adapt_delta = 0.95), refresh = 0
   )
   print(fit_gam)
-  
+
   ce <- conditional_effects(fit_gam)
   expect_ggplot(plot(ce, ask = FALSE, rug = TRUE, points = TRUE)[[1]])
   ce <- conditional_effects(fit_gam, surface = TRUE, too_far = 0.05)
   expect_ggplot(plot(ce, ask = FALSE, rug = TRUE)[[1]])
-  
+
   cs <- conditional_smooths(fit_gam, resolution = 25)
   expect_ggplot(plot(cs, rug = TRUE, ask = FALSE)[[1]])
   cs <- conditional_smooths(fit_gam, resolution = 100, too_far = 0.05)
   expect_ggplot(plot(cs, rug = TRUE, ask = FALSE)[[1]])
-  
+
   expect_range(loo(fit_gam)$estimates[3, 1], 830, 870)
   expect_equal(dim(predict(fit_gam)), c(nobs(fit_gam), 4))
-  
+
   newd <- data.frame(x0 = (0:30)/30, x1 = (0:30)/30,
                      x2 = (0:30)/30, x3 = (0:30)/30)
   prfi <- cbind(predict(fit_gam, newd), fitted(fit_gam, newdata = newd))
@@ -446,16 +446,16 @@ test_that("GAMMs with factor variable in 'by' work correctly", {
   fit_gam2 <- brm(y ~ fac + s(x2, by = fac, k = 4), dat,
                   chains = 2, refresh = 0)
   print(fit_gam2)
-  
+
   ce <- conditional_effects(fit_gam2, "x2:fac")
   expect_ggplot(plot(ce, points = TRUE, ask = FALSE)[[1]])
   cs <- conditional_smooths(fit_gam2, res = 10)
   expect_ggplot(plot(cs, rug = TRUE, ask = FALSE)[[1]])
-  
+
   fit_gam3 <- brm(y ~ fac + t2(x1, x2, by = fac), dat,
                   chains = 2, refresh = 0)
   print(fit_gam3)
-  
+
   ce <- conditional_effects(fit_gam3, "x2:fac")
   expect_ggplot(plot(ce, points = TRUE, ask = FALSE)[[1]])
   cs <- conditional_smooths(fit_gam3, too_far = 0.1)
@@ -473,7 +473,7 @@ test_that("generalized extreme value models work correctly", {
       max(Year) + c(0, 10)) - median(Year)
     )
   )
-  
+
   fit_gev <- brm(
     bf(SeaLevel ~ cYear + SOI,
        sigma ~ s(cYear, bs = "bs", m = 1, k = 3) + SOI),
@@ -482,7 +482,7 @@ test_that("generalized extreme value models work correctly", {
     control = list(adapt_delta = 0.95), refresh = 0
   )
   print(fit_gev)
-  
+
   prfi <- cbind(predict(fit_gev), fitted(fit_gev))
   expect_range(prfi[, 1], prfi[, 5] - 0.03, prfi[, 5] + 0.03)
   # expect_range(loo(fit_gev)$estimates[3, 1], -115, -95)
@@ -497,7 +497,7 @@ test_that("update works correctly for some special cases", {
   expect_equal(rownames(fixef(fit2)), c("Intercept", "Trt1"))
   fit3 <- update(fit2, ~ . - Trt, newdata = epilepsy, refresh = 0)
   expect_equal(rownames(fixef(fit3)), c("Intercept"))
-  
+
   # test that family is correctly updated
   fit4 <- update(fit1, family = student(), refresh = 0)
   expect_equal(family(fit4)$family, "student")
@@ -512,7 +512,7 @@ test_that("Wiener diffusion models work correctly", {
   x <- rnorm(100, mean = 1)
   dat <- rwiener(n = 1, alpha = 2, tau = .3, beta = .5, delta = .5 + x)
   dat$x <- x
-  
+
   fit_d1 <- brm(bf(q | dec(resp) ~ x), dat,
                 family = wiener(), refresh = 0)
   print(fit_d1)
@@ -520,7 +520,7 @@ test_that("Wiener diffusion models work correctly", {
   expect_ggplot(pp_check(fit_d1))
   pp <- posterior_predict(fit_d1, nsamples = 10, negative_rt = TRUE)
   expect_true(min(pp) < 0)
-  
+
   fit_d2 <- brm(bf(q | dec(resp) ~ x, ndt ~ x),
                 dat, family = wiener(), refresh = 0)
   print(fit_d2)
@@ -528,7 +528,7 @@ test_that("Wiener diffusion models work correctly", {
   expect_ggplot(pp_check(fit_d2))
   pred <- predict(fit_d2, nsamples = 10, negative_rt = TRUE, summary = FALSE)
   expect_true(any(pred < 0))
-  
+
   waic_d <- WAIC(fit_d1, fit_d2)
   expect_equal(dim(waic_d$ic_diffs__), c(1, 2))
 })
@@ -564,7 +564,7 @@ test_that("Argument `incl_thres` works correctly for non-grouped thresholds", {
   thres_minus_eta_ch <- apply(thres, 2, "-", eta)
   thres_minus_eta_ch <- array(thres_minus_eta_ch,
                               dim = c(nrow(thres), ncol(eta), ncol(thres)))
-  dimnames(thres_minus_eta_ch) <- 
+  dimnames(thres_minus_eta_ch) <-
     list(NULL, NULL, as.character(seq_len(ncol(thres))))
   expect_identical(thres_minus_eta, thres_minus_eta_ch)
 })
@@ -586,7 +586,7 @@ test_that("Mixture models work correctly", {
     prior(normal(5, 5), Intercept, dpar = mu2),
     prior(normal(10, 5), Intercept, dpar = mu3)
   )
-  
+
   fit1 <- brm(
     bform1, data = dat, family = mixfam,
     prior = c(prior, prior(dirichlet(1, 1, 1), theta)),
@@ -596,11 +596,11 @@ test_that("Mixture models work correctly", {
   expect_ggplot(pp_check(fit1))
   loo1 <- LOO(fit1)
   expect_equal(dim(pp_mixture(fit1)), c(nobs(fit1), 4, 3))
-  
+
   bform2 <- bf(bform1, theta1 = 1, theta2 = 1, theta3 = 1)
   fit2 <- brm(
     bform2, data = dat, family = mixfam,
-    prior = prior, chains = 2, 
+    prior = prior, chains = 2,
     inits = 0, refresh = 0
   )
   print(fit2)
@@ -608,7 +608,7 @@ test_that("Mixture models work correctly", {
   loo2 <- LOO(fit2)
   expect_gt(loo2$estimates[3, 1], loo1$estimates[3, 1])
   expect_equal(dim(pp_mixture(fit2)), c(nobs(fit2), 4, 3))
-  
+
   # MCMC chains get stuck when fitting this model
   # bform3 <- bf(bform1, theta1 ~ z, theta2 ~ 1)
   # prior3 <- prior +
@@ -617,7 +617,7 @@ test_that("Mixture models work correctly", {
   #   prior(normal(0, 1), Intercept, dpar = theta2)
   # fit3 <- brm(
   #   bform3, data = dat, family = mixfam,
-  #   prior = prior3, init_r = 0.1, 
+  #   prior = prior3, init_r = 0.1,
   #   chains = 1, refresh = 0
   # )
   # print(fit3)
@@ -633,14 +633,14 @@ test_that("Gaussian processes work correctly", {
   ## Basic GPs
   set.seed(1112)
   dat <- mgcv::gamSim(1, n = 30, scale = 2)
-  fit1 <- brm(y ~ gp(x0) + x1 + gp(x2) + x3, dat, 
+  fit1 <- brm(y ~ gp(x0) + x1 + gp(x2) + x3, dat,
               chains = 2, refresh = 0)
   print(fit1)
   expect_ggplot(pp_check(fit1))
   ce <- conditional_effects(fit1, nsamples = 200, nug = 1e-07)
   expect_ggplot(plot(ce, ask = FALSE)[[3]])
   expect_range(WAIC(fit1)$estimates[3, 1], 100, 200)
-  
+
   # multivariate GPs
   fit2 <- brm(y ~ gp(x1, x2), dat, chains = 2, refresh = 0)
   print(fit2)
@@ -651,7 +651,7 @@ test_that("Gaussian processes work correctly", {
   )
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
   expect_range(WAIC(fit2)$estimates[3, 1], 100, 200)
-  
+
   # GP with continuous 'by' variable
   fit3 <- brm(y ~ gp(x1, by = x2), dat, chains = 2, refresh = 0)
   print(fit3)
@@ -659,7 +659,7 @@ test_that("Gaussian processes work correctly", {
   ce <- conditional_effects(fit3, nsamples = 200, nug = 1e-07)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
   expect_range(WAIC(fit3)$estimates[3, 1], 100, 200)
-  
+
   # GP with factor 'by' variable
   dat2 <- mgcv::gamSim(4, n = 100, scale = 2)
   fit4 <- brm(y ~ gp(x2, by = fac), dat2, chains = 2, refresh = 0)
@@ -673,22 +673,22 @@ test_that("Gaussian processes work correctly", {
 test_that("Approximate Gaussian processes work correctly", {
   set.seed(1245)
   dat <- mgcv::gamSim(4, n = 200, scale = 2)
-  
+
   # isotropic approximate GP
   fit1 <- brm(
-    y ~ gp(x1, x2, by = fac, k = 10, c = 5/4), 
+    y ~ gp(x1, x2, by = fac, k = 10, c = 5/4),
     data = dat, chains = 2, cores = 2, refresh = 0,
     control = list(adapt_delta = 0.99)
   )
   print(fit1)
-  expect_range(bayes_R2(fit1)[1, 1], 0.45, 0.7) 
+  expect_range(bayes_R2(fit1)[1, 1], 0.45, 0.7)
   ce <- conditional_effects(
     fit1, "x2:x1", conditions = data.frame(fac = unique(dat$fac)),
     resolution = 20, surface = TRUE
   )
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
   expect_range(WAIC(fit1)$estimates[3, 1], 900, 1000)
-  
+
   # non isotropic approximate GP
   fit2 <- brm(
     y ~ gp(x1, x2, by = fac, k = 10, c = 5/4, iso = FALSE),
@@ -696,7 +696,7 @@ test_that("Approximate Gaussian processes work correctly", {
     control = list(adapt_delta = 0.99)
   )
   print(fit2)
-  expect_range(bayes_R2(fit2)[1, 1], 0.50, 0.62) 
+  expect_range(bayes_R2(fit2)[1, 1], 0.50, 0.62)
   ce <- conditional_effects(
     fit2, "x2:x1", conditions = data.frame(fac = unique(dat$fac)),
     resolution = 20, surface = TRUE
@@ -707,7 +707,7 @@ test_that("Approximate Gaussian processes work correctly", {
 
 test_that("SAR models work correctly", {
   data(oldcol, package = "spdep")
-  fit_lagsar <- brm(CRIME ~ INC + HOVAL + sar(COL.nb), 
+  fit_lagsar <- brm(CRIME ~ INC + HOVAL + sar(COL.nb),
                     data = COL.OLD, data2 = list(COL.nb = COL.nb),
                     chains = 2, refresh = 0)
   print(fit_lagsar)
@@ -715,8 +715,8 @@ test_that("SAR models work correctly", {
   ce <- conditional_effects(fit_lagsar, nsamples = 200)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
   expect_range(WAIC(fit_lagsar)$estimates[3, 1], 350, 380)
-  
-  fit_errorsar <- brm(CRIME ~ INC + HOVAL + sar(COL.nb, type = "error"), 
+
+  fit_errorsar <- brm(CRIME ~ INC + HOVAL + sar(COL.nb, type = "error"),
                       data = COL.OLD, data2 = list(COL.nb = COL.nb),
                       chains = 2, refresh = 0)
   print(fit_errorsar)
@@ -732,13 +732,13 @@ test_that("CAR models work correctly", {
   east <- north <- 1:10
   Grid <- expand.grid(east, north)
   K <- nrow(Grid)
-  
+
   # set up distance and neighbourhood matrices
   distance <- as.matrix(dist(Grid))
   W <- array(0, c(K, K))
   W[distance == 1] <- 1
   rownames(W) <- 1:nrow(W)
-  
+
   # generate the covariates and response data
   x1 <- rnorm(K)
   x2 <- rnorm(K)
@@ -751,27 +751,27 @@ test_that("CAR models work correctly", {
   size <- rep(50, K)
   y <- rbinom(n = K, size = size, prob = prob)
   dat <- data.frame(y, size, x1, x2, obs = 1:length(y))
-  
+
   # fit a CAR model
   fit_car <- brm(
     y | trials(size) ~ x1 + x2 + car(W, obs),
-    data = dat, data2 = list(W = W), family = binomial(), 
+    data = dat, data2 = list(W = W), family = binomial(),
     chains = 2, refresh = 0
-  ) 
+  )
   print(fit_car)
   expect_ggplot(pp_check(fit_car))
   ce = conditional_effects(fit_car, nsamples = 200)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
   expect_range(LOO(fit_car)$estimates[3, 1], 450, 550)
   expect_false(isTRUE(all.equal(
-    fitted(fit_car, newdata = dat[1:5, ]), 
+    fitted(fit_car, newdata = dat[1:5, ]),
     fitted(fit_car, newdata = dat[1:5, ], incl_autocor = FALSE)
   )))
-  
+
   newdata <- data.frame(x1 = 0, x2 = 0, size = 50, obs = 1)
   pp <- posterior_predict(fit_car, newdata = newdata)
   expect_equal(dim(pp), c(nsamples(fit_car), 1))
-  
+
   newdata <- data.frame(x1 = 0, x2 = 0, size = 50, obs = -1)
   new_W <- W
   rownames(W)[1] <- "-1"
@@ -783,20 +783,20 @@ test_that("CAR models work correctly", {
 test_that("Missing value imputation works correctly", {
   library(mice)
   data("nhanes", package = "mice")
-  
+
   # missing value imputation via multiple imputation
   imp <- mice(nhanes)
-  fit_imp1 <- brm_multiple(bmi ~ age * chl, imp, chains = 1, 
+  fit_imp1 <- brm_multiple(bmi ~ age * chl, imp, chains = 1,
                            backend = "rstan", refresh = 0)
   print(fit_imp1)
   expect_equal(nsamples(fit_imp1), 5000)
   expect_equal(dim(fit_imp1$rhats), c(5, length(parnames(fit_imp1))))
-  
+
   fit_imp1 <- update(fit_imp1, . ~ chl, newdata = imp)
   print(fit_imp1)
   expect_true(!"b_age" %in% parnames(fit_imp1))
   expect_equal(nsamples(fit_imp1), 5000)
-  
+
   # missing value imputation within Stan
   bform <- bf(bmi | mi() ~ age * mi(chl)) +
     bf(chl | mi() ~ age) + set_rescor(FALSE)
@@ -808,14 +808,14 @@ test_that("Missing value imputation works correctly", {
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
   loo <- LOO(fit_imp2, newdata = na.omit(fit_imp2$data))
   expect_range(loo$estimates[3, 1], 200, 220)
-  
+
   # overimputation within Stan
   dat <- nhanes
   dat$sdy <- 5
   bform <- bf(bmi | mi() ~ age * mi(chl)) +
     bf(chl | mi(sdy) ~ age) + set_rescor(FALSE)
   fit_imp3 <- brm(bform, data = dat,
-                  save_pars = save_pars(latent = TRUE), 
+                  save_pars = save_pars(latent = TRUE),
                   backend = "rstan", refresh = 0)
   print(fit_imp3)
   pred <- predict(fit_imp3)
@@ -829,7 +829,7 @@ test_that("Missing value imputation works correctly", {
 test_that("student-t-distributed group-level effects work correctly", {
   fit <- brm(
     count ~ Trt * zBase + (1 | gr(patient, dist = "student")),
-    data = epilepsy, family = poisson(), 
+    data = epilepsy, family = poisson(),
     chains = 1, refresh = 0
   )
   print(summary(fit))
@@ -843,12 +843,12 @@ test_that("multinomial models work correctly", {
   set.seed(1245)
   N <- 100
   dat <- data.frame(
-    y1 = rbinom(N, 10, 0.1), y2 = rbinom(N, 10, 0.4), 
+    y1 = rbinom(N, 10, 0.1), y2 = rbinom(N, 10, 0.4),
     y3 = rbinom(N, 10, 0.7), x = rnorm(N)
   )
   dat$size <- with(dat, y1 + y2 + y3)
   dat$y <- with(dat, cbind(y1, y2, y3))
-  
+
   fit <- brm(y | trials(size) ~ x, data = dat,
              family = multinomial(), refresh = 0)
   print(summary(fit))
@@ -868,7 +868,7 @@ test_that("dirichlet models work correctly", {
   names(dat) <- c("y1", "y2", "y3")
   dat$x <- rnorm(N)
   dat$y <- with(dat, cbind(y1, y2, y3))
-  
+
   fit <- brm(y ~ x, data = dat, family = dirichlet(), refresh = 0)
   print(summary(fit))
   expect_output(print(fit), "muy2 = logit")
@@ -886,7 +886,7 @@ test_that("Addition argument 'subset' works correctly", {
   data("BTdata", package = "MCMCglmm")
   BTdata$sub1 <- sample(0:1, nrow(BTdata), replace = TRUE)
   BTdata$sub2 <- sample(0:1, nrow(BTdata), replace = TRUE)
-  
+
   bform <- bf(tarsus | subset(sub1) ~ sex + (1|p|fosternest) + (1|q|dam)) +
     bf(back | subset(sub2) ~ sex + (1|p|fosternest) + (1|q|dam)) +
     set_rescor(FALSE)
@@ -910,8 +910,8 @@ test_that("Cox models work correctly", {
   d1 <- simsurv::simsurv(lambdas = 0.1, gammas  = 1.5, betas = c(trt = -0.5),
                          x = covs, maxt  = 5)
   d1 <- merge(d1, covs)
-  
-  fit1 <- brm(eventtime | cens(1 - status) ~ 1 + trt, 
+
+  fit1 <- brm(eventtime | cens(1 - status) ~ 1 + trt,
               data = d1, family = brmsfamily("cox"), refresh = 0)
   print(summary(fit1))
   expect_range(posterior_summary(fit1)["b_trt", "Estimate"], -0.70, -0.30)
@@ -926,16 +926,16 @@ test_that("ordinal model with grouped thresholds works correctly", {
     th = rep(5:6, each = 50),
     x = rnorm(100)
   )
-  
+
   prior <- prior(normal(0,1), class = "Intercept", group = "b")
-  fit <- brm(y | thres(th, gr) ~ x, dat, cumulative(), prior = prior) 
+  fit <- brm(y | thres(th, gr) ~ x, dat, cumulative(), prior = prior)
   print(summary(fit))
   pred <- predict(fit)
   expect_equal(dim(pred), c(nrow(dat), max(dat$th) + 1))
   expect_range(waic(fit)$estimates[3, 1], 350, 400)
   ce <- conditional_effects(fit, categorical = TRUE)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
-  
+
   # test incl_thres = TRUE
   thres_minus_eta <- posterior_linpred(fit, incl_thres = TRUE)
   bprep <- prepare_predictions(fit)
@@ -960,10 +960,10 @@ test_that("ordinal model with grouped thresholds works correctly", {
         dim(thres_minus_eta_ch_gr)[-3],
         nthres_max - dim(thres_minus_eta_ch_gr)[3]
       )
-      thres_minus_eta_ch_gr <- 
+      thres_minus_eta_ch_gr <-
         abind::abind(thres_minus_eta_ch_gr, array(dim = dim_NA))
     }
-    dimnames(thres_minus_eta_ch_gr) <- 
+    dimnames(thres_minus_eta_ch_gr) <-
       list(NULL, NULL, as.character(seq_len(nthres_max)))
     return(thres_minus_eta_ch_gr)
   })
@@ -977,7 +977,7 @@ test_that("Fixing parameters to constants works correctly", {
   bprior <- prior(normal(0, 1), class = "b") +
     prior(constant(2), class = "b", coef = "zBase") +
     prior(constant(0.5), class = "sd")
-  
+
   fit <- brm(count ~ zAge + zBase + (1 | patient),
              data = epilepsy, prior = bprior)
   print(summary(fit))
@@ -990,11 +990,11 @@ test_that("projpred methods can be run", {
   fit <- brm(count ~ zAge + zBase * Trt,
              data = epilepsy, family = poisson())
   summary(fit)
-  
+
   # perform variable selection without cross-validation
   vs <- varsel(fit)
   expect_is(vs, "vsel")
-  
+
   # perform variable selection with cross-validation
   cv_vs <- cv_varsel(fit)
   expect_is(vs, "vsel")
@@ -1006,9 +1006,9 @@ test_that(paste(
 ), {
   set.seed(1234)
   dat2 <- data.frame(
-    rating = sample(1:4, 50, TRUE), 
+    rating = sample(1:4, 50, TRUE),
     subject = rep(1:10, 5),
-    x1 = rnorm(50), 
+    x1 = rnorm(50),
     x2 = rnorm(50),
     x3 = rnorm(50)
   )
@@ -1016,7 +1016,7 @@ test_that(paste(
   iter <- 200
   chains <- 1
   stan_model_args <- list(save_dso = FALSE)
-  
+
   fit_sratio <- SW(brm(
     bf(rating ~ x1 + cs(x2) + (cs(x2)||subject), disc ~ 1),
     data = dat2, family = sratio(),
@@ -1024,7 +1024,7 @@ test_that(paste(
     stan_model_args = stan_model_args, seed = 533273
   ))
   draws_sratio <- as.matrix(fit_sratio)
-  
+
   fit_cratio <- SW(brm(
     bf(rating ~ x1 + cs(x2) + (cs(x2)||subject), disc ~ 1),
     data = dat2, family = cratio(),
@@ -1032,6 +1032,65 @@ test_that(paste(
     stan_model_args = stan_model_args, seed = 533273
   ))
   draws_cratio <- as.matrix(fit_cratio)
-  
+
   expect_equal(draws_sratio, draws_cratio)
 })
+
+test_that("Non-linear non-looped model predictions work correctly in blocked order", {
+    loss_alt  <- transform(loss, row=as.integer(1:nrow(loss)), nr=nrow(loss), test=as.integer(0))
+    growth_model  <- stanvar(name="growth_test", scode="
+vector growth_test(vector ult, int[] dev, vector theta, vector omega, int[] row, int[] test) {
+    int N = rows(ult);
+    vector[N] mu;
+    int rows_sorted = 1;
+
+    for(i in 1:N) {
+      if(row[i] != i)
+         rows_sorted = 0;
+    }
+
+    for(i in 1:N) {
+       if(test[i] == 0) {
+         mu[i] = ult[i] * (1 - exp(-(dev[i]/theta[i])^omega[i]));
+       } else if(test[i] == 1) {
+         mu[i] = rows_sorted;
+       } else if(test[i] == 2) {
+         mu[i] = N;
+       }
+    }
+    return(mu);
+}
+", block="functions")
+  fit_loss <- brm(
+    bf(cum ~ growth_test(ult, dev, theta, omega, row, test),
+       ult ~ 1 + (1|AY), omega ~ 1, theta ~ 1,
+       nl = TRUE, loop=FALSE),
+    data = loss_alt, family = gaussian(),
+    stanvars=growth_model,
+    prior = c(prior(normal(5000, 1000), nlpar = "ult"),
+              prior(normal(1, 2), nlpar = "omega"),
+              prior(normal(45, 10), nlpar = "theta")),
+    control = list(adapt_delta = 0.9),
+    refresh = 0,
+    chains=1,
+    backend="rstan"
+  )
+    expose_functions(fit_loss)
+    N <- nrow(loss_alt)
+    pr1 <- posterior_epred(fit_loss, newdata=transform(loss_alt, test=1), nsamples=10)
+    expect_true(all(dim(pr1) == c(10,N)))
+    expect_true(all(pr1 == 1))
+    pr1b <- posterior_epred(fit_loss, newdata=transform(loss_alt, test=1)[-5,], nsamples=10)
+    expect_true(all(dim(pr1b) == c(10,N-1)))
+    expect_true(all(pr1b == 0))
+    pr1c <- posterior_epred(fit_loss, newdata=transform(loss_alt, test=1)[-N,], nsamples=10)
+    expect_true(all(dim(pr1c) == c(10,N-1)))
+    expect_true(all(pr1c == 1))
+    pr2 <- posterior_epred(fit_loss, newdata=transform(loss_alt, test=2), nsamples=10)
+    expect_true(all(dim(pr2) == c(10,N)))
+    expect_true(all(pr2 == N))
+    pr2b <- posterior_epred(fit_loss, newdata=transform(loss_alt, test=2)[-N,], nsamples=10)
+    expect_true(all(dim(pr2b) == c(10,N-1)))
+    expect_true(all(pr2b == N-1))
+})
+


### PR DESCRIPTION

This test ensures that predictions for non-looped non-linear models are evaluated in a blocked way with the order of the data-set not being changed.
