### PR TITLE
`get_refmodel.brmsfit()`: Add `resp` in `posterior_linpred()`

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -130,7 +130,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     }
     set.seed(refprd_seed)
     lprd_args <- nlist(
-      object = fit, newdata, allow_new_levels = TRUE,
+      object = fit, newdata, resp, allow_new_levels = TRUE,
       sample_new_levels = "gaussian"
     )
     if (is_ordinal(family)) {


### PR DESCRIPTION
This fixes what must have been a long-standing bug (in particular, it must have already existed back then where projpred's default `ref_predfun` was used): In the `ref_predfun`'s `posterior_linpred()` call, the `resp` argument was not included. So the following failed because `posterior_linpred()` returned an array of linear predictors (third margin corresponding to the responses):
```r
library(brms)
options(mc.cores = parallel::detectCores())
data(keeley, package = "piecewiseSEM")
keeley_fit <- brm(
  bf(rich ~ firesev + cover) + bf(cover ~ firesev) + set_rescor(FALSE),
  data = keeley,
  seed = 9512,
  refresh = 0
)

library(projpred)
refm <- get_refmodel(keeley_fit, resp = "rich", brms_seed = 8532)

```
Sorry that this escaped my attention when I defined the custom `ref_predfun` in `get_refmodel.brmsfit()` in an earlier PR.