### PR TITLE
doc updates for custom families

### DIFF
--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -331,10 +331,12 @@
 #'   For custom families, it is possible to pass an arbitrary number of real and
 #'   integer vectors via the addition terms \code{vreal} and \code{vint},
 #'   respectively. An example is provided in
-#'   \code{vignette('brms_customfamilies')}.
+#'   \code{vignette('brms_customfamilies')}. To pass multiple vectors of the
+#'   same data type, provide them separated by commas inside a single 
+#'   \code{vreal} or \code{vint} statement.
 #' 
-#'   Multiple addition terms may be specified at the same time using the
-#'   \code{+} operator. For example, the formula
+#'   Multiple addition terms of different types may be specified at the same 
+#'   time using the \code{+} operator. For example, the formula
 #'   \code{formula = yi | se(sei) + cens(censored) ~ 1} implies a censored 
 #'   meta-analytic model.
 #'   

--- a/R/families.R
+++ b/R/families.R
@@ -974,17 +974,22 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL) {
 #' @param links Names of the link functions of the 
 #'   distributional parameters.
 #' @param type Indicates if the response distribution is
-#'   continuous (\code{"real"}) or discrete (\code{"int"}) and controls
-#'   if the corresonding function will be named with "_lpdf" or "_lpmf".
+#'   continuous (\code{"real"}) or discrete (\code{"int"}). This controls
+#'   if the corresponding density function will be named with
+#'   \code{<name>_lpdf} or \code{<name>_lpmf}.
 #' @param lb Vector of lower bounds of the distributional 
 #'   parameters. Defaults to \code{NA} that is no lower bound.
 #' @param ub Vector of upper bounds of the distributional 
 #'   parameters. Defaults to \code{NA} that is no upper bound.
-#' @param vars Names of variables, which are part of the likelihood
-#'   function without being distributional parameters. That is,
-#'   \code{vars} can be used to pass data to the likelihood. 
-#'   See \code{\link{stanvar}} for details about adding self-defined
-#'   data to the generated \pkg{Stan} model.
+#' @param vars Names of variables that are part of the likelihood function
+#'   without being distributional parameters. That is, \code{vars} can be used
+#'   to pass data to the likelihood. Such arguments will be added to the list of
+#'   function arguments at the end, after the distributional parameters. See
+#'   \code{\link{stanvar}} for details about adding self-defined data to the
+#'   generated \pkg{Stan} model. Addition arguments \code{vreal} and \code{vint}
+#'   may be used for this purpose as well (see Examples below). See also
+#'   \code{\link{brmsformula}} and \code{\link{addition-terms}} for more
+#'   details.
 #' @param loop Logical; Should the likelihood be evaluated via a loop
 #'   (\code{TRUE}; the default) over observations in Stan?
 #'   If \code{FALSE}, the Stan code will be written in a vectorized
@@ -1025,7 +1030,8 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL) {
 #' @return An object of class \code{customfamily} inheriting
 #'   from class \code{\link{brmsfamily}}.
 #'   
-#' @seealso \code{\link{brmsfamily}}, \code{\link{stanvar}}
+#' @seealso \code{\link{brmsfamily}}, \code{\link{brmsformula}},
+#'    \code{\link{stanvar}}
 #' 
 #' @examples
 #' \dontrun{
@@ -1047,20 +1053,44 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL) {
 #' beta_binomial2 <- custom_family(
 #'   "beta_binomial2", dpars = c("mu", "phi"),
 #'   links = c("logit", "log"), lb = c(NA, 0),
-#'   type = "int", vars = "trials[n]"
+#'   type = "int", vars = "vint1[n]"
 #' )
 #' 
 #' # define the corresponding Stan density function
-#' stan_funs <- "
+#' stan_density <- "
 #'   real beta_binomial2_lpmf(int y, real mu, real phi, int N) {
 #'     return beta_binomial_lpmf(y | N, mu * phi, (1 - mu) * phi);
 #'   }
 #' "
+#' stanvars <- stanvar(scode = stan_density, block = "functions")
 #' 
 #' # fit the model
-#' fit <- brm(y | trials(ntrials) ~ z, data = dat, 
-#'            family = beta_binomial2, stan_funs = stan_funs)
+#' fit <- brm(y | vint(ntrials) ~ z, data = dat, 
+#'            family = beta_binomial2, stanvars = stanvars)
 #' summary(fit)
+#' 
+#' 
+#' # define a *vectorized* custom family (no loop over observations)
+#' # notice also that 'vint' no longer has an observation index
+#' beta_binomial2_vec <- custom_family(
+#'   "beta_binomial2", dpars = c("mu", "phi"),
+#'   links = c("logit", "log"), lb = c(NA, 0),
+#'   type = "int", vars = "vint1", loop = FALSE
+#' )
+#' 
+#' # define the corresponding Stan density function
+#' stan_density_vec <- "
+#'   real beta_binomial2_lpmf(int[] y, vector mu, real phi, int[] N) {
+#'     return beta_binomial_lpmf(y | N, mu * phi, (1 - mu) * phi);
+#'   }
+#' "
+#' stanvars_vec <- stanvar(scode = stan_density_vec, block = "functions")
+#' 
+#' # fit the model
+#' fit_vec <- brm(y | vint(ntrials) ~ z, data = dat, 
+#'            family = beta_binomial2_vec, 
+#'            stanvars = stanvars_vec)
+#' summary(fit_vec)
 #' }
 #' 
 #' @export

--- a/R/families.R
+++ b/R/families.R
@@ -974,7 +974,8 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL) {
 #' @param links Names of the link functions of the 
 #'   distributional parameters.
 #' @param type Indicates if the response distribution is
-#'   continuous (\code{"real"}) or discrete (\code{"int"}).
+#'   continuous (\code{"real"}) or discrete (\code{"int"}) and controls
+#'   if the corresonding function will be named with "_lpdf" or "_lpmf".
 #' @param lb Vector of lower bounds of the distributional 
 #'   parameters. Defaults to \code{NA} that is no lower bound.
 #' @param ub Vector of upper bounds of the distributional 

--- a/R/formula-ad.R
+++ b/R/formula-ad.R
@@ -39,7 +39,9 @@
 #'   the denominator values from which the response rates are computed.
 #' @param gr A vector of grouping indicators.
 #' @param ... For \code{resp_vreal}, vectors of real values. 
-#'   For \code{resp_vint}, vectors of integer values.  
+#'   For \code{resp_vint}, vectors of integer values. In Stan,
+#'   these variables will be named \code{vreal1}, \code{vreal2}, ...,
+#'   and \code{vint1}, \code{vint2}, ..., respectively.
 #'
 #' @return A list of additional response information to be processed further
 #'   by \pkg{brms}.

--- a/man/addition-terms.Rd
+++ b/man/addition-terms.Rd
@@ -89,7 +89,9 @@ at the same time using the plausible-values-technique.}
 the denominator values from which the response rates are computed.}
 
 \item{...}{For \code{resp_vreal}, vectors of real values. 
-For \code{resp_vint}, vectors of integer values.}
+For \code{resp_vint}, vectors of integer values. In Stan,
+these variables will be named \code{vreal1}, \code{vreal2}, ...,
+and \code{vint1}, \code{vint2}, ..., respectively.}
 }
 \value{
 A list of additional response information to be processed further

--- a/man/brmsformula.Rd
+++ b/man/brmsformula.Rd
@@ -360,10 +360,12 @@ models for all parameters of the assumed response distribution.
   For custom families, it is possible to pass an arbitrary number of real and
   integer vectors via the addition terms \code{vreal} and \code{vint},
   respectively. An example is provided in
-  \code{vignette('brms_customfamilies')}.
+  \code{vignette('brms_customfamilies')}. To pass multiple vectors of the
+  same data type, provide them separated by commas inside a single 
+  \code{vreal} or \code{vint} statement.
 
-  Multiple addition terms may be specified at the same time using the
-  \code{+} operator. For example, the formula
+  Multiple addition terms of different types may be specified at the same 
+  time using the \code{+} operator. For example, the formula
   \code{formula = yi | se(sei) + cens(censored) ~ 1} implies a censored 
   meta-analytic model.
   

--- a/man/custom_family.Rd
+++ b/man/custom_family.Rd
@@ -36,7 +36,9 @@ parameter.}
 distributional parameters.}
 
 \item{type}{Indicates if the response distribution is
-continuous (\code{"real"}) or discrete (\code{"int"}).}
+continuous (\code{"real"}) or discrete (\code{"int"}). This controls
+if the corresponding density function will be named with
+\code{<name>_lpdf} or \code{<name>_lpmf}.}
 
 \item{lb}{Vector of lower bounds of the distributional 
 parameters. Defaults to \code{NA} that is no lower bound.}
@@ -44,11 +46,15 @@ parameters. Defaults to \code{NA} that is no lower bound.}
 \item{ub}{Vector of upper bounds of the distributional 
 parameters. Defaults to \code{NA} that is no upper bound.}
 
-\item{vars}{Names of variables, which are part of the likelihood
-function without being distributional parameters. That is,
-\code{vars} can be used to pass data to the likelihood. 
-See \code{\link{stanvar}} for details about adding self-defined
-data to the generated \pkg{Stan} model.}
+\item{vars}{Names of variables that are part of the likelihood function
+without being distributional parameters. That is, \code{vars} can be used
+to pass data to the likelihood. Such arguments will be added to the list of
+function arguments at the end, after the distributional parameters. See
+\code{\link{stanvar}} for details about adding self-defined data to the
+generated \pkg{Stan} model. Addition arguments \code{vreal} and \code{vint}
+may be used for this purpose as well (see Examples below). See also
+\code{\link{brmsformula}} and \code{\link{addition-terms}} for more
+details.}
 
 \item{loop}{Logical; Should the likelihood be evaluated via a loop
 (\code{TRUE}; the default) over observations in Stan?
@@ -129,23 +135,48 @@ dat <- data.frame(y, z, ntrials)
 beta_binomial2 <- custom_family(
   "beta_binomial2", dpars = c("mu", "phi"),
   links = c("logit", "log"), lb = c(NA, 0),
-  type = "int", vars = "trials[n]"
+  type = "int", vars = "vint1[n]"
 )
 
 # define the corresponding Stan density function
-stan_funs <- "
+stan_density <- "
   real beta_binomial2_lpmf(int y, real mu, real phi, int N) {
     return beta_binomial_lpmf(y | N, mu * phi, (1 - mu) * phi);
   }
 "
+stanvars <- stanvar(scode = stan_density, block = "functions")
 
 # fit the model
-fit <- brm(y | trials(ntrials) ~ z, data = dat, 
-           family = beta_binomial2, stan_funs = stan_funs)
+fit <- brm(y | vint(ntrials) ~ z, data = dat, 
+           family = beta_binomial2, stanvars = stanvars)
 summary(fit)
+
+
+# define a *vectorized* custom family (no loop over observations)
+# notice also that 'vint' no longer has an observation index
+beta_binomial2_vec <- custom_family(
+  "beta_binomial2", dpars = c("mu", "phi"),
+  links = c("logit", "log"), lb = c(NA, 0),
+  type = "int", vars = "vint1", loop = FALSE
+)
+
+# define the corresponding Stan density function
+stan_density_vec <- "
+  real beta_binomial2_lpmf(int[] y, vector mu, real phi, int[] N) {
+    return beta_binomial_lpmf(y | N, mu * phi, (1 - mu) * phi);
+  }
+"
+stanvars_vec <- stanvar(scode = stan_density_vec, block = "functions")
+
+# fit the model
+fit_vec <- brm(y | vint(ntrials) ~ z, data = dat, 
+           family = beta_binomial2_vec, 
+           stanvars = stanvars_vec)
+summary(fit_vec)
 }
 
 }
 \seealso{
-\code{\link{brmsfamily}}, \code{\link{stanvar}}
+\code{\link{brmsfamily}}, \code{\link{brmsformula}},
+   \code{\link{stanvar}}
 }


### PR DESCRIPTION
This is a minor doc update to explain how to pass multiple vint or vreal terms and to further clarify the impact of setting `custom_family(type = )`.  I have not yet run roxygenise.  

While I think this is the only relevant place in the doc for this information, a potential problem is that it is not easily discoverable.  For example `?custom_family` provides a link to the doc for `stanvars`, but there's not trail of links to get through to the doc for `?brmsformula`.

Additionally, there are two things that I'd like to doc but I'm not sure where to put the doc:
* The important distinction between `custom_family(..., vars = vint1)` and `custom_family(..., vars = vint1[n])` that was a stumbling block for both me and @wds15.
* How multiple `vint` or `vreal` terms get matched to the arguments of the lpdf or lpmf.  (Not only am I unsure of where to document this; I am unsure of what the answer even is!)