### PR TITLE
Quick fix for issue #1286 (and other changes for K-fold CV)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,19 @@
 # brms 2.16.3++
 
+### Other changes
+
+* Argument `kfold_seed` has been added to `get_refmodel.brmsfit()`. (#1286)
+
 ### Bug Fixes
 
 * Fix Stan code of threaded multivariate models 
 thanks to Anirban Mukherjee. (#1277)
 * Fix usage of `int_conditions` in `conditional_smooths`
 thanks to Urs Kalbitzer. (#1280)
+* Fix an error sometimes occurring for multilevel (reference) models in
+`projpred`'s K-fold CV. For reproducible predictions of multilevel (reference)
+models, argument `refprd_seed` has been added to
+`get_refmodel.brmsfit()`. (#1286)
 
 # brms 2.16.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### Other changes
 
-* Argument `kfold_seed` has been added to `get_refmodel.brmsfit()`. (#1286)
+* Argument `brms_seed` has been added to `get_refmodel.brmsfit()`. (#1287)
 
 ### Bug Fixes
 
@@ -11,9 +11,7 @@ thanks to Anirban Mukherjee. (#1277)
 * Fix usage of `int_conditions` in `conditional_smooths`
 thanks to Urs Kalbitzer. (#1280)
 * Fix an error sometimes occurring for multilevel (reference) models in
-`projpred`'s K-fold CV. For reproducible predictions of multilevel (reference)
-models, argument `refprd_seed` has been added to
-`get_refmodel.brmsfit()`. (#1286)
+`projpred`'s K-fold CV. (#1286)
 
 # brms 2.16.3
 

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -243,7 +243,7 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
     ks <- match(k, Ksub)
     message("Fitting model ", k, " out of ", K)
     futures[[ks]] <- future::future(
-      .kfold_k(k), packages = "brms", seed = TRUE
+      .kfold_k(k), seed = TRUE
     )
   }
   for (k in Ksub) {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -13,6 +13,7 @@
 #' (see \code{\link[projpred:get-refmodel]{get_refmodel}} for details).
 #' If \code{NULL} (the default), \code{cvfun} is defined internally
 #' based on \code{\link{kfold.brmsfit}}.
+#' @param kfold_seed A seed passed to \code{\link{kfold.brmsfit}}.
 #' @param ... Further arguments passed to 
 #' \code{\link[projpred:get-refmodel]{init_refmodel}}.
 #' 
@@ -45,7 +46,7 @@
 #' plot(cv_vs)
 #' }
 get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL, 
-                                 cvfun = NULL, ...) {
+                                 cvfun = NULL, kfold_seed = NULL, ...) {
   require_package("projpred")
   dots <- list(...)
   resp <- validate_resp(resp, object, multiple = FALSE)
@@ -142,8 +143,13 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   # extract a list of K-fold sub-models
   if (is.null(cvfun)) {
     cvfun <- function(folds, ...) {
+      if (is.null(kfold_seed)) {
+        # Since kfold() doesn't seem to accept `seed = NULL`, set a random seed:
+        kfold_seed <- sample.int(.Machine$integer.max, 1)
+      }
       kfold(
-        object, K = max(folds), save_fits = TRUE, folds = folds, ...
+        object, K = max(folds), save_fits = TRUE, folds = folds,
+        seed = kfold_seed, ...
       )$fits[, "fit"]
     }
   } else {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -142,13 +142,9 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   # extract a list of K-fold sub-models
   if (is.null(cvfun)) {
     cvfun <- function(folds, ...) {
-      cvres <- kfold(
-        object, K = max(folds),
-        save_fits = TRUE, folds = folds,
-        ...
-      )
-      fits <- cvres$fits[, "fit"]
-      return(fits)
+      kfold(
+        object, K = max(folds), save_fits = TRUE, folds = folds, ...
+      )$fits[, "fit"]
     }
   } else {
     if (!is.function(cvfun)) {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -57,8 +57,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   
   # Infer "sub-seeds":
-  if (exists(".Random.seed")) {
-    rng_state_old <- .Random.seed
+  if (exists(".Random.seed", envir = .GlobalEnv)) {
+    rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
   }
   set.seed(brms_seed)
@@ -127,8 +127,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   ref_predfun <- function(fit, newdata = NULL) {
     # Setting a seed is necessary for reproducible sampling of group-level
     # effects for new levels:
-    if (exists(".Random.seed")) {
-      rng_state_old <- .Random.seed
+    if (exists(".Random.seed", envir = .GlobalEnv)) {
+      rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
       on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
     }
     set.seed(refprd_seed)
@@ -145,8 +145,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     # ref_predfun <- function(fit, newdata = NULL) {
     #   # Setting a seed is necessary for reproducible sampling of group-level
     #   # effects for new levels:
-    #   if (exists(".Random.seed")) {
-    #     rng_state_old <- .Random.seed
+    #   if (exists(".Random.seed", envir = .GlobalEnv)) {
+    #     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
     #     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
     #   }
     #   set.seed(refprd_seed)

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -164,6 +164,11 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     # }
   }
   
+  if (utils::packageVersion("projpred") <= "2.0.2") {
+    warning2("Under projpred version <= 2.0.2, projpred's K-fold CV results ",
+             "may not be reproducible for multilevel brms reference models.")
+  }
+  
   # extract a list of K-fold sub-models
   if (is.null(cvfun)) {
     cvfun <- function(folds, ...) {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -164,7 +164,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     # }
   }
   
-  if (utils::packageVersion("projpred") <= "2.0.2") {
+  if (utils::packageVersion("projpred") <= "2.0.2" && NROW(object$ranef)) {
     warning2("Under projpred version <= 2.0.2, projpred's K-fold CV results ",
              "may not be reproducible for multilevel brms reference models.")
   }

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -182,9 +182,21 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     }
   }
   
+  cvrefbuilder <- function(cvfit) {
+    # For `refprd_seed` in fold `cvfit$projpred_k` (= k) of K, choose a new seed
+    # which is based on the original `refprd_seed`:
+    if (is.null(refprd_seed)) {
+      refprd_seed_k <- NULL
+    } else {
+      refprd_seed_k <- refprd_seed + cvfit$projpred_k
+    }
+    projpred::get_refmodel(cvfit, resp = resp, refprd_seed = refprd_seed_k, ...)
+  }
+  
   args <- nlist(
     object, data, formula, family, dis, ref_predfun = ref_predfun,
-    cvfun = cvfun, extract_model_data = extract_model_data, ...
+    cvfun = cvfun, extract_model_data = extract_model_data,
+    cvrefbuilder = cvrefbuilder, ...
   )
   do_call(projpred::init_refmodel, args)
 }

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -10,14 +10,14 @@
 #' 
 #' @inheritParams posterior_predict.brmsfit
 #' @param cvfun Optional cross-validation function
-#' (see \code{\link[projpred:get-refmodel]{get_refmodel}} for details).
+#' (see \code{\link[projpred:get_refmodel]{get_refmodel}} for details).
 #' If \code{NULL} (the default), \code{cvfun} is defined internally
 #' based on \code{\link{kfold.brmsfit}}.
 #' @param kfold_seed A seed passed to \code{\link{kfold.brmsfit}}.
 #' @param refprd_seed A seed for sampling group-level effects for new levels (in
 #' multilevel models).
 #' @param ... Further arguments passed to 
-#' \code{\link[projpred:get-refmodel]{init_refmodel}}.
+#' \code{\link[projpred:init_refmodel]{init_refmodel}}.
 #' 
 #' @details Note that the \code{extract_model_data} function used internally by
 #'   \code{get_refmodel.brmsfit} ignores arguments \code{wrhs}, \code{orhs}, and

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -4,7 +4,14 @@
 \alias{get_refmodel.brmsfit}
 \title{Projection Predictive Variable Selection: Get Reference Model}
 \usage{
-get_refmodel.brmsfit(object, newdata = NULL, resp = NULL, cvfun = NULL, ...)
+get_refmodel.brmsfit(
+  object,
+  newdata = NULL,
+  resp = NULL,
+  cvfun = NULL,
+  kfold_seed = NULL,
+  ...
+)
 }
 \arguments{
 \item{object}{An object of class \code{brmsfit}.}
@@ -22,6 +29,8 @@ are performed only for the specified response variables.}
 (see \code{\link[projpred:get-refmodel]{get_refmodel}} for details).
 If \code{NULL} (the default), \code{cvfun} is defined internally
 based on \code{\link{kfold.brmsfit}}.}
+
+\item{kfold_seed}{A seed passed to \code{\link{kfold.brmsfit}}.}
 
 \item{...}{Further arguments passed to 
 \code{\link[projpred:get-refmodel]{init_refmodel}}.}

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -9,8 +9,7 @@ get_refmodel.brmsfit(
   newdata = NULL,
   resp = NULL,
   cvfun = NULL,
-  kfold_seed = NULL,
-  refprd_seed = NULL,
+  brms_seed = NULL,
   ...
 )
 }
@@ -31,10 +30,8 @@ are performed only for the specified response variables.}
 If \code{NULL} (the default), \code{cvfun} is defined internally
 based on \code{\link{kfold.brmsfit}}.}
 
-\item{kfold_seed}{A seed passed to \code{\link{kfold.brmsfit}}.}
-
-\item{refprd_seed}{A seed for sampling group-level effects for new levels (in
-multilevel models).}
+\item{brms_seed}{A seed used to infer seeds for \code{\link{kfold.brmsfit}}
+and for sampling group-level effects for new levels (in multilevel models).}
 
 \item{...}{Further arguments passed to 
 \code{\link[projpred:init_refmodel]{init_refmodel}}.}

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -27,7 +27,7 @@ predictions of the grand mean when using sum coding.}
 are performed only for the specified response variables.}
 
 \item{cvfun}{Optional cross-validation function
-(see \code{\link[projpred:get-refmodel]{get_refmodel}} for details).
+(see \code{\link[projpred:get_refmodel]{get_refmodel}} for details).
 If \code{NULL} (the default), \code{cvfun} is defined internally
 based on \code{\link{kfold.brmsfit}}.}
 
@@ -37,7 +37,7 @@ based on \code{\link{kfold.brmsfit}}.}
 multilevel models).}
 
 \item{...}{Further arguments passed to 
-\code{\link[projpred:get-refmodel]{init_refmodel}}.}
+\code{\link[projpred:init_refmodel]{init_refmodel}}.}
 }
 \value{
 A \code{refmodel} object to be used in conjunction with the

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -10,6 +10,7 @@ get_refmodel.brmsfit(
   resp = NULL,
   cvfun = NULL,
   kfold_seed = NULL,
+  refprd_seed = NULL,
   ...
 )
 }
@@ -31,6 +32,9 @@ If \code{NULL} (the default), \code{cvfun} is defined internally
 based on \code{\link{kfold.brmsfit}}.}
 
 \item{kfold_seed}{A seed passed to \code{\link{kfold.brmsfit}}.}
+
+\item{refprd_seed}{A seed for sampling group-level effects for new levels (in
+multilevel models).}
 
 \item{...}{Further arguments passed to 
 \code{\link[projpred:get-refmodel]{init_refmodel}}.}


### PR DESCRIPTION
This is a "quick" fix for issue #1286 because it resolves the error described in #1286 (due to `allow_new_levels`), but it doesn't resolve the inconsistency between the reference model's linear predictors and the submodels' linear predictors described in stan-dev/projpred#268.

The first three commits (d47829399fb55015ad46ef9f69a575d6a9d740a4, ddcece60c8eda555087e8b4a1e17d2f3d44ffe3f, db89c178406339ae68124357fad50cade8da88d6) are not really related to the `allow_new_levels` issue; I stumbled across them while working on this. To see the issue of attaching brms (solved by commit db89c178406339ae68124357fad50cade8da88d6), consider the following reprex:
```r

# Data --------------------------------------------------------------------

set.seed(457211)
dat <- matrix(rnorm(41 * 2, sd = 0.4),
              ncol = 2,
              dimnames = list(NULL, paste0("X", 1:2)))
dat <- data.frame(dat)
dat$group <- gl(n = 8, k = floor(nrow(dat) / 8), length = nrow(dat),
                labels = paste0("gr", seq_len(8)))
group_icpts_truth <- rnorm(nlevels(dat$group), sd = 6)
group_X1_truth <- rnorm(nlevels(dat$group), sd = 6)
icpt <- -4.2
dat$y <- icpt +
  group_icpts_truth[dat$group] +
  group_X1_truth[dat$group] * dat$X1
dat$y <- rnorm(nrow(dat), mean = dat$y, sd = 4)

# Fit reference model -----------------------------------------------------

options(mc.cores = parallel::detectCores(logical = FALSE))
bfit <- brms::brm(y ~ X1 + X2 + (1 + X1 | group),
                  data = dat,
                  control = list(adapt_delta = 0.9),
                  refresh = 0,
                  seed = 1140350788)

# Refit in K folds --------------------------------------------------------

Kcv <- 2
set.seed(568456) # Needed to make the construction of the CV folds reproducible.
cvfits_grp <- loo::kfold(bfit,
                         K = Kcv,
                         folds = "grouped",
                         group = "group",
                         save_fits = TRUE,
                         seed = 4910396)
```
which reports the following to the console:
```
Fitting model 1 out of 2
Loading required package: Rcpp
Loading 'brms' package (version 2.16.3). Useful instructions
can be found by typing help('brms'). A more detailed introduction
to the package is available through vignette('brms_overview').

Attaching package: ‘brms’

The following object is masked from ‘package:stats’:

  ar

Fitting model 2 out of 2
Start sampling
Start sampling
```

Note that `projpred::init_refmodel()`'s new argument `cvrefbuilder` is not available yet in projpred's current CRAN version 2.0.2. But because of `init_refmodel()`'s ellipsis, it is possible to use projpred 2.0.2 nonetheless (`cvrefbuilder` simply gets swallowed up by the ellipsis), at the danger of non-reproducible results in K-fold CV for multilevel (brms) reference models. I hope projpred's development version will make it to CRAN soon and then this reproducibility issue will be resolved. Until then, I added a corresponding warning. The condition for that warning could be further refined if brms had a function checking whether a `brmsfit` is multilevel (so something like `has_group_effects(<brmsfit>)`). I couldn't find such a function, but if it exists, we could simply replace `packageVersion("projpred") <= "2.0.2"` by `packageVersion("projpred") <= "2.0.2" && has_group_effects(object)` or whatever the name of that function is.

For the tests at the state of this PR, I had to revert commit 61a2f94e87e4e25a7f44bbcdf722a6f519afca3d from `master`. Then, the tests passed (apart from the two mock backend tests I already mentioned in PR #1223, but that may be due to my rstan and StanHeaders version, see [here](https://discourse.mc-stan.org/t/error-expected-end-of-file-after-end-of-generated-quantities-block/26077/6)).

