### PR TITLE
Canonicalize model code for CmdStan >= 2.29.0

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -25,7 +25,7 @@ parse_model <- function(model, backend, ...) {
   require_package("cmdstanr")
   temp_file <- cmdstanr::write_stan_file(model)
   if (cmdstanr::cmdstan_version() >= "2.29.0") {
-    .canonicalize_stan_model(temp_file, overwrite_file = FALSE)
+    .canonicalize_stan_model(temp_file, overwrite_file = TRUE)
   }
   out <- eval_silent(
     cmdstanr::cmdstan_model(temp_file, compile = FALSE, ...),
@@ -98,7 +98,7 @@ compile_model <- function(model, backend, ...) {
   args <- list(...)
   args$stan_file <- cmdstanr::write_stan_file(model)
   if (cmdstanr::cmdstan_version() >= "2.29.0") {
-    .canonicalize_stan_model(args$stan_file, overwrite_file = FALSE)
+    .canonicalize_stan_model(args$stan_file, overwrite_file = TRUE)
   }
   if (use_threading(threads)) {
     args$cpp_options$stan_threads <- TRUE

--- a/R/backends.R
+++ b/R/backends.R
@@ -24,6 +24,9 @@ parse_model <- function(model, backend, ...) {
 .parse_model_cmdstanr <- function(model, silent = 1, ...) {
   require_package("cmdstanr")
   temp_file <- cmdstanr::write_stan_file(model)
+  if (cmdstanr::cmdstan_version() >= "2.29.0") {
+    .canonicalize_stan_model(temp_file, overwrite_file = FALSE)
+  }
   out <- eval_silent(
     cmdstanr::cmdstan_model(temp_file, compile = FALSE, ...),
     type = "message", try = TRUE, silent = silent
@@ -94,6 +97,9 @@ compile_model <- function(model, backend, ...) {
   require_package("cmdstanr")
   args <- list(...)
   args$stan_file <- cmdstanr::write_stan_file(model)
+  if (cmdstanr::cmdstan_version() >= "2.29.0") {
+    .canonicalize_stan_model(args$stan_file, overwrite_file = FALSE)
+  }
   if (use_threading(threads)) {
     args$cpp_options$stan_threads <- TRUE
   }
@@ -609,4 +615,34 @@ repair_stanfit_names <- function(x) {
 # possible options for argument 'file_refit'
 file_refit_options <- function() {
   c("never", "always", "on_change")
+}
+
+.canonicalize_stan_model <- function(stan_file, overwrite_file = TRUE) {
+  if (os_is_windows()) {
+    stanc_cmd <- "bin/stanc.exe"
+  } else {
+    stanc_cmd <- "bin/stanc"
+  }
+  stanc_flags <- c(
+    "--auto-format",
+    "--canonicalize=deprecations,braces,parentheses" 
+  )
+  if (cmdstanr::cmdstan_version() >= "2.29.0") {
+    res <- processx::run(
+      command = stanc_cmd,
+      args = c(stan_file, stanc_flags),
+      wd = cmdstanr::cmdstan_path(),
+      echo = FALSE,
+      echo_cmd = FALSE,
+      spinner = FALSE,
+      stderr_callback = function(x, p) {
+        message(x)
+      },
+      error_on_status = TRUE
+    )
+    if (overwrite_file) {
+      cat(res$stdout, file = stan_file, sep = "\n")
+    }    
+  }
+  res$stdout
 }

--- a/R/make_stancode.R
+++ b/R/make_stancode.R
@@ -307,6 +307,12 @@ make_stancode <- function(formula, data, family = gaussian(),
   if (parse) {
     scode <- parse_model(scode, backend, silent = silent)
   }
+  if (backend == "cmdstanr") {
+    if (cmdstanr::cmdstan_version() >= "2.29.0") {
+      tmp_file <- cmdstanr::write_stan_file(scode)
+      scode <- .canonicalize_stan_model(tmp_file, overwrite_file = FALSE)
+    }
+  }
   if (is.character(save_model)) {
     cat(scode, file = save_model)
   }

--- a/tests/testthat/tests.make_stancode.R
+++ b/tests/testthat/tests.make_stancode.R
@@ -10,9 +10,9 @@ not_cran <- identical(Sys.getenv("NOT_CRAN"), "true")
 options(brms.parse_stancode = not_cran, brms.backend = "rstan")
 
 test_that("specified priors appear in the Stan code", {
-  dat <- data.frame(y = 1:10, x1 = rnorm(10), x2 = rnorm(10), 
+  dat <- data.frame(y = 1:10, x1 = rnorm(10), x2 = rnorm(10),
                     g = rep(1:5, 2), h = factor(rep(1:5, each = 2)))
-  
+
   prior <- c(prior(std_normal(), coef = x1),
              prior(normal(0,2), coef = x2),
              prior(normal(0,5), Intercept),
@@ -36,13 +36,13 @@ test_that("specified priors appear in the Stan code", {
   expect_match2(scode, "while (prior_sd_1__1 < 0)")
   expect_match2(scode, "prior_sd_2 = gamma_rng(1,1)")
   expect_match2(scode, "while (prior_sd_2 < 0)")
-  
+
   prior <- c(prior(lkj(0.5), class = cor, group = g),
              prior(normal(0, 1), class = b),
              prior(normal(0, 5), class = Intercept),
              prior(cauchy(0, 5), class = sd))
-  scode <- make_stancode(y ~ x1 + cs(x2) + (0 + x1 + x2 | g), 
-                         data = dat, family = acat(), 
+  scode <- make_stancode(y ~ x1 + cs(x2) + (0 + x1 + x2 | g),
+                         data = dat, family = acat(),
                          prior = prior, sample_prior = TRUE)
   expect_match2(scode, "lprior += normal_lpdf(b | 0, 1)")
   expect_match2(scode, "lprior += normal_lpdf(Intercept | 0, 5)")
@@ -50,7 +50,7 @@ test_that("specified priors appear in the Stan code", {
   expect_match2(scode, "lprior += lkj_corr_cholesky_lpdf(L_1 | 0.5)")
   expect_match2(scode, "lprior += normal_lpdf(to_vector(bcs) | 0, 1)")
   expect_match2(scode, "prior_bcs = normal_rng(0,1)")
-  
+
   prior <- c(prior(normal(0,5), nlpar = a),
              prior(normal(0,10), nlpar = b),
              prior(cauchy(0,1), class = sd, nlpar = a),
@@ -66,17 +66,17 @@ test_that("specified priors appear in the Stan code", {
   expect_match2(scode, "prior_b_a = normal_rng(0,5)")
   expect_match2(scode, "prior_sd_1__2 = student_t_rng(3,0,3.7)")
   expect_match2(scode, "prior_cor_1 = lkj_corr_rng(M_1,2)[1, 2]")
-  
+
   prior <- c(prior(lkj(2), rescor),
              prior(cauchy(0, 5), sigma, resp = y),
              prior(cauchy(0, 1), sigma, resp = x1))
   form <- bf(mvbind(y, x1) ~ x2) + set_rescor(TRUE)
-  scode <- make_stancode(form, dat, prior = prior, 
+  scode <- make_stancode(form, dat, prior = prior,
                          sample_prior = TRUE)
   expect_match2(scode, "lprior += lkj_corr_cholesky_lpdf(Lrescor | 2)")
   expect_match2(scode, "prior_sigma_y = cauchy_rng(0,5)")
   expect_match2(scode, "prior_rescor = lkj_corr_rng(nresp,2)[1, 2]")
-  
+
   prior <- c(prior(uniform(-1, 1), ar),
              prior(normal(0, 0.5), ma),
              prior(normal(0, 5)))
@@ -86,7 +86,7 @@ test_that("specified priors appear in the Stan code", {
   expect_match2(scode, "vector<lower=-1,upper=1>[Kma] ma;")
   expect_match2(scode, "lprior += uniform_lpdf(ar | -1, 1)")
   expect_match2(scode, "lprior += normal_lpdf(ma | 0, 0.5)")
-  expect_match2(scode, 
+  expect_match2(scode,
     "- 1 * log_diff_exp(normal_lcdf(1 | 0, 0.5), normal_lcdf(-1 | 0, 0.5))"
   )
   expect_match2(scode, "lprior += normal_lpdf(bsp | 0, 5)")
@@ -94,20 +94,20 @@ test_that("specified priors appear in the Stan code", {
   expect_match2(scode, "prior_simo_1 = dirichlet_rng(con_simo_1)")
   expect_match2(scode, "prior_ar = uniform_rng(-1,1)")
   expect_match2(scode, "while (prior_ar < -1 || prior_ar > 1)")
-  
+
   # test for problem described in #213
   prior <- c(prior(normal(0, 1), coef = x1),
              prior(normal(0, 2), coef = x1, dpar = sigma))
   scode <- make_stancode(bf(y ~ x1, sigma ~ x1), dat, prior = prior)
   expect_match2(scode, "lprior += normal_lpdf(b[1] | 0, 1);")
   expect_match2(scode, "lprior += normal_lpdf(b_sigma[1] | 0, 2);")
-  
+
   prior <- c(set_prior("target += normal_lpdf(b[1] | 0, 1)", check = FALSE),
              set_prior("", class = "sigma"))
   scode <- make_stancode(y ~ x1, dat, prior = prior, sample_prior = TRUE)
   expect_match2(scode, "target += normal_lpdf(b[1] | 0, 1)")
   expect_true(!grepl("sigma \\|", scode))
-  
+
   prior <- prior(gamma(0, 1), coef = x1)
   expect_warning(make_stancode(y ~ x1, dat, prior = prior),
                  "no natural lower bound")
@@ -123,34 +123,34 @@ test_that("specified priors appear in the Stan code", {
 
 test_that("special shrinkage priors appear in the Stan code", {
   dat <- data.frame(y = 1:10, x1 = rnorm(10), x2 = rnorm(10))
-  
+
   # horseshoe prior
   hs <- horseshoe(7, scale_global = 2, df_global = 3,
                   df_slab = 6, scale_slab = 3)
-  scode <- make_stancode(y ~ x1*x2, data = dat, 
+  scode <- make_stancode(y ~ x1*x2, data = dat,
                          prior = set_prior(hs),
                          sample_prior = TRUE)
-  expect_match2(scode, "vector<lower=0>[Kc] hs_local;") 
-  expect_match2(scode, "real<lower=0> hs_global;") 
-  expect_match2(scode, 
+  expect_match2(scode, "vector<lower=0>[Kc] hs_local;")
+  expect_match2(scode, "real<lower=0> hs_global;")
+  expect_match2(scode,
     "target += student_t_lpdf(hs_local | hs_df, 0, 1)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "lprior += student_t_lpdf(hs_global | hs_df_global, 0, hs_scale_global * sigma)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "lprior += inv_gamma_lpdf(hs_slab | 0.5 * hs_df_slab, 0.5 * hs_df_slab)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "b = horseshoe(zb, hs_local, hs_global, hs_scale_slab^2 * hs_slab);"
   )
-  
+
   scode <- make_stancode(y ~ x1*x2, data = dat, poisson(),
                          prior = prior(horseshoe(scale_global = 3)))
-  expect_match2(scode, 
+  expect_match2(scode,
     "b = horseshoe(zb, hs_local, hs_global, hs_scale_slab^2 * hs_slab);"
   )
-  
+
   scode <- make_stancode(x1 ~ mo(y), dat, prior = prior(horseshoe()))
   expect_match2(scode, "target += std_normal_lpdf(zbsp);")
   expect_match2(scode,
@@ -161,8 +161,8 @@ test_that("special shrinkage priors appear in the Stan code", {
       "bsp = horseshoe(zbsp, hs_localsp, hs_global, hs_scale_slab^2 * hs_slab);"
     )
   )
-  
-  # R2D2 prior 
+
+  # R2D2 prior
   scode <- make_stancode(y ~ x1*x2, data = dat,
                          prior = prior(R2D2(0.5, 10)),
                          sample_prior = TRUE)
@@ -170,21 +170,21 @@ test_that("special shrinkage priors appear in the Stan code", {
   expect_match2(scode, "target += dirichlet_lpdf(R2D2_phi | R2D2_cons_D2);")
   expect_match2(scode, "lprior += beta_lpdf(R2D2_R2 | R2D2_mean_R2 * R2D2_prec_R2, (1 - R2D2_mean_R2) * R2D2_prec_R2);")
   expect_match2(scode, "R2D2_tau2 = sigma^2 * R2D2_R2 / (1 - R2D2_R2);")
-  
+
   # lasso prior
   scode <- make_stancode(y ~ x1*x2, data = dat,
                          prior = prior(lasso(2, scale = 10)),
                          sample_prior = TRUE)
   expect_match2(scode, "lprior += chi_square_lpdf(lasso_inv_lambda | lasso_df);")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += double_exponential_lpdf(b | 0, lasso_scale * lasso_inv_lambda);"
   )
-  
+
   scode <- make_stancode(x1 ~ mo(y), dat, prior = prior(lasso()))
-  expect_match2(scode, 
+  expect_match2(scode,
     "double_exponential_lpdf(bsp | 0, lasso_scale * lasso_inv_lambda)"
   )
-  
+
   # horseshoe and lasso prior applied in a non-linear model
   hs_a1 <- horseshoe(7, scale_global = 2, df_global = 3)
   lasso_a2 <- lasso(2, scale = 10)
@@ -196,33 +196,33 @@ test_that("special shrinkage priors appear in the Stan code", {
               set_prior(lasso_a2, nlpar = "a2"),
               set_prior(R2D2_a3, nlpar = "a3"))
   )
-  expect_match2(scode, "vector<lower=0>[K_a1] hs_local_a1;") 
-  expect_match2(scode, "real<lower=0> hs_global_a1;") 
-  expect_match2(scode, 
+  expect_match2(scode, "vector<lower=0>[K_a1] hs_local_a1;")
+  expect_match2(scode, "real<lower=0> hs_global_a1;")
+  expect_match2(scode,
     "target += student_t_lpdf(hs_local_a1 | hs_df_a1, 0, 1)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "lprior += student_t_lpdf(hs_global_a1 | hs_df_global_a1, 0, hs_scale_global_a1 * sigma)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "lprior += inv_gamma_lpdf(hs_slab_a1 | 0.5 * hs_df_slab_a1, 0.5 * hs_df_slab_a1)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "b_a1 = horseshoe(zb_a1, hs_local_a1, hs_global_a1, hs_scale_slab_a1^2 * hs_slab_a1);"
   )
   expect_match2(scode,
     "lprior += chi_square_lpdf(lasso_inv_lambda_a2 | lasso_df_a2);"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += double_exponential_lpdf(b_a2 | 0, lasso_scale_a2 * lasso_inv_lambda_a2);"
   )
   expect_match2(scode, "b_a3 = R2D2(zb_a3, R2D2_phi_a3, R2D2_tau2_a3);")
-  
+
   # check error messages
-  expect_error(make_stancode(y ~ x1*x2, data = dat, 
+  expect_error(make_stancode(y ~ x1*x2, data = dat,
                              prior = prior(horseshoe(-1))),
                "Degrees of freedom of the local priors")
-  expect_error(make_stancode(y ~ x1*x2, data = dat, 
+  expect_error(make_stancode(y ~ x1*x2, data = dat,
                              prior = prior(horseshoe(1, -1))),
                "Scale of the global prior")
   expect_error(make_stancode(y ~ x1*x2, data = dat, prior = prior(lasso(-1))),
@@ -237,15 +237,15 @@ test_that("special shrinkage priors appear in the Stan code", {
 })
 
 test_that("priors can be fixed to constants", {
-  dat <- data.frame(y = 1:12, x1 = rnorm(12), x2 = rnorm(12), 
+  dat <- data.frame(y = 1:12, x1 = rnorm(12), x2 = rnorm(12),
                     g = rep(1:6, each = 2), h = factor(rep(1:2, each = 6)))
-  
+
   prior <- prior(normal(0, 1), b) +
     prior(constant(3), b, coef = x1) +
     prior(constant(-1), b, coef = x2) +
-    prior(constant(10), Intercept) + 
+    prior(constant(10), Intercept) +
     prior(normal(0, 5), sd) +
-    prior(constant(1), sd, group = g, coef = x2) + 
+    prior(constant(1), sd, group = g, coef = x2) +
     prior(constant(2), sd, group = g, coef = x1) +
     prior(constant(0.3), sigma)
   scode <- make_stancode(y ~ x1*x2 + (x1*x2 | g), dat, prior = prior)
@@ -259,13 +259,13 @@ test_that("priors can be fixed to constants", {
   expect_match2(scode, "sd_1[4] = par_sd_1_4;")
   expect_match2(scode, "lprior += normal_lpdf(sd_1[4] | 0, 5)")
   expect_match2(scode, "sigma = 0.3;")
-  
+
   prior <- prior(constant(3))
   scode <- make_stancode(y ~ x2 + x1 + cs(g), dat, family = sratio(),
                          prior = prior)
   expect_match2(scode, "b = rep_vector(3, rows(b));")
   expect_match2(scode, "bcs = rep_matrix(3, rows(bcs), cols(bcs));")
-  
+
   prior <- prior(normal(0, 3)) +
     prior(constant(3), coef = x1) +
     prior(constant(-1), coef = g)
@@ -275,28 +275,28 @@ test_that("priors can be fixed to constants", {
   expect_match2(scode, "bcs[1] = par_bcs_1;")
   expect_match2(scode, "lprior += normal_lpdf(bcs[1] | 0, 3);")
   expect_match2(scode, "bcs[2] = rep_row_vector(-1, cols(bcs[2]));")
-  
+
   prior <- prior(constant(3), class = "sd", group = "g") +
     prior("constant([[1, 0], [0, 1]])", class = "cor")
   scode <- make_stancode(y ~ x1 + (x1 | gr(g, by = h)), dat, prior = prior)
   expect_match2(scode, "sd_1 = rep_matrix(3, rows(sd_1), cols(sd_1));")
   expect_match2(scode, "L_1[2] = [[1, 0], [0, 1]];")
-  
+
   prior <- prior(constant(0.5), class = lscale, coef = gpx1h1) +
     prior(normal(0, 10), class = lscale, coef = gpx1h2)
   scode <- make_stancode(y ~ gp(x1, by = h), dat, prior = prior)
   expect_match2(scode, "lscale_1[1][1] = 0.5;")
   expect_match2(scode, "lscale_1[2][1] = par_lscale_1_2_1;")
   expect_match2(scode, "lprior += normal_lpdf(lscale_1[2][1] | 0, 10)")
-  
+
   # test that improper base priors are correctly recognized (#919)
   prior <- prior(constant(-1), b, coef = x2)
   scode <- make_stancode(y ~ x1*x2, dat, prior = prior)
   expect_match2(scode, "real par_b_1;")
   expect_match2(scode, "b[3] = par_b_3;")
-  
+
   # test error messages
-  prior <- prior(normal(0, 1), Intercept) + 
+  prior <- prior(normal(0, 1), Intercept) +
     prior(constant(3), Intercept, coef = 2)
   expect_error(
     make_stancode(y ~ x1, data = dat, family = cumulative(), prior = prior),
@@ -306,12 +306,12 @@ test_that("priors can be fixed to constants", {
 
 test_that("link functions appear in the Stan code", {
   dat <- data.frame(y = 1:10, x = rnorm(10))
-  expect_match2(make_stancode(y ~ s(x), dat, family = poisson()), 
+  expect_match2(make_stancode(y ~ s(x), dat, family = poisson()),
                "target += poisson_log_lpmf(Y | mu);")
-  expect_match2(make_stancode(mvbind(y, y + 1) ~ x, dat, 
-                              family = skew_normal("log")), 
+  expect_match2(make_stancode(mvbind(y, y + 1) ~ x, dat,
+                              family = skew_normal("log")),
                "mu_y[n] = exp(mu_y[n]);")
-  expect_match2(make_stancode(y ~ x, dat, family = von_mises(tan_half)), 
+  expect_match2(make_stancode(y ~ x, dat, family = von_mises(tan_half)),
                "mu[n] = inv_tan_half(mu[n]);")
   expect_match2(make_stancode(y ~ x, dat, family = weibull()),
                 "mu[n] = exp(mu[n]) / tgamma(1 + 1 / shape);")
@@ -325,35 +325,35 @@ test_that("link functions appear in the Stan code", {
 
 test_that("Stan GLM primitives are applied correctly", {
   dat <- data.frame(x = rnorm(10), y = 1:10)
-  
+
   scode <- make_stancode(y ~ x, dat, family = gaussian)
   expect_match2(scode, "normal_id_glm_lpdf(Y | Xc, Intercept, b, sigma)")
-  
+
   scode <- make_stancode(y ~ x, dat, family = bernoulli)
   expect_match2(scode, "bernoulli_logit_glm_lpmf(Y | Xc, Intercept, b)")
-  
+
   scode <- make_stancode(y ~ x, dat, family = poisson)
   expect_match2(scode, "poisson_log_glm_lpmf(Y | Xc, Intercept, b)")
-  
+
   scode <- make_stancode(y ~ x, dat, family = negbinomial)
-  expect_match2(scode, 
+  expect_match2(scode,
     "neg_binomial_2_log_glm_lpmf(Y | Xc, Intercept, b, shape)"
   )
-  
+
   scode <- make_stancode(y ~ x, dat, family = brmsfamily("negbinomial2"))
-  expect_match2(scode, 
+  expect_match2(scode,
     "neg_binomial_2_log_glm_lpmf(Y | Xc, Intercept, b, inv(sigma))"
   )
-  
+
   scode <- make_stancode(y ~ 0 + x, dat, family = gaussian)
   expect_match2(scode, "normal_id_glm_lpdf(Y | X, 0, b, sigma)")
-  
+
   bform <- bf(y ~ x) + bf(x ~ 1, family = negbinomial()) + set_rescor(FALSE)
   scode <- make_stancode(bform, dat, family = gaussian)
-  expect_match2(scode, 
+  expect_match2(scode,
     "normal_id_glm_lpdf(Y_y | Xc_y, Intercept_y, b_y, sigma_y)"
   )
-  
+
   scode <- make_stancode(bf(y ~ x, decomp = "QR"), dat, family = gaussian)
   expect_match2(scode, "normal_id_glm_lpdf(Y | XQ, Intercept, bQ, sigma);")
 })
@@ -362,28 +362,28 @@ test_that("customized covariances appear in the Stan code", {
   M <- diag(1, nrow = length(unique(inhaler$subject)))
   rownames(M) <- unique(inhaler$subject)
   dat2 <- list(M = M)
-  
-  scode <- make_stancode(rating ~ treat + (1 | gr(subject, cov = M)), 
+
+  scode <- make_stancode(rating ~ treat + (1 | gr(subject, cov = M)),
                          data = inhaler, data2 = dat2)
   expect_match2(scode, "r_1_1 = (sd_1[1] * (Lcov_1 * z_1[1]))")
-  
-  scode <- make_stancode(rating ~ treat + (1 + treat | gr(subject, cov = M)), 
+
+  scode <- make_stancode(rating ~ treat + (1 + treat | gr(subject, cov = M)),
                          data = inhaler, data2 = dat2)
   expect_match2(scode, "r_1 = scale_r_cor_cov(z_1, sd_1, L_1, Lcov_1);")
   expect_match2(scode, "cor_1[choose(k - 1, 2) + j] = Cor_1[j, k];")
-  
-  scode <- make_stancode(rating ~ (1 + treat | gr(subject, cor = FALSE, cov = M)), 
+
+  scode <- make_stancode(rating ~ (1 + treat | gr(subject, cor = FALSE, cov = M)),
                          data = inhaler, data2 = dat2)
   expect_match2(scode, "r_1_1 = (sd_1[1] * (Lcov_1 * z_1[1]));")
   expect_match2(scode, "r_1_2 = (sd_1[2] * (Lcov_1 * z_1[2]));")
-  
+
   inhaler$by <- inhaler$subject %% 2
-  scode <- make_stancode(rating ~ (1 + treat | gr(subject, by = by, cov = M)), 
+  scode <- make_stancode(rating ~ (1 + treat | gr(subject, by = by, cov = M)),
                          data = inhaler, data2 = dat2)
   expect_match2(scode, "r_1 = scale_r_cor_by_cov(z_1, sd_1, L_1, Jby_1, Lcov_1);")
-  
+
   expect_warning(
-    scode <- make_stancode(rating ~ treat + period + carry + (1|subject), 
+    scode <- make_stancode(rating ~ treat + period + carry + (1|subject),
                            data = inhaler, cov_ranef = list(subject = 1)),
     "Argument 'cov_ranef' is deprecated"
   )
@@ -395,39 +395,39 @@ test_that("truncation appears in the Stan code", {
                          data = kidney, family = "gamma")
   expect_match2(scode, "target += gamma_lpdf(Y[n] | shape, mu[n]) -")
   expect_match2(scode, "gamma_lccdf(lb[n] | shape, mu[n]);")
-  
-  scode <- make_stancode(time | trunc(ub = 100) ~ age + sex + disease, 
+
+  scode <- make_stancode(time | trunc(ub = 100) ~ age + sex + disease,
                          data = kidney, family = student("log"))
-  
+
   expect_match2(scode, "target += student_t_lpdf(Y[n] | nu, mu[n], sigma) -")
   expect_match2(scode, "student_t_lcdf(ub[n] | nu, mu[n], sigma);")
-  
-  scode <- make_stancode(count | trunc(0, 150) ~ Trt, 
+
+  scode <- make_stancode(count | trunc(0, 150) ~ Trt,
                          data = epilepsy, family = "poisson")
   expect_match2(scode, "target += poisson_lpmf(Y[n] | mu[n]) -")
-  expect_match2(scode, 
+  expect_match2(scode,
     "log_diff_exp(poisson_lcdf(ub[n] | mu[n]), poisson_lcdf(lb[n] - 1 | mu[n]));"
   )
 })
 
 test_that("make_stancode handles models without fixed effects", {
-  expect_match2(make_stancode(count ~ 0 + (1|patient) + (1+Trt|visit), 
-                             data = epilepsy, family = "poisson"), 
+  expect_match2(make_stancode(count ~ 0 + (1|patient) + (1+Trt|visit),
+                             data = epilepsy, family = "poisson"),
                "mu = rep_vector(0.0, N);")
 })
 
 test_that("make_stancode correctly restricts FE parameters", {
   data <- data.frame(y = rep(0:1, each = 5), x = rnorm(10))
-  
+
   scode <- make_stancode(y ~ x, data, prior = set_prior("", lb = 2))
   expect_match2(scode, "vector<lower=2>[Kc] b")
-  
+
   scode <- make_stancode(
     y ~ x, data, prior = set_prior("normal (0, 2)", ub = "4")
   )
   expect_match2(scode, "vector<upper=4>[Kc] b")
   expect_match2(scode, "- 1 * normal_lcdf(4 | 0, 2)")
-  
+
   prior <- set_prior("normal(0,5)", lb = "-3", ub = 5)
   scode <- make_stancode(y ~ 0 + x, data, prior = prior)
   expect_match2(scode, "vector<lower=-3,upper=5>[K] b")
@@ -438,27 +438,27 @@ test_that("self-defined functions appear in the Stan code", {
   scode <- make_stancode(rating ~ treat, data = inhaler,
                          family = bernoulli("cauchit"))
   expect_match2(scode, "real inv_cauchit(real y)")
-  
+
   # softplus link
   scode <- make_stancode(rating ~ treat, data = inhaler,
                          family = brmsfamily("poisson", "softplus"))
   expect_match2(scode, "real log_expm1(real x)")
-  
+
   # squareplus link
   scode <- make_stancode(rating ~ treat, data = inhaler,
                          family = brmsfamily("poisson", "squareplus"))
   expect_match2(scode, "real squareplus(real x)")
-  
+
   # tan_half link
   expect_match2(make_stancode(rating ~ treat, data = inhaler,
                               family = von_mises("tan_half")),
                "real inv_tan_half(real y)")
-  
+
   # logm1 link
   expect_match2(make_stancode(rating ~ treat, data = inhaler,
                               family = frechet()),
                 "real expp1(real y)")
-  
+
   # inverse gaussian models
   scode <- make_stancode(time | cens(censored) ~ age, data = kidney,
                                  family = inverse.gaussian)
@@ -466,41 +466,41 @@ test_that("self-defined functions appear in the Stan code", {
   expect_match2(scode, "real inv_gaussian_lcdf(real y")
   expect_match2(scode, "real inv_gaussian_lccdf(real y")
   expect_match2(scode, "real inv_gaussian_vector_lpdf(vector y")
-  
+
   # von Mises models
   scode <- make_stancode(time ~ age, data = kidney, family = von_mises)
   expect_match2(scode, "real von_mises_real_lpdf(real y")
   expect_match2(scode, "real von_mises_vector_lpdf(vector y")
-  
+
   # zero-inflated and hurdle models
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                               family = "zero_inflated_poisson"),
                "real zero_inflated_poisson_lpmf(int y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                              family = "zero_inflated_negbinomial"),
                "real zero_inflated_neg_binomial_lpmf(int y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                               family = "zero_inflated_binomial"),
                "real zero_inflated_binomial_lpmf(int y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                              family = "zero_inflated_beta"),
                "real zero_inflated_beta_lpdf(real y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                               family = "zero_one_inflated_beta"),
                 "real zero_one_inflated_beta_lpdf(real y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                              family = hurdle_poisson()),
                "real hurdle_poisson_lpmf(int y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                              family = hurdle_negbinomial),
                "real hurdle_neg_binomial_lpmf(int y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                              family = hurdle_gamma("log")),
                "real hurdle_gamma_lpdf(real y")
-  expect_match2(make_stancode(count ~ Trt, data = epilepsy, 
+  expect_match2(make_stancode(count ~ Trt, data = epilepsy,
                              family = hurdle_lognormal("identity")),
                "real hurdle_lognormal_lpdf(real y")
-  
+
   # linear models with special covariance structures
   expect_match2(
     make_stancode(rating ~ treat + ar(cov = TRUE), data = inhaler),
@@ -511,7 +511,7 @@ test_that("self-defined functions appear in the Stan code", {
                   family = "student"),
     "real student_t_time_hom_lpdf(vector y"
   )
-  
+
   # ARMA covariance matrices
   expect_match2(
     make_stancode(rating ~ treat + ar(cov = TRUE), data = inhaler),
@@ -528,7 +528,7 @@ test_that("self-defined functions appear in the Stan code", {
 })
 
 test_that("invalid combinations of modeling options are detected", {
-  data <- data.frame(y1 = rnorm(10), y2 = rnorm(10), 
+  data <- data.frame(y1 = rnorm(10), y2 = rnorm(10),
                      wi = 1:10, ci = sample(-1:1, 10, TRUE))
   expect_error(
     make_stancode(y1 | cens(ci) ~ y2 + ar(cov = TRUE), data = data),
@@ -547,13 +547,13 @@ test_that("invalid combinations of modeling options are detected", {
 
 test_that("Stan code for multivariate models is correct", {
   dat <- data.frame(
-    y1 = rnorm(10), y2 = rnorm(10), 
+    y1 = rnorm(10), y2 = rnorm(10),
     x = 1:10, g = rep(1:2, each = 5),
     censi = sample(0:1, 10, TRUE)
   )
   # models with residual correlations
   form <- bf(mvbind(y1, y2) ~ x) + set_rescor(TRUE)
-  prior <- prior(horseshoe(2), resp = "y1") + 
+  prior <- prior(horseshoe(2), resp = "y1") +
     prior(horseshoe(2), resp = "y2")
   scode <- make_stancode(form, dat, prior = prior)
   expect_match2(scode, "target += multi_normal_cholesky_lpdf(Y | Mu, LSigma);")
@@ -561,30 +561,30 @@ test_that("Stan code for multivariate models is correct", {
   expect_match2(scode, "target += student_t_lpdf(hs_local_y1 | hs_df_y1, 0, 1)")
   expect_match2(scode, "target += student_t_lpdf(hs_local_y2 | hs_df_y2, 0, 1)")
   expect_match2(scode, "rescor[choose(k - 1, 2) + j] = Rescor[j, k];")
-  
+
   form <- bf(mvbind(y1, y2) ~ x) + set_rescor(TRUE)
-  prior <- prior(lasso(2, 10), resp = "y1") + 
+  prior <- prior(lasso(2, 10), resp = "y1") +
     prior(lasso(2, 10), resp = "y2")
   scode <- make_stancode(form, dat, student(), prior = prior)
   expect_match2(scode, "target += multi_student_t_lpdf(Y | nu, Mu, Sigma);")
   expect_match2(scode, "matrix[nresp, nresp] Sigma = multiply_lower")
   expect_match2(scode, "lprior += gamma_lpdf(nu | 2, 0.1)")
-  expect_match2(scode, 
+  expect_match2(scode,
     "lprior += chi_square_lpdf(lasso_inv_lambda_y1 | lasso_df_y1)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "lprior += chi_square_lpdf(lasso_inv_lambda_y2 | lasso_df_y2)"
   )
-  
+
   form <- bf(mvbind(y1, y2) |  weights(x) ~ 1) + set_rescor(TRUE)
   scode <- make_stancode(form, dat)
   expect_match2(scode,
     "target += weights[n] * (multi_normal_cholesky_lpdf(Y[n] | Mu[n], LSigma));"
   )
-  
+
   # models without residual correlations
   expect_warning(
-    bform <- bf(y1 | cens(censi) ~ x + y2 + (x|2|g)) + 
+    bform <- bf(y1 | cens(censi) ~ x + y2 + (x|2|g)) +
       gaussian() + cor_ar() +
       (bf(x ~ 1) + mixture(poisson, nmix = 2)) +
       (bf(y2 ~ s(y2) + (1|2|g)) + skew_normal()),
@@ -600,13 +600,13 @@ test_that("Stan code for multivariate models is correct", {
   expect_match2(scode, "ps[1] = log(theta1_x) + poisson_log_lpmf(Y_x[n] | mu1_x[n])")
   expect_match2(scode, "lprior += normal_lpdf(b_y1 | 0, 5)")
   expect_match2(scode, "lprior += normal_lpdf(bs_y2 | 0, 10)")
-  
+
   # multivariate binomial models
   bform <- bf(x ~ 1) + bf(g ~ 1) + binomial()
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "binomial_logit_lpmf(Y_x | trials_x, mu_x)")
   expect_match2(scode, "binomial_logit_lpmf(Y_g | trials_g, mu_g)")
-  
+
   bform <- bform + weibull()
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "mu_g[n] = exp(mu_g[n]) / tgamma(1 + 1 / shape_g)")
@@ -618,8 +618,8 @@ test_that("Stan code for categorical models is correct", {
     prior(normal(0, 10), "b", dpar = mu2) +
     prior(cauchy(0, 1), "Intercept", dpar = mu2) +
     prior(normal(0, 2), "Intercept", dpar = mu3)
-  
-  scode <- make_stancode(y ~ x + (1 | gr(.g, id = "ID")), data = dat, 
+
+  scode <- make_stancode(y ~ x + (1 | gr(.g, id = "ID")), data = dat,
                          family = categorical(), prior = prior)
   expect_match2(scode, "target += categorical_logit_lpmf(Y[n] | mu[n]);")
   expect_match2(scode, "mu[n] = transpose([0, mu2[n], mu3[n], muab[n]]);")
@@ -630,8 +630,8 @@ test_that("Stan code for categorical models is correct", {
   expect_match2(scode, "lprior += cauchy_lpdf(Intercept_mu2 | 0, 1);")
   expect_match2(scode, "lprior += normal_lpdf(Intercept_mu3 | 0, 2);")
   expect_match2(scode, "r_1 = scale_r_cor(z_1, sd_1, L_1);")
-  
-  scode <- make_stancode(y ~ x + (1 |ID| .g), data = dat, 
+
+  scode <- make_stancode(y ~ x + (1 |ID| .g), data = dat,
                          family = categorical(refcat = NA))
   expect_match2(scode, "mu[n] = transpose([mu1[n], mu2[n], mu3[n], muab[n]]);")
 })
@@ -639,7 +639,7 @@ test_that("Stan code for categorical models is correct", {
 test_that("Stan code for multinomial models is correct", {
   N <- 15
   dat <- data.frame(
-    y1 = rbinom(N, 10, 0.3), y2 = rbinom(N, 10, 0.5), 
+    y1 = rbinom(N, 10, 0.3), y2 = rbinom(N, 10, 0.5),
     y3 = rbinom(N, 10, 0.7), x = rnorm(N)
   )
   dat$size <- with(dat, y1 + y2 + y3)
@@ -647,7 +647,7 @@ test_that("Stan code for multinomial models is correct", {
   prior <- prior(normal(0, 10), "b", dpar = muy2) +
     prior(cauchy(0, 1), "Intercept", dpar = muy2) +
     prior(normal(0, 2), "Intercept", dpar = muy3)
-  scode <- make_stancode(bf(y | trials(size)  ~ 1, muy2 ~ x), data = dat, 
+  scode <- make_stancode(bf(y | trials(size)  ~ 1, muy2 ~ x), data = dat,
                          family = multinomial(), prior = prior)
   expect_match2(scode, "int Y[N, ncat];")
   expect_match2(scode, "target += multinomial_logit2_lpmf(Y[n] | mu[n]);")
@@ -663,27 +663,27 @@ test_that("Stan code for dirichlet models is correct", {
   names(dat) <- c("y1", "y2", "y3")
   dat$x <- rnorm(N)
   dat$y <- with(dat, cbind(y1, y2, y3))
-  
+
   # dirichlet in probability-sum(alpha) concentration
   prior <- prior(normal(0, 5), class = "b", dpar = "muy3") +
     prior(exponential(10), "phi")
-  scode <- make_stancode(bf(y ~ 1, muy3 ~ x), data = dat, 
+  scode <- make_stancode(bf(y ~ 1, muy3 ~ x), data = dat,
                          family = dirichlet(), prior = prior)
   expect_match2(scode, "vector[ncat] Y[N];")
   expect_match2(scode, "target += dirichlet_logit_lpdf(Y[n] | mu[n], phi);")
   expect_match2(scode, "muy3 = Intercept_muy3 + Xc_muy3 * b_muy3;")
   expect_match2(scode, "lprior += normal_lpdf(b_muy3 | 0, 5);")
   expect_match2(scode, "lprior += exponential_lpdf(phi | 10);")
-  
-  scode <- make_stancode(bf(y ~ x, phi ~ x), data = dat, 
+
+  scode <- make_stancode(bf(y ~ x, phi ~ x), data = dat,
                          family = dirichlet())
   expect_match2(scode, "target += dirichlet_logit_lpdf(Y[n] | mu[n], phi[n]);")
   expect_match2(scode, "vector[N] phi = Intercept_phi + Xc_phi * b_phi;")
   expect_match2(scode, "phi[n] = exp(phi[n]);")
-  
+
   # dirichlet2 in alpha parameterization
   prior <- prior(normal(0, 5), class = "b", dpar = "muy3")
-  scode <- make_stancode(bf(y ~ 1, muy3 ~ x), data = dat, 
+  scode <- make_stancode(bf(y ~ 1, muy3 ~ x), data = dat,
                          family = brmsfamily("dirichlet2"), prior = prior)
   expect_match2(scode, "vector[ncat] Y[N];")
   expect_match2(scode, "muy3[n] = exp(muy3[n]);")
@@ -700,12 +700,12 @@ test_that("Stan code for logistic_normal models is correct", {
   names(dat) <- c("y1", "y2", "y3")
   dat$x <- rnorm(N)
   dat$y <- with(dat, cbind(y1, y2, y3))
-  
+
   prior <- prior(normal(0, 5), class = "b", dpar = "muy3") +
     prior(exponential(10), "sigmay1") +
     prior(lkj(3), "lncor")
-  scode <- make_stancode(bf(y ~ x), data = dat, 
-                         family = logistic_normal(refcat = "y2"), 
+  scode <- make_stancode(bf(y ~ x), data = dat,
+                         family = logistic_normal(refcat = "y2"),
                          prior = prior)
   expect_match2(scode, "vector[ncat] Y[N];")
   expect_match2(scode, "mu[n] = transpose([muy1[n], muy3[n]]);")
@@ -715,11 +715,11 @@ test_that("Stan code for logistic_normal models is correct", {
   expect_match2(scode, "lprior += normal_lpdf(b_muy3 | 0, 5);")
   expect_match2(scode, "lprior += exponential_lpdf(sigmay1 | 10);")
   expect_match2(scode, "lprior += lkj_corr_cholesky_lpdf(Llncor | 3);")
-  
+
   prior <- prior(normal(0, 5), class = "b", dpar = "muy3") +
     prior(normal(0, 3), class = "b", dpar = "sigmay2")
-  scode <- make_stancode(bf(y ~ 1, muy3 ~ x, sigmay2 ~ x), data = dat, 
-                         family = logistic_normal(), 
+  scode <- make_stancode(bf(y ~ 1, muy3 ~ x, sigmay2 ~ x), data = dat,
+                         family = logistic_normal(),
                          prior = prior)
   expect_match2(scode, "vector[ncat] Y[N];")
   expect_match2(scode, "mu[n] = transpose([muy2[n], muy3[n]]);")
@@ -736,38 +736,38 @@ test_that("Stan code for ARMA models is correct", {
   scode <- make_stancode(y ~ x + ar(time), dat, student())
   expect_match2(scode, "err[n] = Y[n] - mu[n];")
   expect_match2(scode, "mu[n] += Err[n, 1:Kar] * ar;")
-  
+
   scode <- make_stancode(y ~ x + ma(time, q = 2), dat, student())
   expect_match2(scode, "mu[n] += Err[n, 1:Kma] * ma;")
-  
+
   expect_warning(
-    scode <- make_stancode(mvbind(y, x) ~ 1, dat, gaussian(), 
+    scode <- make_stancode(mvbind(y, x) ~ 1, dat, gaussian(),
                            autocor = cor_ar()),
     "Argument 'autocor' should be specified within the 'formula' argument"
   )
   expect_match2(scode, "err_y[n] = Y_y[n] - mu_y[n];")
-  
+
   bform <- bf(y ~ x, sigma ~ x) + acformula(~arma(time, cov = TRUE))
   scode <- make_stancode(bform, dat, family = student)
   expect_match2(scode, "student_t_time_het_lpdf(Y | nu, mu, sigma, chol_cor")
-  
+
   bform <- bf(y ~ exp(eta) - 1, eta ~ x, autocor = ~ar(time), nl = TRUE)
   scode <- make_stancode(bform, dat, family = student,
                          prior = prior(normal(0, 1), nlpar = eta))
   expect_match2(scode, "mu[n] += Err[n, 1:Kar] * ar;")
-  
+
   # correlations of latent residuals
   scode <- make_stancode(
     y ~ x + ar(time, cov = TRUE), dat, family = poisson,
     prior = prior(cauchy(0, 10), class = sderr)
   )
   expect_match2(scode, "chol_cor = cholesky_cor_ar1(ar[1], max_nobs_tg);")
-  expect_match2(scode, 
+  expect_match2(scode,
     "err = scale_time_err(zerr, sderr, chol_cor, nobs_tg, begin_tg, end_tg);"
   )
   expect_match2(scode, "vector[N] mu = Intercept + Xc * b + err;")
   expect_match2(scode, "lprior += cauchy_lpdf(sderr | 0, 10);")
-  
+
   scode <- make_stancode(
     y ~ x + ar(time), dat, family = poisson,
     prior = prior(cauchy(0, 10), class = sderr)
@@ -787,37 +787,37 @@ test_that("Stan code for compound symmetry models is correct", {
   expect_match2(scode, "real<lower=0,upper=1> cosy;")
   expect_match2(scode, "chol_cor = cholesky_cor_cosy(cosy, max_nobs_tg);")
   expect_match2(scode, "lprior += normal_lpdf(cosy | 0, 2);")
-  
+
   scode <- make_stancode(bf(y ~ x + cosy(time), sigma ~ x), dat)
   expect_match2(scode, "normal_time_het_lpdf(Y | mu, sigma, chol_cor")
-  
+
   scode <- make_stancode(y ~ x + cosy(time), dat, family = poisson)
   expect_match2(scode, "chol_cor = cholesky_cor_cosy(cosy, max_nobs_tg);")
 })
 
 test_that("Stan code for intercept only models is correct", {
   expect_match2(make_stancode(rating ~ 1, data = inhaler),
-               "b_Intercept = Intercept;") 
+               "b_Intercept = Intercept;")
   expect_match2(make_stancode(rating ~ 1, data = inhaler, family = cratio()),
-               "b_Intercept = Intercept;") 
+               "b_Intercept = Intercept;")
   expect_match2(make_stancode(rating ~ 1, data = inhaler, family = categorical()),
                "b_mu3_Intercept = Intercept_mu3;")
 })
 
 test_that("Stan code of ordinal models is correct", {
-  dat <- data.frame(y = c(rep(1:4, 2), 1, 1), x1 = rnorm(10), 
+  dat <- data.frame(y = c(rep(1:4, 2), 1, 1), x1 = rnorm(10),
                     x2 = rnorm(10), g = factor(rep(1:2, 5)))
-  
+
   scode <- make_stancode(
     y ~ x1, dat, family = cumulative(),
     prior = prior(normal(0, 2), Intercept, coef = 2)
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += ordered_logistic_lpmf(Y[n] | mu[n], Intercept);"
   )
   expect_match2(scode, "lprior += student_t_lpdf(Intercept[1] | 3, 0, 2.5);")
   expect_match2(scode, "lprior += normal_lpdf(Intercept[2] | 0, 2);")
-  
+
   scode <- make_stancode(
     y ~ x1, dat, cumulative("probit", threshold = "equidistant"),
     prior = prior(normal(0, 2), Intercept)
@@ -828,7 +828,7 @@ test_that("Stan code of ordinal models is correct", {
   expect_match2(scode, "Intercept[k] = first_Intercept + (k - 1.0) * delta;")
   expect_match2(scode, "b_Intercept = Intercept + dot_product(means_X, b);")
   expect_match2(scode, "lprior += normal_lpdf(first_Intercept | 0, 2);")
-  
+
   scode <- make_stancode(y ~ x1, dat, family = cratio("probit"))
   expect_match2(scode, "real cratio_probit_lpmf(int y")
   expect_match2(scode, "q[k] = normal_lcdf(disc * (mu - thres[k])|0,1);")
@@ -838,23 +838,23 @@ test_that("Stan code of ordinal models is correct", {
   expect_match2(scode, "matrix[N, Kcs] Xcs;")
   expect_match2(scode, "matrix[Kcs, nthres] bcs;")
   expect_match2(scode, "mucs = Xcs * bcs;")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += sratio_logit_lpmf(Y[n] | mu[n], disc, Intercept - transpose(mucs[n]));"
   )
-  
+
   scode <- make_stancode(y ~ x1 + cse(x2) + (cse(1)|g), dat, family = acat())
   expect_match2(scode, "real acat_logit_lpmf(int y")
   expect_match2(scode, "mucs[n, 1] = mucs[n, 1] + r_1_1[J_1[n]] * Z_1_1[n];")
   expect_match2(scode, "b_Intercept = Intercept + dot_product(means_X, b);")
-  
+
   scode <- make_stancode(y ~ x1 + (cse(x2)||g), dat, family = acat("probit_approx"))
-  expect_match2(scode, 
-    paste("mucs[n, 3] = mucs[n, 3] + r_1_3[J_1[n]] * Z_1_3[n]", 
+  expect_match2(scode,
+    paste("mucs[n, 3] = mucs[n, 3] + r_1_3[J_1[n]] * Z_1_3[n]",
           "+ r_1_6[J_1[n]] * Z_1_6[n];"))
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += acat_probit_approx_lpmf(Y[n] | mu[n], disc, Intercept - transpose(mucs[n]));"
   )
-  
+
   # sum-to-zero thresholds
   scode <- make_stancode(
     y ~ x1, dat, cumulative("probit", threshold = "sum_to_zero"),
@@ -863,20 +863,20 @@ test_that("Stan code of ordinal models is correct", {
   expect_match2(scode, "Intercept_stz = Intercept - mean(Intercept);")
   expect_match2(scode, "cumulative_probit_lpmf(Y[n] | mu[n], disc, Intercept_stz);")
   expect_match2(scode, "vector[nthres] b_Intercept = Intercept_stz;")
-  
+
   # non-linear ordinal models
   scode <- make_stancode(
     bf(y ~ eta, eta ~ x1, nl = TRUE), dat, family = cumulative(),
     prior = prior(normal(0, 2), nlpar = eta)
   )
   expect_match2(scode, "ordered[nthres] Intercept;")
-  expect_match2(scode, 
-    "target += ordered_logistic_lpmf(Y[n] | mu[n], Intercept);"             
+  expect_match2(scode,
+    "target += ordered_logistic_lpmf(Y[n] | mu[n], Intercept);"
   )
-  
+
   # ordinal mixture models with fixed intercepts
   scode <- make_stancode(
-    bf(y ~ 1, mu1 ~ x1, mu2 ~ 1), data = dat, 
+    bf(y ~ 1, mu1 ~ x1, mu2 ~ 1), data = dat,
     family = mixture(cumulative(), nmix = 2, order = "mu")
   )
   expect_match2(scode, "Intercept_mu2 = fixed_Intercept;")
@@ -886,10 +886,10 @@ test_that("Stan code of ordinal models is correct", {
 test_that("ordinal disc parameters appear in the Stan code", {
   scode <- make_stancode(
     bf(rating ~ period + carry + treat, disc ~ period),
-    data = inhaler, family = cumulative(), 
+    data = inhaler, family = cumulative(),
     prior = prior(normal(0,5), dpar = disc)
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += cumulative_logit_lpmf(Y[n] | mu[n], disc[n], Intercept)"
   )
   expect_match2(scode, "lprior += normal_lpdf(b_disc | 0, 5)")
@@ -904,10 +904,10 @@ test_that("grouped ordinal thresholds appear in the Stan code", {
     th = rep(5:6, each = 5),
     x = rnorm(10)
   )
-  
+
   prior <- prior(normal(0,1), class = "Intercept", group = "b")
   scode <- make_stancode(
-    y | thres(th, gr) ~ x, data = dat, 
+    y | thres(th, gr) ~ x, data = dat,
     family = sratio(), prior = prior
   )
   expect_match2(scode, "int<lower=1> nthres[ngrthres];")
@@ -916,31 +916,31 @@ test_that("grouped ordinal thresholds appear in the Stan code", {
   expect_match2(scode, "lprior += normal_lpdf(Intercept_2 | 0, 1);")
   # centering needs to be deactivated automatically
   expect_match2(scode, "vector[nthres[1]] b_Intercept_1 = Intercept_1;")
-  
+
   # model with equidistant thresholds
   scode <- make_stancode(
-    y | thres(th, gr) ~ x, data = dat, 
-    family = cumulative(threshold = "equidistant"), 
+    y | thres(th, gr) ~ x, data = dat,
+    family = cumulative(threshold = "equidistant"),
     prior = prior
   )
   expect_match2(scode, "target += ordered_logistic_merged_lpmf(Y[n]")
   expect_match2(scode, "real first_Intercept_1;")
   expect_match2(scode, "lprior += normal_lpdf(first_Intercept_2 | 0, 1);")
   expect_match2(scode, "Intercept_2[k] = first_Intercept_2 + (k - 1.0) * delta_2;")
-  
+
   # sum-to-zero constraints
   scode <- make_stancode(
-    y | thres(gr = gr) ~ x, data = dat, 
+    y | thres(gr = gr) ~ x, data = dat,
     cumulative(threshold = "sum_to_zero"),
     prior = prior(normal(0, 2), Intercept)
   )
   expect_match2(scode, "merged_Intercept_stz[Kthres_start[2]:Kthres_end[2]] = Intercept_stz_2;")
   expect_match2(scode, "ordered_logistic_merged_lpmf(Y[n] | mu[n], merged_Intercept_stz, Jthres[n]);")
-  
+
   # ordinal mixture model
   scode <- make_stancode(
-    y | thres(th, gr) ~ x, data = dat, 
-    family = mixture(cratio, acat, order = "mu"), 
+    y | thres(th, gr) ~ x, data = dat,
+    family = mixture(cratio, acat, order = "mu"),
     prior = prior
   )
   expect_match2(scode, "ps[1] = log(theta1) + cratio_logit_merged_lpmf(Y[n]")
@@ -948,20 +948,20 @@ test_that("grouped ordinal thresholds appear in the Stan code", {
   expect_match2(scode, "vector[nmthres] merged_Intercept_mu1;")
   expect_match2(scode, "merged_Intercept_mu2[Kthres_start[1]:Kthres_end[1]] = Intercept_mu2_1;")
   expect_match2(scode, "vector[nthres[1]] b_mu1_Intercept_1 = Intercept_mu1_1;")
-  
+
   # multivariate ordinal model
   bform <- bf(y | thres(th, gr) ~ x, family = sratio) +
-    bf(y2 | thres(th, gr) ~ x, family = cumulative) 
+    bf(y2 | thres(th, gr) ~ x, family = cumulative)
   scode <- make_stancode(bform, data = dat)
   expect_match2(scode, "lprior += student_t_lpdf(Intercept_y2_1 | 3, 0, 2.5);")
   expect_match2(scode, "merged_Intercept_y[Kthres_start_y[2]:Kthres_end_y[2]] = Intercept_y_2;")
 })
 
 test_that("monotonic effects appear in the Stan code", {
-  dat <- data.frame(y = rpois(120, 10), x1 = rep(1:4, 30), 
+  dat <- data.frame(y = rpois(120, 10), x1 = rep(1:4, 30),
                     x2 = factor(rep(c("a", "b", "c"), 40), ordered = TRUE),
                     g = rep(1:10, each = 12))
-  
+
   prior <- c(prior(normal(0,1), class = b, coef = mox1),
              prior(dirichlet(c(1,0.5,2)), simo, coef = mox11),
              prior(dirichlet(c(1,0.5,2)), simo, coef = mox21))
@@ -969,40 +969,40 @@ test_that("monotonic effects appear in the Stan code", {
   expect_match2(scode, "int Xmo_3[N];")
   expect_match2(scode, "simplex[Jmo[1]] simo_1;")
   expect_match2(scode, "(bsp[2]) * mo(simo_2, Xmo_2[n])")
-  expect_match2(scode, 
+  expect_match2(scode,
     "(bsp[6]) * mo(simo_7, Xmo_7[n]) * mo(simo_8, Xmo_8[n]) * Csp_3[n]"
   )
   expect_match2(scode, "lprior += normal_lpdf(bsp[1] | 0, 1)")
   expect_match2(scode, "lprior += dirichlet_lpdf(simo_1 | con_simo_1);")
   expect_match2(scode, "lprior += dirichlet_lpdf(simo_8 | con_simo_8);")
-  
+
   scode <- make_stancode(y ~ mo(x1) + (mo(x1) | x2), dat)
   expect_match2(scode, "(bsp[1] + r_1_2[J_1[n]]) * mo(simo_1, Xmo_1[n])")
   expect_true(!grepl("Z_1_w", scode))
-  
+
   # test issue reported in discourse post #12978
   scode <- make_stancode(y ~ mo(x1) + (mo(x1) | x2) + (mo(x1) | g), dat)
   expect_match2(scode, "(bsp[1] + r_1_2[J_1[n]] + r_2_2[J_2[n]]) * mo(simo_1, Xmo_1[n])")
-  
+
   # test issue #813
   scode <- make_stancode(y ~ mo(x1):y, dat)
   expect_match2(scode, "mu[n] += (bsp[1]) * mo(simo_1, Xmo_1[n]) * Csp_1[n];")
-  
+
   # test issue #924 (conditional monotonicity)
   prior <- c(prior(dirichlet(c(1,0.5,2)), simo, coef = "v"),
              prior(dirichlet(c(1,0.5,2)), simo, coef = "w"))
-  scode <- make_stancode(y ~ y*mo(x1, id = "v")*mo(x2, id = "w"), 
+  scode <- make_stancode(y ~ y*mo(x1, id = "v")*mo(x2, id = "w"),
                          dat, prior = prior)
   expect_match2(scode, "lprior += dirichlet_lpdf(simo_1 | con_simo_1);")
   expect_match2(scode, "lprior += dirichlet_lpdf(simo_2 | con_simo_2);")
   expect_match2(scode, "simplex[Jmo[6]] simo_6 = simo_2;")
   expect_match2(scode, "simplex[Jmo[7]] simo_7 = simo_1;")
-  
+
   expect_error(
     make_stancode(y ~ mo(x1) + (mo(x2) | x2), dat),
     "Special group-level terms require"
   )
-  
+
   prior <- prior(beta(1, 1), simo, coef = mox11)
   expect_error(
     make_stancode(y ~ mo(x1), dat, prior = prior),
@@ -1013,49 +1013,49 @@ test_that("monotonic effects appear in the Stan code", {
 test_that("Stan code for non-linear models is correct", {
   flist <- list(a ~ x, b ~ z + (1|g))
   data <- data.frame(
-    y = rgamma(9, 1, 1), x = rnorm(9), 
+    y = rgamma(9, 1, 1), x = rnorm(9),
     z = rnorm(9), v = 1L:9L, g = rep(1:3, 3)
   )
   prior <- c(set_prior("normal(0,5)", nlpar = "a"),
              set_prior("normal(0,1)", nlpar = "b"))
   # syntactic validity is already checked within make_stancode
   scode <- make_stancode(
-    bf(y ~ a - exp(b^z) * (z <= a) * v, flist = flist, nl = TRUE), 
+    bf(y ~ a - exp(b^z) * (z <= a) * v, flist = flist, nl = TRUE),
     data = data, prior = prior
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "mu[n] = nlp_a[n] - exp(nlp_b[n] ^ C_1[n]) * (C_1[n] <= nlp_a[n]) * C_2[n];"
   )
   expect_match2(scode, "vector[N] C_1;")
   expect_match2(scode, "int C_2[N];")
-  
+
   # non-linear predictor can be computed outside a loop
-  scode <- make_stancode(bf(y ~ a - exp(b + z), flist = flist, 
-                            nl = TRUE, loop = FALSE), 
+  scode <- make_stancode(bf(y ~ a - exp(b + z), flist = flist,
+                            nl = TRUE, loop = FALSE),
                          data = data, prior = prior)
   expect_match2(scode, "mu = nlp_a - exp(nlp_b + C_1);")
-  
+
   # check if that only works with threading
-  scode <- make_stancode(bf(y ~ a - exp(b + z), flist = flist, 
-                            nl = TRUE, loop = FALSE), 
-                         data = data, prior = prior, 
+  scode <- make_stancode(bf(y ~ a - exp(b + z), flist = flist,
+                            nl = TRUE, loop = FALSE),
+                         data = data, prior = prior,
                          threads = threading(2), parse = FALSE)
   expect_match2(scode, "mu = nlp_a - exp(nlp_b + C_1[start:end]);")
-  
+
   flist <- list(a1 ~ 1, a2 ~ z + (x|g))
   prior <- c(set_prior("beta(1,1)", nlpar = "a1", lb = 0, ub = 1),
              set_prior("normal(0,1)", nlpar = "a2"))
   scode <- make_stancode(
-    bf(y ~ a1 * exp(-x/(a2 + z)), 
+    bf(y ~ a1 * exp(-x/(a2 + z)),
        flist = flist, nl = TRUE),
-    data = data, family = Gamma("log"), 
+    data = data, family = Gamma("log"),
     prior = prior
   )
   expect_match2(scode,
-    paste("mu[n] = shape * exp(-(nlp_a1[n] *", 
+    paste("mu[n] = shape * exp(-(nlp_a1[n] *",
           "exp( - C_1[n] / (nlp_a2[n] + C_2[n]))));"))
-  
-  bform <- bf(y ~ x) + 
+
+  bform <- bf(y ~ x) +
     nlf(sigma ~ a1 * exp(-x/(a2 + z))) +
     lf(a1 ~ 1, a2 ~ z + (x|g)) +
     lf(alpha ~ x)
@@ -1071,7 +1071,7 @@ test_that("Stan code for non-linear models is correct", {
     "sigma[n] = exp(nlp_a1[n] * exp( - C_sigma_1[n] / (nlp_a2[n] + C_sigma_2[n])))"
   )
   expect_match2(scode, "lprior += normal_lpdf(b_a2 | 0, 5)")
-  
+
   expect_error(make_stancode(bform, data, family = skew_normal()),
                "Priors on population-level coefficients are required")
 })
@@ -1087,14 +1087,14 @@ test_that("Stan code for nested non-linear parameters is correct", {
     prior(normal(0, 1), nlpar = "b")
   scode <- make_stancode(bform, dat, prior = bprior)
   expect_match2(scode, "nlp_lb[n] = inv_logit(nlp_a[n] / C_lb_1[n]);")
-  expect_match2(scode, 
+  expect_match2(scode,
     "mu[n] = nlp_lb[n] + (1 - nlp_lb[n]) * inv_logit(nlp_b[n] * C_1[n]);"
   )
 })
 
 test_that("make_stancode accepts very long non-linear formulas", {
   data <- data.frame(y = rnorm(10), this_is_a_very_long_predictor = rnorm(10))
-  expect_silent(make_stancode(bf(y ~ b0 + this_is_a_very_long_predictor + 
+  expect_silent(make_stancode(bf(y ~ b0 + this_is_a_very_long_predictor +
                                  this_is_a_very_long_predictor +
                                  this_is_a_very_long_predictor,
                                  b0 ~ 1, nl = TRUE),
@@ -1104,8 +1104,8 @@ test_that("make_stancode accepts very long non-linear formulas", {
 test_that("no loop in trans-par is defined for simple 'identity' models", {
   expect_true(!grepl(make_stancode(time ~ age, data = kidney),
                      "mu[n] = (mu[n]);", fixed = TRUE))
-  expect_true(!grepl(make_stancode(time ~ age, data = kidney, 
-                                   family = poisson("identity")), 
+  expect_true(!grepl(make_stancode(time ~ age, data = kidney,
+                                   family = poisson("identity")),
                      "mu[n] = (mu[n]);", fixed = TRUE))
 })
 
@@ -1116,7 +1116,7 @@ test_that("known standard errors appear in the Stan code", {
   expect_match2(scode, "target += weights[n] * (normal_lpdf(Y[n] | mu[n], se[n]))")
   scode <- make_stancode(time | se(age, sigma = TRUE) ~ sex, data = kidney)
   expect_match2(scode, "target += normal_lpdf(Y | mu, sqrt(square(sigma) + se2))")
-  scode <- make_stancode(bf(time | se(age, sigma = TRUE) ~ sex, sigma ~ sex), 
+  scode <- make_stancode(bf(time | se(age, sigma = TRUE) ~ sex, sigma ~ sex),
                          data = kidney)
   expect_match2(scode, "target += normal_lpdf(Y | mu, sqrt(square(sigma) + se2))")
 })
@@ -1148,16 +1148,16 @@ test_that("Stan code for GAMMs is correct", {
   expect_match2(scode, "matrix[N, knots_1[1]] Zs_1_1")
   expect_match2(scode, "target += std_normal_lpdf(zs_1_1)")
   expect_match2(scode, "lprior += normal_lpdf(sds_1_1 | 0,2)")
-  
+
   prior <- c(set_prior("normal(0,5)", nlpar = "lp"),
              set_prior("normal(0,2)", "sds", nlpar = "lp"))
-  scode <- make_stancode(bf(y ~ lp, lp ~ s(x) + (1|g), nl = TRUE), 
+  scode <- make_stancode(bf(y ~ lp, lp ~ s(x) + (1|g), nl = TRUE),
                          data = dat, prior = prior)
   expect_match2(scode, "Zs_lp_1_1 * s_lp_1_1")
   expect_match2(scode, "matrix[N, knots_lp_1[1]] Zs_lp_1_1")
   expect_match2(scode, "target += std_normal_lpdf(zs_lp_1_1)")
   expect_match2(scode, "lprior += normal_lpdf(sds_lp_1_1 | 0,2)")
-  
+
   scode <- make_stancode(
     y ~ s(x) + t2(x,y), data = dat,
     prior = set_prior("normal(0,1)", "sds") +
@@ -1168,7 +1168,7 @@ test_that("Stan code for GAMMs is correct", {
   expect_match2(scode, "target += std_normal_lpdf(zs_2_2)")
   expect_match2(scode, "lprior += normal_lpdf(sds_1_1 | 0,1)")
   expect_match2(scode, "lprior += normal_lpdf(sds_2_2 | 0,2)")
-  
+
   scode <- make_stancode(y ~ g + s(x, by = g), data = dat)
   expect_match2(scode, "vector[knots_2[1]] zs_2_1")
   expect_match2(scode, "s_2_1 = sds_2_1 * zs_2_1")
@@ -1185,25 +1185,25 @@ test_that("Stan code of response times models is correct", {
   )
   expect_match2(scode, "mu[n] = exp(mu[n])")
   expect_match2(scode, "lprior += gamma_lpdf(beta | 1, 1)")
-  
+
   scode <- make_stancode(bf(count ~ Trt + (1|patient),
                          sigma ~ Trt, beta ~ Trt),
                       data = dat, family = exgaussian())
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += exp_mod_normal_lpdf(Y | mu - beta, sigma, inv(beta))"
   )
   expect_match2(scode, "beta[n] = exp(beta[n])")
-  
+
   scode <- make_stancode(count | cens(cens) ~ Trt + (1|patient),
                       data = dat, family = exgaussian("inverse"))
   expect_match2(scode, "exp_mod_normal_lccdf(Y[n] | mu[n] - beta, sigma, inv(beta))")
-  
+
   scode <- make_stancode(count ~ Trt, dat, family = shifted_lognormal())
   expect_match2(scode, "target += lognormal_lpdf(Y - ndt | mu, sigma)")
-  
+
   scode <- make_stancode(count | cens(cens) ~ Trt, dat, family = shifted_lognormal())
   expect_match2(scode, "target += lognormal_lcdf(Y[n] - ndt | mu[n], sigma)")
-  
+
   # test issue #837
   scode <- make_stancode(mvbind(count, zBase) ~ Trt, data = dat,
                          family = shifted_lognormal())
@@ -1214,32 +1214,32 @@ test_that("Stan code of response times models is correct", {
 test_that("Stan code of wiener diffusion models is correct", {
   dat <- data.frame(q = 1:10, resp = sample(0:1, 10, TRUE), x = rnorm(10))
   scode <- make_stancode(q | dec(resp) ~ x, data = dat, family = wiener())
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += wiener_diffusion_lpdf(Y[n] | dec[n], bs, ndt, bias, mu[n])"
   )
-  
-  scode <- make_stancode(bf(q | dec(resp) ~ x, bs ~ x, ndt ~ x, bias ~ x), 
+
+  scode <- make_stancode(bf(q | dec(resp) ~ x, bs ~ x, ndt ~ x, bias ~ x),
                          data = dat, family = wiener())
   expect_match2(scode,
     "target += wiener_diffusion_lpdf(Y[n] | dec[n], bs[n], ndt[n], bias[n], mu[n])"
   )
   expect_match2(scode, "bias[n] = inv_logit(bias[n]);")
-  
-  scode <- make_stancode(bf(q | dec(resp) ~ x, ndt = 0.5), 
+
+  scode <- make_stancode(bf(q | dec(resp) ~ x, ndt = 0.5),
                          data = dat, family = wiener())
   expect_match2(scode, "real<lower=0,upper=min(Y)> ndt = 0.5;")
-  
+
   expect_error(make_stancode(q ~ x, data = dat, family = wiener()),
                "Addition argument 'dec' is required for family 'wiener'")
 })
 
 test_that("Group IDs appear in the Stan code", {
-  form <- bf(count ~ Trt + (1+Trt|3|visit) + (1|patient), 
+  form <- bf(count ~ Trt + (1+Trt|3|visit) + (1|patient),
              shape ~ (1|3|visit) + (Trt||patient))
   scode <- make_stancode(form, data = epilepsy, family = negbinomial())
   expect_match2(scode, "r_2_1 = r_2[, 1]")
   expect_match2(scode, "r_2_shape_3 = r_2[, 3]")
-  
+
   form <- bf(count ~ a, sigma ~ (1|3|visit) + (Trt||patient),
              a ~ Trt + (1+Trt|3|visit) + (1|patient), nl = TRUE)
   scode <- make_stancode(form, data = epilepsy, family = student(),
@@ -1251,64 +1251,64 @@ test_that("Group IDs appear in the Stan code", {
 test_that("distributional gamma models are handled correctly", {
   # test fix of issue #124
   scode <- make_stancode(
-    bf(time ~ age * sex + disease + (1|patient), 
-       shape ~ age + (1|patient)), 
+    bf(time ~ age * sex + disease + (1|patient),
+       shape ~ age + (1|patient)),
     data = kidney, family = Gamma("log")
   )
   expect_match(scode, paste0(
     brms:::escape_all("shape[n] = exp(shape[n]);"), ".+",
     brms:::escape_all("mu[n] = shape[n] * exp(-(mu[n]));")
   ))
-  
+
   scode <- make_stancode(
     bf(time ~ inv_logit(a) * exp(b * age),
-       a + b ~ sex + (1|patient), nl = TRUE, 
-       shape ~ age + (1|patient)), 
+       a + b ~ sex + (1|patient), nl = TRUE,
+       shape ~ age + (1|patient)),
     data = kidney, family = Gamma("identity"),
     prior = c(set_prior("normal(2,2)", nlpar = "a"),
               set_prior("normal(0,3)", nlpar = "b"))
   )
   expect_match(scode, paste0(
-    brms:::escape_all("shape[n] = exp(shape[n]);"), ".+", 
+    brms:::escape_all("shape[n] = exp(shape[n]);"), ".+",
     brms:::escape_all("mu[n] = shape[n] / (inv_logit(nlp_a[n]) * exp(nlp_b[n] * C_1[n]));")
   ))
 })
 
 test_that("weighted, censored, and truncated likelihoods are correct", {
   dat <- data.frame(y = 1:9, x = rep(-1:1, 3), y2 = 10:18)
-  
+
   scode <- make_stancode(y | weights(y2) ~ 1, dat, poisson())
   expect_match2(scode, "target += weights[n] * (poisson_log_lpmf(Y[n] | mu[n]));")
-  
+
   scode <- make_stancode(y | trials(y2) + weights(y2) ~ 1, dat, binomial())
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += weights[n] * (binomial_logit_lpmf(Y[n] | trials[n], mu[n]));"
   )
-  
+
   scode <- make_stancode(y | cens(x, y2) ~ 1, dat, poisson())
   expect_match2(scode, "target += poisson_lpmf(Y[n] | mu[n]);")
-  
+
   scode <- make_stancode(y | cens(x) ~ 1, dat, weibull())
   expect_match2(scode, "target += weibull_lccdf(Y[n] | shape, mu[n]);")
-  
+
   dat$x[1] <- 2
   scode <- make_stancode(y | cens(x, y2) ~ 1, dat, gaussian())
   expect_match2(scode, paste0(
-    "target += log_diff_exp(\n", 
+    "target += log_diff_exp(\n",
     "          normal_lcdf(rcens[n] | mu[n], sigma),"
   ))
   dat$x <- 1
   expect_match2(make_stancode(y | cens(x) + weights(x) ~ 1, dat, weibull()),
    "target += weights[n] * weibull_lccdf(Y[n] | shape, mu[n]);")
-  
+
   scode <- make_stancode(y | cens(x) + trunc(0.1) ~ 1, dat, weibull())
   expect_match2(scode, "target += weibull_lccdf(Y[n] | shape, mu[n]) -")
   expect_match2(scode, "  weibull_lccdf(lb[n] | shape, mu[n]);")
-  
+
   scode <- make_stancode(y | cens(x) + trunc(ub = 30) ~ 1, dat)
   expect_match2(scode, "target += normal_lccdf(Y[n] | mu[n], sigma) -")
   expect_match2(scode, "  normal_lcdf(ub[n] | mu[n], sigma);")
-  
+
   scode <- make_stancode(y | weights(x) + trunc(0, 30) ~ 1, dat)
   expect_match2(scode, "target += weights[n] * (normal_lpdf(Y[n] | mu[n], sigma) -")
   expect_match2(scode, "  log_diff_exp(normal_lcdf(ub[n] | mu[n], sigma),")
@@ -1321,8 +1321,8 @@ test_that("noise-free terms appear in the Stan code", {
     xsd = abs(rnorm(N, 1)), zsd = abs(rnorm(N, 1)),
     ID = rep(1:5, each = N / 5)
   )
-  
-  me_prior <- prior(normal(0,5)) + 
+
+  me_prior <- prior(normal(0,5)) +
     prior(normal(0, 10), "meanme") +
     prior(cauchy(0, 5), "sdme", coef = "mez") +
     prior(lkj(2), "corme")
@@ -1330,7 +1330,7 @@ test_that("noise-free terms appear in the Stan code", {
     y ~ me(x, xsd)*me(z, zsd)*x, data = dat, prior = me_prior,
     sample_prior = "yes"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "(bsp[1]) * Xme_1[n] + (bsp[2]) * Xme_2[n] + (bsp[3]) * Xme_1[n] * Xme_2[n]"
   )
   expect_match2(scode, "(bsp[6]) * Xme_1[n] * Xme_2[n] * Csp_3[n]")
@@ -1342,40 +1342,40 @@ test_that("noise-free terms appear in the Stan code", {
   expect_match2(scode, "lprior += lkj_corr_cholesky_lpdf(Lme_1 | 2)")
   expect_match2(scode, "+ transpose(diag_pre_multiply(sdme_1, Lme_1) * zme_1)")
   expect_match2(scode, "corme_1[choose(k - 1, 2) + j] = Corme_1[j, k];")
-  
+
   scode <- make_stancode(
     y ~ me(x, xsd)*z + (me(x, xsd)*z | ID), data = dat
   )
   expect_match2(scode, "(bsp[1] + r_1_3[J_1[n]]) * Xme_1[n]")
   expect_match2(scode, "(bsp[2] + r_1_4[J_1[n]]) * Xme_1[n] * Csp_1[n]")
-  
+
   expect_match2(make_stancode(y ~ I(me(x, xsd)^2), data = dat),
                "(bsp[1]) * (Xme_1[n]^2)")
-  
+
   # test that noise-free variables are unique across model parts
   scode <- make_stancode(
-    bf(y ~ me(x, xsd)*me(z, zsd)*x, sigma ~ me(x, xsd)), 
+    bf(y ~ me(x, xsd)*me(z, zsd)*x, sigma ~ me(x, xsd)),
     data = dat, prior = prior(normal(0,5))
   )
   expect_match2(scode, "mu[n] += (bsp[1]) * Xme_1[n]")
   expect_match2(scode, "sigma[n] += (bsp_sigma[1]) * Xme_1[n]")
-  
+
   scode <- make_stancode(
-    bf(y ~ a * b, a + b ~ me(x, xsd), nl = TRUE), 
-    data = dat, 
-    prior = prior(normal(0,5), nlpar = a) + 
+    bf(y ~ a * b, a + b ~ me(x, xsd), nl = TRUE),
+    data = dat,
+    prior = prior(normal(0,5), nlpar = a) +
       prior(normal(0, 5), nlpar = b)
   )
   expect_match2(scode, "nlp_a[n] += (bsp_a[1]) * Xme_1[n]")
   expect_match2(scode, "nlp_b[n] += (bsp_b[1]) * Xme_1[n]")
-  
-  bform <- bf(mvbind(y, z) ~ me(x, xsd)) + 
+
+  bform <- bf(mvbind(y, z) ~ me(x, xsd)) +
     set_rescor(TRUE) + set_mecor(FALSE)
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "mu_y[n] += (bsp_y[1]) * Xme_1[n]")
   expect_match2(scode, "mu_z[n] += (bsp_z[1]) * Xme_1[n]")
   expect_match2(scode, "Xme_1 = meanme_1[1] + sdme_1[1] * zme_1;")
-  
+
   # noise-free terms with grouping factors
   bform <- bf(y ~ me(x, xsd, ID) + me(z, xsd) + (me(x, xsd, ID) | ID))
   scode <- make_stancode(bform, dat)
@@ -1383,7 +1383,7 @@ test_that("noise-free terms appear in the Stan code", {
   expect_match2(scode, "Xme_1 = meanme_1[1] + sdme_1[1] * zme_1;")
   expect_match2(scode, "Xme_2 = meanme_2[1] + sdme_2[1] * zme_2;")
   expect_match2(scode, "(bsp[1] + r_1_2[J_1[n]]) * Xme_1[Jme_1[n]]")
-  
+
   bform <- bform + set_mecor(FALSE)
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "Xme_1 = meanme_1[1] + sdme_1[1] * zme_1;")
@@ -1393,15 +1393,15 @@ test_that("Stan code of multi-membership models is correct", {
   dat <- data.frame(y = rnorm(10), g1 = sample(1:10, 10, TRUE),
                     g2 = sample(1:10, 10, TRUE), w1 = rep(1, 10),
                     w2 = rep(abs(rnorm(10))))
-  expect_match2(make_stancode(y ~ (1|mm(g1, g2)), data = dat), 
+  expect_match2(make_stancode(y ~ (1|mm(g1, g2)), data = dat),
     paste0(" W_1_1[n] * r_1_1[J_1_1[n]] * Z_1_1_1[n]",
            " + W_1_2[n] * r_1_1[J_1_2[n]] * Z_1_1_2[n]")
   )
-  expect_match2(make_stancode(y ~ (1+w1|mm(g1,g2)), data = dat), 
+  expect_match2(make_stancode(y ~ (1+w1|mm(g1,g2)), data = dat),
     paste0(" W_1_1[n] * r_1_2[J_1_1[n]] * Z_1_2_1[n]",
            " + W_1_2[n] * r_1_2[J_1_2[n]] * Z_1_2_2[n]")
   )
-  expect_match2(make_stancode(y ~ (1+mmc(w1, w2)|mm(g1,g2)), data = dat), 
+  expect_match2(make_stancode(y ~ (1+mmc(w1, w2)|mm(g1,g2)), data = dat),
     " W_1_2[n] * r_1_2[J_1_2[n]] * Z_1_2_2[n];"
   )
 })
@@ -1430,61 +1430,61 @@ test_that("Group syntax | and || is handled correctly,", {
 })
 
 test_that("predicting zi and hu works correctly", {
-  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy, 
+  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy,
                          family = "zero_inflated_poisson")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += zero_inflated_poisson_log_logit_lpmf(Y[n] | mu[n], zi[n])"
   )
   expect_true(!grepl("inv_logit\\(", scode))
   expect_true(!grepl("exp(mu[n])", scode, fixed = TRUE))
-  
-  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy, 
+
+  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy,
                          family = zero_inflated_poisson(identity))
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += zero_inflated_poisson_logit_lpmf(Y[n] | mu[n], zi[n])"
   )
-  
-  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy, 
+
+  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy,
                          family = "zero_inflated_binomial")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += zero_inflated_binomial_blogit_logit_lpmf(Y[n] | trials[n], mu[n], zi[n])"
   )
   expect_true(!grepl("inv_logit\\(", scode))
-  
+
   fam <- zero_inflated_binomial("probit", link_zi = "identity")
-  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy, 
+  scode <- make_stancode(bf(count ~ Trt, zi ~ Trt), epilepsy,
                          family = fam)
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += zero_inflated_binomial_lpmf(Y[n] | trials[n], mu[n], zi[n])"
   )
   expect_match2(scode, "mu[n] = Phi(mu[n]);")
-  
+
   scode <- make_stancode(
-    bf(count ~ Trt, zi ~ Trt), epilepsy, 
+    bf(count ~ Trt, zi ~ Trt), epilepsy,
     family = zero_inflated_beta()
   )
   expect_match2(scode,
-    "target += zero_inflated_beta_logit_lpdf(Y[n] | mu[n], phi, zi[n])"      
+    "target += zero_inflated_beta_logit_lpdf(Y[n] | mu[n], phi, zi[n])"
   )
-  
-  scode <- make_stancode(bf(count ~ Trt, hu ~ Trt), epilepsy, 
+
+  scode <- make_stancode(bf(count ~ Trt, hu ~ Trt), epilepsy,
                          family = "hurdle_negbinomial")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += hurdle_neg_binomial_log_logit_lpmf(Y[n] | mu[n], shape, hu[n])"
   )
   expect_true(!grepl("inv_logit\\(", scode))
   expect_true(!grepl("exp(mu[n])", scode, fixed = TRUE))
-  
-  scode <- make_stancode(bf(count ~ Trt, hu ~ Trt), epilepsy, 
+
+  scode <- make_stancode(bf(count ~ Trt, hu ~ Trt), epilepsy,
                          family = "hurdle_gamma")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += hurdle_gamma_logit_lpdf(Y[n] | shape, mu[n], hu[n])"
   )
   expect_true(!grepl("inv_logit\\(", scode))
   expect_match2(scode, "mu[n] = shape * exp(-(mu[n]));")
-  
+
   scode <- make_stancode(
-    bf(count ~ Trt, hu ~ Trt), epilepsy, 
+    bf(count ~ Trt, hu ~ Trt), epilepsy,
     family = hurdle_gamma(link_hu = "identity")
   )
   expect_match2(scode, "target += hurdle_gamma_lpdf(Y[n] | shape, mu[n], hu[n])")
@@ -1501,19 +1501,19 @@ test_that("Stan code of quantile regression models is correct", {
   data <- data.frame(y = rnorm(10), x = rnorm(10), c = 1)
   scode <- make_stancode(y ~ x, data, family = asym_laplace())
   expect_match2(scode, "target += asym_laplace_lpdf(Y[n] | mu[n], sigma, quantile)")
-  
+
   scode <- make_stancode(bf(y ~ x, quantile = 0.75), data, family = asym_laplace())
   expect_match2(scode, "real<lower=0,upper=1> quantile = 0.75;")
-  
+
   scode <- make_stancode(y | cens(c) ~ x, data, family = asym_laplace())
   expect_match2(scode, "target += asym_laplace_lccdf(Y[n] | mu[n], sigma, quantile)")
-  
+
   scode <- make_stancode(bf(y ~ x, sigma ~ x), data, family = asym_laplace())
   expect_match2(scode, "target += asym_laplace_lpdf(Y[n] | mu[n], sigma[n], quantile)")
-  
-  scode <- make_stancode(bf(y ~ x, quantile = 0.75), data, 
+
+  scode <- make_stancode(bf(y ~ x, quantile = 0.75), data,
                          family = brmsfamily("zero_inflated_asym_laplace"))
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += zero_inflated_asym_laplace_lpdf(Y[n] | mu[n], sigma, quantile, zi)"
   )
 })
@@ -1522,16 +1522,16 @@ test_that("Stan code of addition term 'rate' is correct", {
   data <- data.frame(y = rpois(10, 1), x = rnorm(10), time = 1:10)
   scode <- make_stancode(y | rate(time) ~ x, data, poisson())
   expect_match2(scode, "target += poisson_log_lpmf(Y | mu + log_denom);")
-  
+
   scode <- make_stancode(y | rate(time) ~ x, data, poisson("identity"))
   expect_match2(scode, "target += poisson_lpmf(Y | mu .* denom);")
-  
+
   scode <- make_stancode(y | rate(time) ~ x, data, negbinomial())
   expect_match2(scode, "target += neg_binomial_2_log_lpmf(Y | mu + log_denom, shape * denom);")
-  
+
   scode <- make_stancode(y | rate(time) ~ x, data, brmsfamily("negbinomial2"))
   expect_match2(scode, "target += neg_binomial_2_log_lpmf(Y | mu + log_denom, inv(sigma) * denom);")
-  
+
   scode <- make_stancode(y | rate(time) + cens(1) ~ x, data, geometric())
   expect_match2(scode, "target += neg_binomial_2_lpmf(Y[n] | mu[n] * denom[n], 1 * denom[n]);")
 })
@@ -1541,16 +1541,16 @@ test_that("Stan code of GEV models is correct", {
   scode <- make_stancode(y ~ x, data, gen_extreme_value())
   expect_match2(scode, "target += gen_extreme_value_lpdf(Y[n] | mu[n], sigma, xi)")
   expect_match2(scode, "xi = scale_xi(tmp_xi, Y, mu, sigma)")
-  
+
   scode <- make_stancode(bf(y ~ x, sigma ~ x), data, gen_extreme_value())
   expect_match2(scode, "xi = scale_xi_vector(tmp_xi, Y, mu, sigma)")
-  
+
   scode <- make_stancode(bf(y ~ x, xi ~ x), data, gen_extreme_value())
   expect_match2(scode, "xi[n] = expm1(xi[n])")
-  
+
   scode <- make_stancode(bf(y ~ x, xi = 0), data, gen_extreme_value())
   expect_match2(scode, "real xi = 0;  // shape parameter")
-  
+
   scode <- make_stancode(y | cens(c) ~ x, data, gen_extreme_value())
   expect_match2(scode, "target += gen_extreme_value_lccdf(Y[n] | mu[n], sigma, xi)")
 })
@@ -1563,7 +1563,7 @@ test_that("Stan code of Cox models is correct", {
   expect_match2(scode, "vector[N] cbhaz = Zcbhaz * sbhaz;")
   expect_match2(scode, "lprior += dirichlet_lpdf(sbhaz | con_sbhaz);")
   expect_match2(scode, "simplex[Kbhaz] sbhaz;")
-  
+
   scode <- make_stancode(bform, data, brmsfamily("cox", "identity"))
   expect_match2(scode, "target += cox_lccdf(Y[n] | mu[n], bhaz[n], cbhaz[n]);")
 })
@@ -1592,7 +1592,7 @@ test_that("prior only models are correctly checked", {
 test_that("Stan code of mixture model is correct", {
   data <- data.frame(y = 1:10, x = rnorm(10), c = 1)
   scode <- make_stancode(
-    bf(y ~ x,  sigma2 ~ x), data, 
+    bf(y ~ x,  sigma2 ~ x), data,
     family = mixture(gaussian, gaussian),
     sample_prior = TRUE
   )
@@ -1603,67 +1603,67 @@ test_that("Stan code of mixture model is correct", {
   expect_match2(scode, "ps[2] = log(theta2) + normal_lpdf(Y[n] | mu2[n], sigma2[n]);")
   expect_match2(scode, "target += log_sum_exp(ps);")
   expect_match2(scode, "simplex[2] prior_theta = dirichlet_rng(con_theta);")
-  
+
   data$z <- abs(data$y)
-  scode <- make_stancode(bf(z | weights(c) ~ x, shape1 ~ x, theta1 = 1, theta2 = 2), 
+  scode <- make_stancode(bf(z | weights(c) ~ x, shape1 ~ x, theta1 = 1, theta2 = 2),
                          data = data, mixture(Gamma("log"), weibull))
   expect_match(scode, "data \\{[^\\}]*real<lower=0,upper=1> theta1;")
   expect_match(scode, "data \\{[^\\}]*real<lower=0,upper=1> theta2;")
   expect_match2(scode, "ps[1] = log(theta1) + gamma_lpdf(Y[n] | shape1[n], mu1[n]);")
   expect_match2(scode, "target += weights[n] * log_sum_exp(ps);")
-  
-  scode <- make_stancode(bf(abs(y) | se(c) ~ x), data = data, 
+
+  scode <- make_stancode(bf(abs(y) | se(c) ~ x), data = data,
                          mixture(gaussian, student))
   expect_match2(scode, "ps[1] = log(theta1) + normal_lpdf(Y[n] | mu1[n], se[n]);")
   expect_match2(scode, "ps[2] = log(theta2) + student_t_lpdf(Y[n] | nu2, mu2[n], se[n]);")
-  
+
   fam <- mixture(gaussian, student, exgaussian)
   scode <- make_stancode(bf(y ~ x), data = data, family = fam)
   expect_match(scode, "parameters \\{[^\\}]*real Intercept_mu3;")
-  expect_match2(scode, 
+  expect_match2(scode,
     "ps[2] = log(theta2) + student_t_lpdf(Y[n] | nu2, mu2[n], sigma2);"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "ps[3] = log(theta3) + exp_mod_normal_lpdf(Y[n] | mu3[n] - beta3, sigma3, inv(beta3));"
   )
-  
-  scode <- make_stancode(bf(y ~ x, theta1 ~ x, theta3 ~ x), 
+
+  scode <- make_stancode(bf(y ~ x, theta1 ~ x, theta3 ~ x),
                          data = data, family = fam)
   expect_match2(scode, "log_sum_exp_theta = log(exp(theta1[n]) + exp(theta2[n]) + exp(theta3[n]));")
   expect_match2(scode, "theta2 = rep_vector(0.0, N);")
   expect_match2(scode, "theta3[n] = theta3[n] - log_sum_exp_theta;")
   expect_match2(scode, "ps[1] = theta1[n] + normal_lpdf(Y[n] | mu1[n], sigma1);")
-  
+
   fam <- mixture(cumulative, sratio)
   scode <- make_stancode(y ~ x, data, family = fam)
   expect_match2(scode, "ordered_logistic_lpmf(Y[n] | mu1[n], Intercept_mu1);")
   expect_match2(scode, "sratio_logit_lpmf(Y[n] | mu2[n], disc2, Intercept_mu2);")
-  
+
   # censored mixture model
   fam <- mixture(gaussian, gaussian)
   scode <- make_stancode(y | cens(2, y2 = 2) ~ x, data, fam)
-  expect_match2(scode, 
+  expect_match2(scode,
     "ps[2] = log(theta2) + normal_lccdf(Y[n] | mu2[n], sigma2);"
   )
   expect_match2(scode, paste0(
     "ps[2] = log(theta2) + log_diff_exp(\n",
     "          normal_lcdf(rcens[n] | mu2[n], sigma2),"
   ))
-  
+
   # truncated mixture model
   scode <- make_stancode(y | trunc(3) ~ x, data, fam)
   expect_match2(scode, paste0(
-    "ps[1] = log(theta1) + normal_lpdf(Y[n] | mu1[n], sigma1) -\n", 
+    "ps[1] = log(theta1) + normal_lpdf(Y[n] | mu1[n], sigma1) -\n",
     "        normal_lccdf(lb[n] | mu1[n], sigma1);"
   ))
-  
+
   # non-linear mixture model
-  bform <- bf(y ~ 1) + 
+  bform <- bf(y ~ 1) +
     nlf(mu1 ~ eta^2) +
     nlf(mu2 ~ log(eta) + a) +
     lf(eta + a ~ x) +
     mixture(gaussian, nmix = 2)
-  bprior <- prior(normal(0, 1), nlpar = "eta") + 
+  bprior <- prior(normal(0, 1), nlpar = "eta") +
     prior(normal(0, 1), nlpar = "a")
   scode <- make_stancode(bform, data = data, prior = bprior)
   expect_match2(scode, "mu1[n] = nlp_eta[n] ^ 2;")
@@ -1672,46 +1672,46 @@ test_that("Stan code of mixture model is correct", {
 
 test_that("sparse matrix multiplication is applied correctly", {
   data <- data.frame(y = rnorm(10), x = rnorm(10))
-  
+
   # linear model
   scode <- make_stancode(
-    bf(y ~ x, sparse = TRUE) + lf(sigma ~ x, sparse = TRUE), 
+    bf(y ~ x, sparse = TRUE) + lf(sigma ~ x, sparse = TRUE),
     data, prior = prior(normal(0, 5), coef = "Intercept")
   )
   expect_match2(scode, "wX = csr_extract_w(X);")
-  expect_match2(scode, 
+  expect_match2(scode,
     "mu = csr_matrix_times_vector(rows(X), cols(X), wX, vX, uX, b);"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "uX_sigma[size(csr_extract_u(X_sigma))] = csr_extract_u(X_sigma);"
   )
   expect_match2(scode,
     paste0(
-      "sigma = csr_matrix_times_vector(rows(X_sigma), cols(X_sigma), ", 
+      "sigma = csr_matrix_times_vector(rows(X_sigma), cols(X_sigma), ",
       "wX_sigma, vX_sigma, uX_sigma, b_sigma);"
     )
   )
   expect_match2(scode, "lprior += normal_lpdf(b[1] | 0, 5);")
   expect_match2(scode, "target += normal_lpdf(Y | mu, sigma);")
-  
+
   # non-linear model
   scode <- make_stancode(
-    bf(y ~ a, lf(a ~ x, sparse = TRUE), nl = TRUE), 
+    bf(y ~ a, lf(a ~ x, sparse = TRUE), nl = TRUE),
     data, prior = prior(normal(0, 1), nlpar = a)
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "vX_a[size(csr_extract_v(X_a))] = csr_extract_v(X_a);"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "nlp_a = csr_matrix_times_vector(rows(X_a), cols(X_a), wX_a, vX_a, uX_a, b_a);"
   )
 })
 
 test_that("QR decomposition is included in the Stan code", {
   data <- data.frame(y = rnorm(10), x1 = rnorm(10), x2 = rnorm(10))
-  bform <- bf(y ~ x1 + x2, decomp = "QR") + 
+  bform <- bf(y ~ x1 + x2, decomp = "QR") +
     lf(sigma ~ 0 + x1 + x2, decomp = "QR")
-  
+
   # simple priors
   scode <- make_stancode(bform, data, prior = prior(normal(0, 2)))
   expect_match2(scode, "XQ = qr_thin_Q(Xc) * sqrt(N - 1);")
@@ -1719,7 +1719,7 @@ test_that("QR decomposition is included in the Stan code", {
   expect_match2(scode, "lprior += normal_lpdf(bQ | 0, 2);")
   expect_match2(scode, "XQ * bQ")
   expect_match2(scode, "XR_sigma = qr_thin_R(X_sigma) / sqrt(N - 1);")
-  
+
   # horseshoe prior
   scode <- make_stancode(bform, data, prior = prior(horseshoe(1)))
   expect_match2(scode, "target += std_normal_lpdf(zb);")
@@ -1730,64 +1730,64 @@ test_that("Stan code for Gaussian processes is correct", {
   set.seed(1234)
   dat <- data.frame(y = rnorm(40), x1 = rnorm(40), x2 = rnorm(40),
                     z = factor(rep(3:6, each = 10)))
-  
+
   prior <- prior(gamma(0.1, 0.1), sdgp)
-  scode <- make_stancode(y ~ gp(x1) + gp(x2, by = x1, gr = FALSE), 
+  scode <- make_stancode(y ~ gp(x1) + gp(x2, by = x1, gr = FALSE),
                          dat, prior = prior)
   expect_match2(scode, "lprior += inv_gamma_lpdf(lscale_1[1]")
   expect_match2(scode, "lprior += gamma_lpdf(sdgp_1 | 0.1, 0.1)")
   expect_match2(scode, "gp_pred_2 = gp(Xgp_2, sdgp_2[1], lscale_2[1], zgp_2);")
   expect_match2(scode, "Cgp_2 .* gp_pred_2;")
-  
+
   prior <- prior + prior(normal(0, 1), lscale, coef = gpx1)
-  scode <- make_stancode(y ~ gp(x1) + gp(x2, by = x1, gr = TRUE), 
+  scode <- make_stancode(y ~ gp(x1) + gp(x2, by = x1, gr = TRUE),
                          data = dat, prior = prior)
   expect_match2(scode, "lprior += normal_lpdf(lscale_1[1][1] | 0, 1)")
   expect_match2(scode, "gp_pred_2 = gp(Xgp_2, sdgp_2[1], lscale_2[1], zgp_2);")
   expect_match2(scode, "+ Cgp_2 .* gp_pred_2[Jgp_2]")
-  
+
   # non-isotropic GP
   scode <- make_stancode(y ~ gp(x1, x2, by = z, iso = FALSE), data = dat)
   expect_match2(scode, "lprior += inv_gamma_lpdf(lscale_1[1][2]")
   expect_match2(scode, "lprior += inv_gamma_lpdf(lscale_1[4][2]")
-  
+
   # Suppress Stan parser warnings that can currently not be avoided
-  scode <- make_stancode(y ~ gp(x1, x2) + gp(x1, by = z, gr = FALSE), 
+  scode <- make_stancode(y ~ gp(x1, x2) + gp(x1, by = z, gr = FALSE),
                          dat, silent = TRUE)
   expect_match2(scode, "gp(Xgp_1, sdgp_1[1], lscale_1[1], zgp_1)")
   expect_match2(scode, "mu[Igp_2_2] += Cgp_2_2 .* gp_pred_2_2;")
-  
+
   # approximate GPS
   scode <- make_stancode(
-    y ~ gp(x1, k = 10, c = 5/4) + gp(x2, by = x1, k = 10, c = 5/4), 
+    y ~ gp(x1, k = 10, c = 5/4) + gp(x2, by = x1, k = 10, c = 5/4),
     data = dat
   )
   expect_match2(scode, "lprior += inv_gamma_lpdf(lscale_1")
-  expect_match2(scode, 
+  expect_match2(scode,
     "rgp_1 = sqrt(spd_cov_exp_quad(slambda_1, sdgp_1[1], lscale_1[1])) .* zgp_1;"
   )
   expect_match2(scode, "Cgp_2 .* gp_pred_2[Jgp_2]")
-  
+
   prior <- c(prior(normal(0, 10), lscale, coef = gpx1, nlpar = a),
              prior(gamma(0.1, 0.1), sdgp, nlpar = a),
              prior(normal(0, 1), b, nlpar = a))
-  scode <- make_stancode(bf(y ~ a, a ~ gp(x1), nl = TRUE), 
+  scode <- make_stancode(bf(y ~ a, a ~ gp(x1), nl = TRUE),
                          data = dat, prior = prior)
   expect_match2(scode, "lprior += normal_lpdf(lscale_a_1[1][1] | 0, 10)")
   expect_match2(scode, "lprior += gamma_lpdf(sdgp_a_1 | 0.1, 0.1)")
   expect_match2(scode, "gp(Xgp_a_1, sdgp_a_1[1], lscale_a_1[1], zgp_a_1)")
-  
+
   prior <- prior(gamma(2, 2), lscale, coef = gpx1z5, nlpar = "a")
   scode <- make_stancode(bf(y ~ a, a ~ gp(x1, by = z, gr = TRUE), nl = TRUE),
                          data = dat, prior = prior, silent = TRUE)
-  expect_match2(scode, 
+  expect_match2(scode,
     "nlp_a[Igp_a_1_1] += Cgp_a_1_1 .* gp_pred_a_1_1[Jgp_a_1_1];"
   )
   expect_match2(scode, "gp(Xgp_a_1_3, sdgp_a_1[3], lscale_a_1[3], zgp_a_1_3)")
   expect_match2(scode, "lprior += gamma_lpdf(lscale_a_1[3][1] | 2, 2);")
   expect_match2(scode, "target += std_normal_lpdf(zgp_a_1_3);")
-  
-  # test warnings 
+
+  # test warnings
   prior <- prior(normal(0, 1), lscale)
   expect_warning(
     make_stancode(y ~ gp(x1), data = dat, prior = prior),
@@ -1800,45 +1800,45 @@ test_that("Stan code for SAR models is correct", {
   dat <- data.frame(y = rnorm(10), x = rnorm(10))
   W <- matrix(0, nrow = 10, ncol = 10)
   dat2 <- list(W = W)
-  
+
   scode <- make_stancode(
     y ~ x + sar(W), data = dat,
     prior = prior(normal(0.5, 1), lagsar),
     data2 = dat2
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += normal_lagsar_lpdf(Y | mu, sigma, lagsar, Msar, eigenMsar)"
   )
   expect_match2(scode, "lprior += normal_lpdf(lagsar | 0.5, 1)")
-  
+
   scode <- make_stancode(
-    y ~ x + sar(W, type = "lag"), 
+    y ~ x + sar(W, type = "lag"),
     data = dat, family = student(),
     data2 = dat2
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += student_t_lagsar_lpdf(Y | nu, mu, sigma, lagsar, Msar, eigenMsar)"
   )
-  
+
   scode <- make_stancode(y ~ x + sar(W, type = "error"), data = dat,
                          data2 = dat2)
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += normal_errorsar_lpdf(Y | mu, sigma, errorsar, Msar, eigenMsar)"
   )
-  
+
   scode <- make_stancode(
-    y ~ x + sar(W, "error"), data = dat, family = student(), 
+    y ~ x + sar(W, "error"), data = dat, family = student(),
     prior = prior(beta(2, 3), errorsar),
     data2 = dat2
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += student_t_errorsar_lpdf(Y | nu, mu, sigma, errorsar, Msar, eigenMsar)"
   )
   expect_match2(scode, "lprior += beta_lpdf(errorsar | 2, 3)")
-  
+
   expect_error(
     make_stancode(bf(y ~ sar(W), sigma ~ x), data = dat),
-    "SAR models are not implemented when predicting 'sigma'" 
+    "SAR models are not implemented when predicting 'sigma'"
   )
 })
 
@@ -1847,11 +1847,11 @@ test_that("Stan code for CAR models is correct", {
   edges <- cbind(1:10, 10:1)
   W <- matrix(0, nrow = 10, ncol = 10)
   for (i in seq_len(nrow(edges))) {
-    W[edges[i, 1], edges[i, 2]] <- 1 
+    W[edges[i, 1], edges[i, 2]] <- 1
   }
   rownames(W) <- seq_len(nrow(W))
   dat2 <- list(W = W)
-  
+
   scode <- make_stancode(y ~ x + car(W), dat, data2 = dat2)
   expect_match2(scode, "real sparse_car_lpdf(vector phi")
   expect_match2(scode, "target += sparse_car_lpdf(")
@@ -1862,23 +1862,23 @@ test_that("Stan code for CAR models is correct", {
   expect_match2(scode, "target += sparse_icar_lpdf(")
   expect_match2(scode, "mu[n] += rcar[Jloc[n]]")
   expect_match2(scode, "rcar[Nloc] = - sum(zcar)")
-  
+
   scode <- make_stancode(y ~ x + car(W, type = "icar"), dat, data2 = dat2)
   expect_match2(scode, "target += -0.5 * dot_self(zcar[edges1] - zcar[edges2])")
   expect_match2(scode, "target += normal_lpdf(sum(zcar) | 0, 0.001 * Nloc)")
   expect_match2(scode, "mu[n] += rcar[Jloc[n]]")
   expect_match2(scode, "rcar = zcar * sdcar")
-  
+
   scode <- make_stancode(y ~ x + car(W, type = "bym2"), dat, data2 = dat2)
   expect_match2(scode, "target += -0.5 * dot_self(zcar[edges1] - zcar[edges2])")
   expect_match2(scode, "target += normal_lpdf(sum(zcar) | 0, 0.001 * Nloc)")
   expect_match2(scode, "mu[n] += rcar[Jloc[n]]")
   expect_match2(scode, "lprior += beta_lpdf(rhocar | 1, 1)")
   expect_match2(scode, paste0(
-    "rcar = (sqrt(1 - rhocar) * nszcar + ", 
+    "rcar = (sqrt(1 - rhocar) * nszcar + ",
     "sqrt(rhocar * inv(car_scale)) * zcar) * sdcar"
   ))
-  
+
   # apply a CAR term on a distributional parameter other than 'mu'
   scode <- make_stancode(bf(y ~ x, sigma ~ car(W)), dat, data2 = dat2)
   expect_match2(scode, "real sparse_car_lpdf(vector phi")
@@ -1892,16 +1892,16 @@ test_that("Stan code for skew_normal models is correct", {
   expect_match2(scode, "delta = alpha / sqrt(1 + alpha^2);")
   expect_match2(scode, "omega = sigma / sqrt(1 - sqrt(2 / pi())^2 * delta^2);")
   expect_match2(scode, "mu[n] = mu[n] - omega * delta * sqrt(2 / pi());")
-  
+
   scode <- make_stancode(bf(y ~ x, sigma ~ x), dat, skew_normal())
   expect_match2(scode, "omega[n] = sigma[n] / sqrt(1 - sqrt(2 / pi())^2 * delta^2);")
   expect_match2(scode, "mu[n] = mu[n] - omega[n] * delta * sqrt(2 / pi());")
-  
+
   scode <- make_stancode(bf(y | se(x) ~ x, alpha ~ x), dat, skew_normal())
   expect_match2(scode, "delta[n] = alpha[n] / sqrt(1 + alpha[n]^2);")
   expect_match2(scode, "omega[n] = se[n] / sqrt(1 - sqrt(2 / pi())^2 * delta[n]^2);")
   expect_match2(scode, "mu[n] = mu[n] - omega[n] * delta[n] * sqrt(2 / pi());")
-  
+
   scode <- make_stancode(y ~ x, dat, mixture(skew_normal, nmix = 2))
   expect_match2(scode, "omega1 = sigma1 / sqrt(1 - sqrt(2 / pi())^2 * delta1^2);")
   expect_match2(scode, "mu2[n] = mu2[n] - omega2 * delta2 * sqrt(2 / pi());")
@@ -1910,7 +1910,7 @@ test_that("Stan code for skew_normal models is correct", {
 test_that("Stan code for missing value terms works correctly", {
   dat = data.frame(y = rnorm(10), x = rnorm(10), g = 1:10, z = 1)
   dat$x[c(1, 3, 9)] <- NA
-  
+
   bform <- bf(y ~ mi(x)*g) + bf(x | mi() ~ g) + set_rescor(FALSE)
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "Yl_x[Jmi_x] = Ymi_x;")
@@ -1919,46 +1919,46 @@ test_that("Stan code for missing value terms works correctly", {
 
   bform <- bf(y ~ mi(x) + (mi(x) | g)) + bf(x | mi() ~ 1) + set_rescor(FALSE)
   scode <- make_stancode(bform, dat)
-  expect_match2(scode, 
+  expect_match2(scode,
     "(bsp_y[1] + r_1_y_2[J_1_y[n]]) * Yl_x[n] + r_1_y_1[J_1_y[n]] * Z_1_y_1[n];"
   )
-  
+
   bform <- bf(y ~ a, a ~ mi(x), nl = TRUE) + bf(x | mi() ~ 1) + set_rescor(FALSE)
   bprior <- prior(normal(0, 1), nlpar = "a", resp = "y")
   scode <- make_stancode(bform, dat, prior = bprior)
   expect_match2(scode, "nlp_y_a[n] += (bsp_y_a[1]) * Yl_x[n];")
   expect_match2(scode, "lprior += normal_lpdf(bsp_y_a | 0, 1);")
-  
+
   bform <- bf(y ~ mi(x)*mo(g)) + bf(x | mi() ~ 1) + set_rescor(FALSE)
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "(bsp_y[3]) * Yl_x[n] * mo(simo_y_2, Xmo_y_2[n]);")
-  
+
   bform <- bf(y ~ 1, sigma ~ 1) + bf(x | mi() ~ 1) + set_rescor(TRUE)
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "Yl[n][2] = Yl_x[n];")
   expect_match2(scode, "sigma[n] = transpose([sigma_y[n], sigma_x]);")
   expect_match2(scode, "LSigma[n] = diag_pre_multiply(sigma[n], Lrescor);")
-  
+
   bform <- bf(x | mi() ~ y, family = "lognormal")
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "vector<lower=0>[Nmi] Ymi;")
-  
-  bform <- bf(y ~ I(log(mi(x))) * g) + 
+
+  bform <- bf(y ~ I(log(mi(x))) * g) +
     bf(x | mi() + trunc(lb = 1) ~ y, family = "lognormal")
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "vector<lower=1>[Nmi_x] Ymi_x;")
-  expect_match2(scode, 
-    "(bsp_y[1]) * (log(Yl_x[n])) + (bsp_y[2]) * (log(Yl_x[n])) * Csp_y_1[n]"              
+  expect_match2(scode,
+    "(bsp_y[1]) * (log(Yl_x[n])) + (bsp_y[2]) * (log(Yl_x[n])) * Csp_y_1[n]"
   )
-  
-  bform <- bf(y ~ mi(x)*g) + 
+
+  bform <- bf(y ~ mi(x)*g) +
     bf(x | mi() + cens(z) ~ y, family = "beta")
   scode <- make_stancode(bform, dat)
   expect_match2(scode, "vector<lower=0,upper=1>[Nmi_x] Ymi_x;")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += beta_lpdf(Yl_x[n] | mu_x[n] * phi_x, (1 - mu_x[n]) * phi_x);"
   )
-  
+
   bform <- bf(y | mi() ~ mi(x), shape ~ mi(x), family=weibull()) +
     bf(x| mi() ~ z, family=gaussian()) + set_rescor(FALSE)
   scode <- make_stancode(bform, data = dat)
@@ -1972,7 +1972,7 @@ test_that("Stan code for overimputation works correctly", {
   bform <- bf(y ~ mi(x_x)*g) + bf(x_x | mi(g) ~ 1) + set_rescor(FALSE)
   scode <- make_stancode(bform, dat, sample_prior = "yes")
   expect_match2(scode, "target += normal_lpdf(Yl_xx | mu_xx, sigma_xx)")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += normal_lpdf(Y_xx[Jme_xx] | Yl_xx[Jme_xx], noise_xx[Jme_xx])"
   )
   expect_match2(scode, "vector[N_xx] Yl_xx;")
@@ -1985,8 +1985,8 @@ test_that("Missing value terms can be combined with 'subset'", {
     g1 = sample(1:5, 10, TRUE),
     s = c(FALSE, rep(TRUE, 9))
   )
-  
-  bform <- bf(y ~ mi(x, idx = g1)*mi(z)) + 
+
+  bform <- bf(y ~ mi(x, idx = g1)*mi(z)) +
     bf(x | mi() + index(g2) + subset(s)  ~ 1) +
     bf(z | mi() ~ s) +
     set_rescor(FALSE)
@@ -2004,7 +2004,7 @@ test_that("Stan code for advanced count data distribution is correct", {
   )
   expect_match2(scode, "mu[n] = inv_logit(mu[n]);")
   expect_match2(scode, "target += discrete_weibull_lpmf(Y[n] | mu[n], shape);")
-  
+
   scode <- make_stancode(
     count ~ zAge + zBase * Trt + (1|patient),
     data = epilepsy, family = brmsfamily("com_poisson")
@@ -2016,78 +2016,78 @@ test_that("argument 'stanvars' is handled correctly", {
   bprior <- prior(normal(mean_intercept, 10), class = "Intercept")
   mean_intercept <- 5
   stanvars <- stanvar(mean_intercept)
-  scode <- make_stancode(count ~ Trt, data = epilepsy, 
+  scode <- make_stancode(count ~ Trt, data = epilepsy,
                          prior = bprior, stanvars = stanvars)
   expect_match2(scode, "real mean_intercept;")
-  
+
   # define a multi_normal prior with known covariance matrix
   bprior <- prior(multi_normal(M, V), class = "b")
   stanvars <- stanvar(rep(0, 2), "M", scode = "vector[K] M;") +
-    stanvar(diag(2), "V", scode = "matrix[K, K] V;") 
+    stanvar(diag(2), "V", scode = "matrix[K, K] V;")
   scode <- make_stancode(count ~ Trt + zBase, epilepsy,
                          prior = bprior, stanvars = stanvars)
   expect_match2(scode, "vector[K] M;")
   expect_match2(scode, "matrix[K, K] V;")
-  
+
   # define a hierarchical prior on the regression coefficients
   bprior <- set_prior("normal(0, tau)", class = "b") +
     set_prior("target += normal_lpdf(tau | 0, 10)", check = FALSE)
-  stanvars <- stanvar(scode = "real<lower=0> tau;", 
+  stanvars <- stanvar(scode = "real<lower=0> tau;",
                       block = "parameters")
   scode <- make_stancode(count ~ Trt + zBase, epilepsy,
                          prior = bprior, stanvars = stanvars)
   expect_match2(scode, "real<lower=0> tau;")
   expect_match2(scode, "lprior += normal_lpdf(b | 0, tau);")
-  
+
   # ensure that variables are passed to the likelihood of a threaded model
   foo <- 0.5
   stanvars <- stanvar(foo) +
-    stanvar(scode = "real<lower=0> tau;", 
+    stanvar(scode = "real<lower=0> tau;",
             block = "parameters", pll_args = "real tau")
   scode <- make_stancode(count ~ 1, data = epilepsy, family = poisson(),
                          stanvars = stanvars, threads = threading(2),
                          parse = FALSE)
-  expect_match2(scode, 
+  expect_match2(scode,
     "partial_log_lik_lpmf(int[] seq, int start, int end, data int[] Y, real Intercept, data real foo, real tau)"
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "reduce_sum(partial_log_lik_lpmf, seq, grainsize, Y, Intercept, foo, tau)"
   )
-  
+
   # specify Stan code in the likelihood part of the model block
   stanvars <- stanvar(scode = "mu += 1.0;", block = "likelihood", position = "start")
-  scode <- make_stancode(count ~ Trt + (1|patient), data = epilepsy, 
+  scode <- make_stancode(count ~ Trt + (1|patient), data = epilepsy,
                          stanvars = stanvars)
   expect_match2(scode, "mu += 1.0;")
-  
+
   stanvars <- stanvar(scode = "mu += 1.0;", block = "likelihood", position = "start")
   scode <- make_stancode(count ~ Trt + (1|patient), data = epilepsy,
                          stanvars = stanvars, threads = 2, parse = FALSE)
   expect_match2(scode, "mu += 1.0;")
-  
-  
+
+
   # add transformation at the end of a block
-  stanvars <- stanvar(scode = "r_1_1 = r_1_1 * 2;", 
+  stanvars <- stanvar(scode = "r_1_1 = r_1_1 * 2;",
                       block = "tparameters", position = "end")
   scode <- make_stancode(count ~ Trt + (1 | patient), epilepsy,
                          stanvars = stanvars)
   expect_match2(scode, "r_1_1 = r_1_1 * 2;\n}")
-  
+
   # use the non-centered parameterization for 'b'
   # unofficial feature not supported anymore for the time being
   # bprior <- set_prior("target += normal_lpdf(zb | 0, 1)", check = FALSE) +
   #   set_prior("target += normal_lpdf(tau | 0, 10)", check = FALSE)
   # stanvars <- stanvar(scode = "vector[Kc] zb;", block = "parameters") +
   #   stanvar(scode = "real<lower=0> tau;", block = "parameters") +
-  #   stanvar(scode = "vector[Kc] b = zb * tau;", 
+  #   stanvar(scode = "vector[Kc] b = zb * tau;",
   #           block="tparameters", name = "b")
-  # scode <- make_stancode(count ~ Trt, epilepsy, 
+  # scode <- make_stancode(count ~ Trt, epilepsy,
   #                        prior = bprior, stanvars = stanvars)
   # expect_match2(scode, "vector[Kc] b = zb * tau;")
-  
+
   # stanvars <- stanvar(scode = "vector[Ksp] zbsp;", block = "parameters") +
   #   stanvar(scode = "real<lower=0> tau;", block = "parameters") +
-  #   stanvar(scode = "vector[Ksp] bsp = zbsp * tau;", 
+  #   stanvar(scode = "vector[Ksp] bsp = zbsp * tau;",
   #           block = "tparameters", name = "bsp")
   # scode <- make_stancode(count ~ mo(Base), epilepsy, stanvars = stanvars)
   # expect_match2(scode, "vector[Ksp] bsp = zbsp * tau;")
@@ -2095,7 +2095,7 @@ test_that("argument 'stanvars' is handled correctly", {
 
 test_that("custom families are handled correctly", {
   dat <- data.frame(size = 10, y = sample(0:10, 20, TRUE), x = rnorm(20))
-  
+
   # define a custom beta-binomial family
   log_lik_beta_binomial2 <- function(i, prep) {
     mu <- prep$dpars$mu[, i]
@@ -2119,9 +2119,9 @@ test_that("custom families are handled correctly", {
   beta_binomial2 <- custom_family(
     "beta_binomial2",
     dpars = c("mu", "tau"),
-    links = c("logit", "log"), 
+    links = c("logit", "log"),
     lb = c(NA, 0),
-    type = "int", 
+    type = "int",
     vars = c("vint1[n]", "vreal1[n]"),
     log_lik = log_lik_beta_binomial2,
     posterior_epred = posterior_epred_beta_binomial2,
@@ -2139,7 +2139,7 @@ test_that("custom families are handled correctly", {
   "
   stanvars <- stanvar(scode = stan_funs, block = "functions")
   scode <- make_stancode(
-    y | vint(size) + vreal(size) ~ x, data = dat, family = beta_binomial2, 
+    y | vint(size) + vreal(size) ~ x, data = dat, family = beta_binomial2,
     prior = prior(gamma(0.1, 0.1), class = "tau"),
     stanvars = stanvars
   )
@@ -2147,29 +2147,29 @@ test_that("custom families are handled correctly", {
   expect_match2(scode, "real<lower=0> tau;")
   expect_match2(scode, "mu[n] = inv_logit(mu[n]);")
   expect_match2(scode, "lprior += gamma_lpdf(tau | 0.1, 0.1);")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += beta_binomial2_lpmf(Y[n] | mu[n], tau, vint1[n], vreal1[n]);"
   )
-  
+
   scode <- make_stancode(
-    bf(y | vint(size) + vreal(size) ~ x, tau ~ x), 
+    bf(y | vint(size) + vreal(size) ~ x, tau ~ x),
     data = dat, family = beta_binomial2, stanvars = stanvars
   )
   expect_match2(scode, "tau[n] = exp(tau[n]);")
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += beta_binomial2_lpmf(Y[n] | mu[n], tau[n], vint1[n], vreal1[n]);"
   )
-  
+
   # check custom families in mixture models
   scode <- make_stancode(
-    y | vint(size) + vreal(size) + trials(size) ~ x, data = dat, 
-    family = mixture(binomial, beta_binomial2), 
+    y | vint(size) + vreal(size) + trials(size) ~ x, data = dat,
+    family = mixture(binomial, beta_binomial2),
     stanvars = stanvars
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "log(theta2) + beta_binomial2_lpmf(Y[n] | mu2[n], tau2, vint1[n], vreal1[n]);"
   )
-  
+
   # check custom families in multivariate models
   bform <- bf(
     y | vint(size) + vreal(size) + trials(size) ~ x,
@@ -2179,14 +2179,14 @@ test_that("custom families are handled correctly", {
   expect_match2(scode,
     "target += beta_binomial2_lpmf(Y_y[n] | mu_y[n], tau_y, vint1_y[n], vreal1_y[n]);"
   )
-  
+
   # check vectorized custom families
   beta_binomial2_vec <- custom_family(
     "beta_binomial2_vec",
     dpars = c("mu", "tau"),
-    links = c("logit", "log"), 
+    links = c("logit", "log"),
     lb = c(NA, 0),
-    type = "int", 
+    type = "int",
     vars = c("vint1", "vreal1"),
     loop = FALSE
   )
@@ -2200,12 +2200,12 @@ test_that("custom families are handled correctly", {
   "
   stanvars <- stanvar(scode = stan_funs_vec, block = "functions")
   scode <- make_stancode(
-    y | vint(size) + vreal(size) ~ x, data = dat, 
-    family = beta_binomial2_vec, 
+    y | vint(size) + vreal(size) ~ x, data = dat,
+    family = beta_binomial2_vec,
     prior = prior(gamma(0.1, 0.1), class = "tau"),
     stanvars = stanvars
   )
-  expect_match2(scode, 
+  expect_match2(scode,
     "target += beta_binomial2_vec_lpmf(Y | mu, tau, vint1, vreal1);"
   )
 })
@@ -2225,10 +2225,10 @@ test_that("student-t group-level effects work without errors", {
   expect_match2(scode, "dfm_1 .* (sd_1[1] * (z_1[1]));")
   expect_match2(scode, "lprior += gamma_lpdf(df_1 | 2, 0.1);")
   expect_match2(scode, "target += inv_chi_square_lpdf(udf_1 | df_1);")
-  
+
   bprior <- prior(normal(20, 5), class = df, group = patient)
   scode <- make_stancode(
-    count ~ Trt + (Trt|gr(patient, dist = "st")), 
+    count ~ Trt + (Trt|gr(patient, dist = "st")),
     epilepsy, prior = bprior
   )
   expect_match2(scode,
@@ -2245,7 +2245,7 @@ test_that("centering design matrices can be changed correctly", {
   )
   expect_match2(scode, "mu = X * b;")
   expect_match2(scode, "lprior += normal_lpdf(b[1] | 0, 1);")
-  
+
   bform <- bf(y ~ eta, nl = TRUE) + lf(eta ~ x, center = TRUE)
   scode <- make_stancode(bform, data = dat)
   expect_match2(scode, "nlp_eta = Intercept_eta + Xc_eta * b_eta;")
@@ -2281,23 +2281,23 @@ test_that("threaded Stan code is correct", {
     count = rpois(236, lambda = 20),
     visit = rep(1:4, each = 59),
     patient = factor(rep(1:59, 4)),
-    Age = rnorm(236), 
+    Age = rnorm(236),
     Trt = factor(sample(0:1, 236, TRUE)),
     AgeSD = abs(rnorm(236, 1)),
     Exp = sample(1:5, 236, TRUE),
     volume = rnorm(236),
     gender = factor(c(rep("m", 30), rep("f", 29)))
   )
-  
+
   # only parse models if cmdstan can be found on the system
   cmdstan_version <- try(cmdstanr::cmdstan_version(), silent = TRUE)
   found_cmdstan <- !is(cmdstan_version, "try-error")
   options(
-    brms.parse_stancode = found_cmdstan && not_cran, 
+    brms.parse_stancode = found_cmdstan && not_cran,
     brms.backend = "cmdstanr"
   )
   threads <- threading(2, grainsize = 20)
-  
+
   bform <- bf(
     count ~ Trt*Age + mo(Exp) + s(Age) + offset(Age) + (1+Trt|visit),
     sigma ~ Trt + gp(Age) + gp(volume, by = Trt)
@@ -2310,37 +2310,37 @@ test_that("threaded Stan code is correct", {
   expect_match2(scode, ".* gp_pred_sigma_2_1[Jgp_sigma_2_1[which_gp_sigma_2_1]];")
   expect_match2(scode, "sigma[start_at_one(Igp_sigma_2_2[which_gp_sigma_2_2], start)] +=")
   expect_match2(scode, "target += reduce_sum(partial_log_lik_lpmf, seq, grainsize, Y,")
-  
+
   scode <- make_stancode(
-    visit ~ cs(Trt) + Age, dat, family = sratio(), 
+    visit ~ cs(Trt) + Age, dat, family = sratio(),
     threads = threads,
   )
   expect_match2(scode, "matrix[N, nthres] mucs = Xcs[start:end] * bcs;")
-  expect_match2(scode, 
+  expect_match2(scode,
     "ptarget += sratio_logit_lpmf(Y[nn] | mu[n], disc, Intercept - transpose(mucs[n]));"
   )
-  
+
   scode <- make_stancode(
     bf(visit ~ a * Trt ^ b, a ~ mo(Exp), b ~ s(Age), nl = TRUE),
-    data = dat, family = Gamma("log"), 
+    data = dat, family = Gamma("log"),
     prior = set_prior("normal(0, 1)", nlpar = c("a", "b")),
     threads = threads
   )
   expect_match2(scode, "mu[n] = shape * exp(-(nlp_a[n] * C_1[nn] ^ nlp_b[n]));")
   expect_match2(scode, "ptarget += gamma_lpdf(Y[start:end] | shape, mu);")
-  
+
   bform <- bf(mvbind(count, Exp) ~ Trt) + set_rescor(TRUE)
   scode <- make_stancode(bform, dat, gaussian(), threads = threads)
   expect_match2(scode, "ptarget += multi_normal_cholesky_lpdf(Y[start:end] | Mu, LSigma);")
-  
+
   bform <- bf(brms::mvbind(count, Exp) ~ Trt) + set_rescor(FALSE)
   scode <- make_stancode(bform, dat, gaussian(), threads = threads)
   expect_match2(scode, "target += reduce_sum(partial_log_lik_count_lpmf, seq_count,")
   expect_match2(scode, "target += reduce_sum(partial_log_lik_Exp_lpmf, seq_Exp,")
-  expect_match2(scode, 
+  expect_match2(scode,
     "ptarget += normal_id_glm_lpdf(Y_Exp[start:end] | Xc_Exp[start:end], Intercept_Exp, b_Exp, sigma_Exp);"
   )
-  
+
   scode <- make_stancode(
     visit ~ Trt, dat, family = mixture(poisson(), nmix = 2),
     threads = threading(4, grainsize = 10, static = TRUE)
@@ -2355,10 +2355,10 @@ test_that("Un-normalized Stan code is correct", {
   cmdstan_version <- try(cmdstanr::cmdstan_version(), silent = TRUE)
   found_cmdstan <- !is(cmdstan_version, "try-error")
   options(
-    brms.parse_stancode = found_cmdstan && cmdstan_version >= "2.25" && not_cran, 
+    brms.parse_stancode = found_cmdstan && cmdstan_version >= "2.25" && not_cran,
     brms.backend = "cmdstanr"
   )
-  
+
   scode <- make_stancode(
     count ~ zAge + zBase * Trt + (1|patient) + (1|obs),
     data = epilepsy, family = poisson(),
@@ -2400,9 +2400,9 @@ test_that("Un-normalized Stan code is correct", {
   beta_binomial2 <- custom_family(
       "beta_binomial2",
       dpars = c("mu", "tau"),
-      links = c("logit", "log"), 
+      links = c("logit", "log"),
       lb = c(NA, 0),
-      type = "int", 
+      type = "int",
       vars = c("vint1[n]", "vreal1[n]"),
   )
 
@@ -2415,12 +2415,52 @@ test_that("Un-normalized Stan code is correct", {
   stanvars <- stanvar(scode = stan_funs, block = "functions")
 
   scode <- make_stancode(
-      y | vint(size) + vreal(size) ~ x, data = dat, family = beta_binomial2, 
+      y | vint(size) + vreal(size) ~ x, data = dat, family = beta_binomial2,
       prior = prior(gamma(0.1, 0.1), class = "tau"),
       stanvars = stanvars, normalize = FALSE, backend = "cmdstanr"
   )
   expect_match2(scode, "target += beta_binomial2_lpmf(Y[n] | mu[n], tau, vint1[n], vreal1[n]);")
   expect_match2(scode, "gamma_lupdf(tau | 0.1, 0.1);")
+})
+
+test_that("Canonicalizing Stan code is correct", {
+  # only canonicalize models if cmdstan >= 2.29 can be found on the system
+  cmdstan_version <- try(cmdstanr::cmdstan_version(), silent = TRUE)
+  found_cmdstan <- !is(cmdstan_version, "try-error")
+  skip_if(!found_cmdstan || cmdstan_version < "2.29.0")
+  options(
+    brms.backend = "cmdstanr"
+  )
+  
+  scode <- make_stancode(
+    count ~ zAge + zBase * Trt + (1|patient) + (1|obs),
+    data = epilepsy, family = poisson(),
+    prior = prior(student_t(5,0,10), class = b) +
+      prior(cauchy(0,2), class = sd),
+    normalize = FALSE
+  )
+  expect_match2(scode, "array[M_1] vector[N_1] z_1;")
+  expect_match2(scode, "array[M_2] vector[N_2] z_2;")
+  
+  model <- "
+  data {
+    int a[5];
+    real b[5];
+    vector[5] c[4];
+  }
+  parameters {
+    real d[5];
+    vector[5] e[4];
+  }
+  "
+  stan_file <- cmdstanr::write_stan_file(model)
+  canonicalized_code <- .canonicalize_stan_model(stan_file, overwrite_file = FALSE)
+  expect_match2(canonicalized_code, "array[5] int a;")
+  expect_match2(canonicalized_code, "array[5] real b;")
+  expect_match2(canonicalized_code, "array[4] vector[5] c;")
+  expect_match2(canonicalized_code, "array[5] real d;")
+  expect_match2(canonicalized_code, "array[4] vector[5] e;")
+  
 })
 
 test_that("Normalizing Stan code works correctly", {


### PR DESCRIPTION
See inline comments for a bit of detail. 

I didn't add any tests yet, will wait if you are fine with this first, I used the following to test this:

```r
library("brms")
data("kidney", package = "brms")
head(kidney, n = 3)

fit1 <- brm(formula = time | cens(censored) ~ age * sex + disease 
            + (1 + age | patient), 
            data = kidney, family = lognormal(),
            backend = "cmdstanr")
```

This produces warnings with 2.29, but not on the PR branch.

Fixes #1301 