### PR TITLE
Fix PR #1287

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -191,10 +191,14 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   
   cvrefbuilder <- function(cvfit) {
-    # For `refprd_seed` in fold `cvfit$projpred_k` (= k) of K, choose a new seed
-    # which is based on the original `refprd_seed`:
-    refprd_seed_k <- refprd_seed + cvfit$projpred_k
-    projpred::get_refmodel(cvfit, resp = resp, refprd_seed = refprd_seed_k, ...)
+    # For `brms_seed` in fold `cvfit$projpred_k` (= k) of K, choose a new seed
+    # which is based on the original `brms_seed`:
+    if (is.null(brms_seed)) {
+      brms_seed_k <- NULL
+    } else {
+      brms_seed_k <- brms_seed + cvfit$projpred_k
+    }
+    projpred::get_refmodel(cvfit, resp = resp, brms_seed = brms_seed_k, ...)
   }
   
   args <- nlist(


### PR DESCRIPTION
Sorry, I just realized that I have overseen something while making the switch from `kfold_seed` and `refprd_seed` to `brms_seed` in PR #1287. I did search for remaining occurrences of `kfold_seed` and `refprd_seed`, but that didn't prevent me from overseeing that more of them need to be replaced. And since that `refprd_seed` remnant got swallowed up by `projpred::init_refmodel()`'s ellipsis, it didn't produce an error in brms's `R CMD check`.