### PR TITLE
Corrected passthrough of threads for VI

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -235,7 +235,11 @@ fit_model <- function(model, backend, ...) {
   }
   args <- nlist(data = sdata, seed, init = inits)
   if (use_threading(threads)) {
-    args$threads_per_chain <- threads$threads
+    if (algorithm %in% c("sampling", "fixed_param")) {
+      args$threads_per_chain <- threads$threads
+    } else if (algorithm %in% c("fullrank", "meanfield")) {
+      args$threads <- threads$threads
+    }
   }
   if (use_opencl(opencl)) {
     args$opencl_ids <- opencl$ids


### PR DESCRIPTION
Variational inference with threading failed with `cmdstanr` since the `threads` argument was misnamed. 

Altered naming of the threads argument for matching algorithms, but left unmatching algorithms to fall through to the later `stop` command. You may prefer to handle the unmatching algorithms here too, or to provide a default via `else`.