### PR TITLE
Support augmented-data projection in projpred

### DIFF
--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1960,7 +1960,7 @@ dcategorical <- function(x, eta, log = FALSE) {
   if (length(dim(eta)) != 2L) {
     stop2("eta must be a numeric vector or matrix.")
   }
-  out <- inv_link_categorical(eta, log = log)
+  out <- inv_link_categorical(eta, refcat_obj = NULL, log = log)
   out[, x, drop = FALSE]
 }
 
@@ -1972,10 +1972,11 @@ dcategorical <- function(x, eta, log = FALSE) {
 #   dcategorical()) or an array (S x N x `ncat` or S x N x `ncat - 1` (depending
 #   on `refcat_obj`)) containing the same values as the matrix just described,
 #   but for N observations.
-# @param refcat_obj Either NULL or an object of class "brmsfamily". If NULL, `x`
-#   is not modified at all. If an object of class "brmsfamily", then
-#   insert_refcat() is used to insert values for the reference category into
-#   `x`.
+# @param refcat_obj Either the string "first", an object of class "brmsfamily",
+#   or NULL. If "first", then the first category is used as reference and
+#   corresponding values are inserted into `x`. If an object of class
+#   "brmsfamily", then passed to insert_refcat() which is used to insert values
+#   for the reference category into `x`. If NULL, `x` is not modified at all.
 # @param log Logical (length 1) indicating whether to log the return value.
 # 
 # @return If `x` is a matrix, then a matrix (S x `ncat`, with S denoting the
@@ -1983,8 +1984,10 @@ dcategorical <- function(x, eta, log = FALSE) {
 #   categories) containing the values of the inverse-link function applied to
 #   `x`. If `x` is an array, then an array (S x N x `ncat`) containing the same
 #   values as the matrix just described, but for N observations.
-inv_link_categorical <- function(x, refcat_obj = NULL, log = FALSE) {
-  if (!is.null(refcat_obj)) {
+inv_link_categorical <- function(x, refcat_obj = "first", log = FALSE) {
+  if (identical(refcat_obj, "first")) {
+    x <- insert_refcat(x, family = categorical()) # The link does not matter.
+  } else if (!is.null(refcat_obj)) {
     x <- insert_refcat(x, family = refcat_obj)
   }
   if (log) {

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1966,14 +1966,14 @@ dcategorical <- function(x, eta, log = FALSE) {
 
 # generic inverse link function for the categorical family
 # 
-# @param x Matrix (S x `ncat` or S x `ncat - 1` (depending on
-#   `refcat_obj`), with S denoting the number of posterior draws and
-#   `ncat` denoting the number of response categories) with values of `eta` for
-#   one observation (see dcategorical()) or an array (S x N x `ncat` or S x N x
-#   `ncat - 1` (depending on `refcat_obj`)) containing the same values as
-#   the matrix just described, but for N observations.
-# @param refcat_obj Either NULL or an object of class "brmsfamily". If
-#   NULL, `x` is not modified at all. If an object of class "brmsfamily", then
+# @param x Matrix (S x `ncat` or S x `ncat - 1` (depending on `refcat_obj`),
+#   with S denoting the number of posterior draws and `ncat` denoting the number
+#   of response categories) with values of `eta` for one observation (see
+#   dcategorical()) or an array (S x N x `ncat` or S x N x `ncat - 1` (depending
+#   on `refcat_obj`)) containing the same values as the matrix just described,
+#   but for N observations.
+# @param refcat_obj Either NULL or an object of class "brmsfamily". If NULL, `x`
+#   is not modified at all. If an object of class "brmsfamily", then
 #   insert_refcat() is used to insert values for the reference category into
 #   `x`.
 # @param log Logical (length 1) indicating whether to log the return value.

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -2012,7 +2012,7 @@ inv_link_categorical <- function(x, insert_refcat_fam = NULL, log = FALSE) {
 #   array (S x N x `ncat` or S x N x `ncat - 1` (depending on `return_refcat`))
 #   containing the same values as the matrix just described, but for N
 #   observations.
-link_categorical <- function(x, refcat = 1, return_refcat = TRUE) {
+link_categorical <- function(x, refcat = 1, return_refcat = FALSE) {
   ndim <- length(dim(x))
   marg_noncat <- seq_along(dim(x))[-ndim]
   if (return_refcat) {

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1967,12 +1967,12 @@ dcategorical <- function(x, eta, log = FALSE) {
 # generic inverse link function for the categorical family
 # 
 # @param x Matrix (S x `ncat` or S x `ncat - 1` (depending on
-#   `insert_refcat_fam`), with S denoting the number of posterior draws and
+#   `refcat_obj`), with S denoting the number of posterior draws and
 #   `ncat` denoting the number of response categories) with values of `eta` for
 #   one observation (see dcategorical()) or an array (S x N x `ncat` or S x N x
-#   `ncat - 1` (depending on `insert_refcat_fam`)) containing the same values as
+#   `ncat - 1` (depending on `refcat_obj`)) containing the same values as
 #   the matrix just described, but for N observations.
-# @param insert_refcat_fam Either NULL or an object of class "brmsfamily". If
+# @param refcat_obj Either NULL or an object of class "brmsfamily". If
 #   NULL, `x` is not modified at all. If an object of class "brmsfamily", then
 #   insert_refcat() is used to insert values for the reference category into
 #   `x`.
@@ -1983,9 +1983,9 @@ dcategorical <- function(x, eta, log = FALSE) {
 #   categories) containing the values of the inverse-link function applied to
 #   `x`. If `x` is an array, then an array (S x N x `ncat`) containing the same
 #   values as the matrix just described, but for N observations.
-inv_link_categorical <- function(x, insert_refcat_fam = NULL, log = FALSE) {
-  if (!is.null(insert_refcat_fam)) {
-    x <- insert_refcat(x, family = insert_refcat_fam)
+inv_link_categorical <- function(x, refcat_obj = NULL, log = FALSE) {
+  if (!is.null(refcat_obj)) {
+    x <- insert_refcat(x, family = refcat_obj)
   }
   if (log) {
     out <- log_softmax(x)

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1985,7 +1985,7 @@ dcategorical <- function(x, eta, log = FALSE) {
 #   `x`. If `x` is an array, then an array (S x N x `ncat`) containing the same
 #   values as the matrix just described, but for N observations.
 inv_link_categorical <- function(x, refcat_obj = "first", log = FALSE) {
-  if (identical(refcat_obj, "first")) {
+  if (is_equal(refcat_obj, "first")) {
     x <- insert_refcat(x, family = categorical()) # The link does not matter.
   } else if (!is.null(refcat_obj)) {
     x <- insert_refcat(x, family = refcat_obj)

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -138,25 +138,23 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
                         sample_new_levels = "gaussian"))
   }
   if (isTRUE(dots$aug_data) && is_ordinal(family$family)) {
-    stop2("This case is not yet supported.")
     # Use argument `incl_thres` of posterior_linpred():
-    # TODO: uncomment the lines below as soon as arr2augmat() is exported
-    # ref_predfun <- function(fit, newdata = NULL) {
-    #   # Setting a seed is necessary for reproducible sampling of group-level
-    #   # effects for new levels:
-    #   if (exists(".Random.seed", envir = .GlobalEnv)) {
-    #     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
-    #     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
-    #   }
-    #   set.seed(refprd_seed)
-    #   # Note: `transform = FALSE` is not needed, but included here for
-    #   # consistency with projpred's default ref_predfun():
-    #   linpred_out <- posterior_linpred(
-    #     fit, transform = FALSE, newdata = newdata, allow_new_levels = TRUE,
-    #     sample_new_levels = "gaussian", incl_thres = TRUE
-    #   )
-    #   return(linpred_out)
-    # }
+    ref_predfun <- function(fit, newdata = NULL) {
+      # Setting a seed is necessary for reproducible sampling of group-level
+      # effects for new levels:
+      if (exists(".Random.seed", envir = .GlobalEnv)) {
+        rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
+        on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+      }
+      set.seed(refprd_seed)
+      # Note: `transform = FALSE` is not needed, but included here for
+      # consistency with projpred's default ref_predfun():
+      linpred_out <- posterior_linpred(
+        fit, transform = FALSE, newdata = newdata, allow_new_levels = TRUE,
+        sample_new_levels = "gaussian", incl_thres = TRUE
+      )
+      return(linpred_out)
+    }
   }
   
   if (utils::packageVersion("projpred") <= "2.0.2" && NROW(object$ranef)) {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -188,7 +188,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     args <- c(args, list(
       augdat_link = get(paste0("link_", family$family), mode = "function"),
       augdat_ilink = get(paste0("inv_link_", family$family), mode = "function"),
-      link = family$link
+      augdat_args_link = list(link = family$link),
+      augdat_args_ilink = list(link = family$link)
     ))
   }
   do_call(projpred::init_refmodel, args)

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -139,8 +139,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   if (isTRUE(dots$aug_data) && is_ordinal(family$family)) {
     stop2("This case is not yet supported.")
-    # Use argument `incl_thres` of posterior_linpred() (and convert the
-    # 3-dimensional array to an "augmented-rows" matrix)
+    # Use argument `incl_thres` of posterior_linpred():
     # TODO: uncomment the lines below as soon as arr2augmat() is exported
     # ref_predfun <- function(fit, newdata = NULL) {
     #   # Setting a seed is necessary for reproducible sampling of group-level
@@ -156,17 +155,6 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     #     fit, transform = FALSE, newdata = newdata, allow_new_levels = TRUE,
     #     sample_new_levels = "gaussian", incl_thres = TRUE
     #   )
-    #   stopifnot(length(dim(linpred_out)) == 3L)
-    #   # Since posterior_linpred() is supposed to include the offsets in its
-    #   # result, subtract them here:
-    #   # Observation weights are not needed here, so use `wrhs = NULL` to avoid
-    #   # potential conflicts for a non-`NULL` default `wrhs`:
-    #   offs <- extract_model_data(fit, newdata = newdata, wrhs = NULL)$offset
-    #   if (length(offs)) {
-    #     stopifnot(length(offs) %in% c(1L, dim(linpred_out)[2]))
-    #     linpred_out <- sweep(linpred_out, 2, offs)
-    #   }
-    #   linpred_out <- projpred:::arr2augmat(linpred_out, margin_draws = 1)
     #   return(linpred_out)
     # }
   }

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -147,13 +147,11 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
         on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
       }
       set.seed(refprd_seed)
-      # Note: `transform = FALSE` is not needed, but included here for
-      # consistency with projpred's default ref_predfun():
-      linpred_out <- posterior_linpred(
-        fit, transform = FALSE, newdata = newdata, allow_new_levels = TRUE,
-        sample_new_levels = "gaussian", incl_thres = TRUE
-      )
-      return(linpred_out)
+      posterior_linpred(fit,
+                        newdata = newdata,
+                        allow_new_levels = TRUE,
+                        sample_new_levels = "gaussian",
+                        incl_thres = TRUE)
     }
   }
   

--- a/tests/testthat/helpers/inv_link_categorical_ch.R
+++ b/tests/testthat/helpers/inv_link_categorical_ch.R
@@ -1,5 +1,10 @@
-# Very similar to inv_link_categorical(), but iterates over the observations:
-inv_link_categorical_ch <- function(x, log = FALSE) {
+# Very similar to inv_link_categorical(), but iterates over the observations and
+# always assumes the first category to be the reference category:
+inv_link_categorical_ch <- function(x, log = FALSE, refcat_ins = TRUE) {
+  if (refcat_ins) {
+    zeros_arr <- array(0, dim = c(head(dim(x), -1), 1))
+    x <- abind::abind(zeros_arr, x)
+  }
   ndim <- length(dim(x))
   # For testing purposes, only allow 3-dimensional arrays here:
   if (ndim <= 1) {

--- a/tests/testthat/helpers/link_categorical_ch.R
+++ b/tests/testthat/helpers/link_categorical_ch.R
@@ -1,5 +1,5 @@
 # Very similar to link_categorical(), but iterates over the observations:
-link_categorical_ch <- function(x, refcat = 1, return_refcat = TRUE) {
+link_categorical_ch <- function(x, refcat = 1, return_refcat = FALSE) {
   # For testing purposes, only allow 3-dimensional arrays here:
   stopifnot(length(dim(x)) == 3)
   x_tosweep <- if (return_refcat) {

--- a/tests/testthat/tests.distributions.R
+++ b/tests/testthat/tests.distributions.R
@@ -501,7 +501,8 @@ test_that("dcategorical() works correctly", {
       }
       for (eta_test in eta_test_list) {
         d_categorical <- dcategorical(seq_len(ncat), eta_test)
-        d_categorical_ch <- inv_link_categorical_ch(eta_test)
+        d_categorical_ch <- inv_link_categorical_ch(eta_test,
+                                                    refcat_ins = FALSE)
         expect_equivalent(d_categorical, d_categorical_ch)
         expect_equal(dim(d_categorical), c(ndraws, ncat))
       }
@@ -517,8 +518,6 @@ test_that("inv_link_categorical() works correctly for arrays", {
       for (ncat in ncat_vec) {
         x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
                         dim = c(ndraws, nobsv, ncat - 1))
-        zeros_arr <- array(0, dim = c(ndraws, nobsv, 1))
-        x_test <- abind::abind(zeros_arr, x_test)
         il_categorical <- inv_link_categorical(x_test)
         il_categorical_ch <- inv_link_categorical_ch(x_test)
         expect_equivalent(il_categorical, il_categorical_ch)
@@ -567,8 +566,6 @@ test_that("link_categorical() inverts inv_link_categorical()", {
       for (ncat in ncat_vec) {
         x_test <- array(rnorm(ndraws * nobsv * (ncat - 1)),
                         dim = c(ndraws, nobsv, ncat - 1))
-        zeros_arr <- array(0, dim = c(ndraws, nobsv, 1))
-        x_test <- abind::abind(zeros_arr, x_test)
         il_categorical <- inv_link_categorical(x_test)
         l_categorical <- link_categorical(il_categorical)
         expect_equivalent(l_categorical, x_test)

--- a/tests/testthat/tests.distributions.R
+++ b/tests/testthat/tests.distributions.R
@@ -539,7 +539,7 @@ test_that("link_categorical() works correctly for arrays", {
         l_categorical <- link_categorical(x_test)
         l_categorical_ch <- link_categorical_ch(x_test)
         expect_equivalent(l_categorical, l_categorical_ch)
-        expect_equal(dim(l_categorical), c(ndraws, nobsv, ncat))
+        expect_equal(dim(l_categorical), c(ndraws, nobsv, ncat - 1))
       }
     }
   }


### PR DESCRIPTION
This PR should perform the final changes which are necessary to support the augmented-data projection in projpred. Note that I partly reverted some of my changes in `get_refmodel.brmsfit()` introduced earlier (by PR #1159). The reason is that I found a more elegant way of handling the preparations for the augmented-data projection, namely by using a wrapper function for the user-specified `ref_predfun` within **projpred**. (Btw, this wrapper also handles the subtraction of the offsets, which is why we didn't have to subtract offsets in the brms-specific `ref_predfun` in PR #1287.) Sorry for the changes in `get_refmodel.brmsfit()` introduced earlier which are now partly reverted. But I think the new handling is much better, especially because it requires much less changes to **brms** and because it avoids exporting **projpred** functions which would only be needed by **brms**.

The development version of **projpred** currently does not support the augmented-data projection yet. If you try to create a reference model with the `categorical()` or an ordinal family such as `cumulative()` (in order to perform an augmented-data projection), **projpred** will throw an appropriate error (not only the development version, but also **projpred**'s CRAN version). That's also why I did not create a `NEWS` entry here in this PR.

I noticed that `get_refmodel.brmsfit()` has argument `newdata`. Currently, I can't think of a situation where this would be necessary, but I left it in case there is indeed a reasonable use case. However, if there are no use cases, this argument might confuse users, so then it might be worth removing it.

I noticed that you recently replaced `ilink` by `inv_link` (in all of the code, it seems). Some time ago, I decided to use the suffix `ilink` in projpred, so with this PR, you get a new occurrence of `ilink` which, however, should not be replaced by `inv_link` (otherwise, we would have to change **projpred** code).