### PR TITLE
Fix `.extract_model_data()`, e.g. in case of no offsets

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -197,6 +197,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   offset <- as.vector(sdata[[paste0("offsets", usc_resp)]])
   weights <- as.vector(sdata[[paste0("weights", usc_resp)]])
   trials <- as.vector(sdata[[paste0("trials", usc_resp)]])
+  stopifnot(!is.null(y))
   if (is_binary(family)) {
     trials <- rep(1, length(y))
   }
@@ -205,6 +206,12 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
       stop2("Projpred cannot handle 'trials' and 'weights' at the same time.") 
     }
     weights <- trials
+  }
+  if (is.null(weights)) {
+    weights <- rep(1, length(y))
+  }
+  if (is.null(offset)) {
+    offset <- rep(0, length(y))
   }
   nlist(y, weights, offset)
 }


### PR DESCRIPTION
This fixes the following issue:
```r
data("df_gaussian", package = "projpred")
dat <- cbind("y" = df_gaussian$y, as.data.frame(df_gaussian$x))

library(brms)
options(mc.cores = parallel::detectCores(logical = FALSE))
bfit <- brm(y ~ V1 + V2 + V3 + V4 + V5,
            data = dat,
            seed = 1140350788)

library(projpred)
refm <- get_refmodel(bfit)
prd <- predict(refm, dat)
str(prd)

```
With brms v2.16.1, that last line returns
```
num(0)
```
With the fix from this PR, that last line returns
```
num [1:100] -0.373 2.549 -0.032 -1.491 -2.386 ...
```

The reason for this issue is that in projpred v2.0.2 (the current CRAN version), `predict.refmodel()` does not expect `weights` or `offset` to be `NULL`. I have already fixed this in one of my projpred branches, but until this is merged into projpred's `master` branch (currently, a different PR for projpred's `develop` branch is still pending) and then released on CRAN, I think it's better to fix this in brms. That will also prevent that issue for users who don't (immediately) upgrade projpred after the fixed version will be released on CRAN.
