### PR TITLE
`get_refmodel.brmsfit()` docs: ignored arguments

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -16,6 +16,11 @@
 #' @param ... Further arguments passed to 
 #' \code{\link[projpred:get-refmodel]{init_refmodel}}.
 #' 
+#' @details Note that the \code{extract_model_data} function used internally by
+#'   \code{get_refmodel.brmsfit} ignores arguments \code{wrhs}, \code{orhs}, and
+#'   \code{extract_y}. This is relevant for
+#'   \code{\link[projpred:predict.refmodel]{predict.refmodel}}, for example.
+#' 
 #' @return A \code{refmodel} object to be used in conjunction with the
 #'   \pkg{projpred} package.
 #' 

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -39,6 +39,12 @@ automatically when performing variable selection via
 \code{\link[projpred:cv_varsel]{cv_varsel}}, so you will rarely need to call
 it manually yourself.
 }
+\details{
+Note that the \code{extract_model_data} function used internally by
+  \code{get_refmodel.brmsfit} ignores arguments \code{wrhs}, \code{orhs}, and
+  \code{extract_y}. This is relevant for
+  \code{\link[projpred:predict.refmodel]{predict.refmodel}}, for example.
+}
 \examples{
 \dontrun{
 # fit a simple model


### PR DESCRIPTION
This fixes #1230: In the `get_refmodel.brmsfit()` docs, details concerning ignored arguments of `extract_model_data()` are added.