### PR TITLE
projpred: Make `extract_model_data()` return a factor `y` if necessary

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -111,7 +111,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   
   # allows to handle additional arguments implicitly
   extract_model_data <- function(object, newdata = NULL, ...) {
-    .extract_model_data(object, newdata = newdata, resp = resp, ...)
+    .extract_model_data(object, newdata = newdata, resp = resp,
+                        aug_data = aug_data, ...)
   }
   
   # The default `ref_predfun` from projpred does not set `allow_new_levels`, so
@@ -193,7 +194,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
 
 # auxiliary data required in predictions via projpred
 # @return a named list with slots 'y', 'weights', and 'offset'
-.extract_model_data <- function(object, newdata = NULL, resp = NULL, ...) {
+.extract_model_data <- function(object, newdata = NULL, resp = NULL,
+                                aug_data = FALSE, ...) {
   stopifnot(is.brmsfit(object))
   resp <- validate_resp(resp, object, multiple = FALSE)
   family <- family(object, resp = resp)
@@ -208,14 +210,13 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   data <- current_data(object, newdata, resp = resp, check_response = TRUE)
   attr(data, "terms") <- NULL
   y <- unname(model.response(model.frame(respform, data, na.action = na.pass)))
-  # TODO: uncomment as soon as the 'aug_data' flag is implemented
-  # if (is_like_factor(y)) {
-  #   y_lvls <- levels(as.factor(y))
-  #   if (aug_data && !is_equal(y_lvls, family$cats)) {
-  #     stop2("The augmented data approach requires all response categories to ",
-  #           "be present in the data passed to projpred.")
-  #   }
-  # }
+  if (aug_data) {
+    y_lvls <- levels(as.factor(y))
+    if (!is_equal(y_lvls, family$cats)) {
+      stop2("The augmented data approach requires all response categories to ",
+            "be present in the data passed to projpred.")
+    }
+  }
   
   # extract relevant auxiliary data
   # call standata to ensure the correct format of the data

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -204,7 +204,10 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     formula <- formula$forms[[resp]]
   }
   respform <- brmsterms(formula)$respform
-  data <- current_data(object, newdata, resp = resp, check_response = TRUE)
+  data <- current_data(
+    object, newdata, resp = resp, check_response = TRUE,
+    allow_new_levels = TRUE
+  )
   y <- unname(model.response(model.frame(respform, data, na.action = na.pass)))
   aug_data <- is_categorical(formula) || is_ordinal(formula)
   if (aug_data) {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -111,8 +111,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   
   # allows to handle additional arguments implicitly
   extract_model_data <- function(object, newdata = NULL, ...) {
-    .extract_model_data(object, newdata = newdata, resp = resp,
-                        aug_data = aug_data, ...)
+    .extract_model_data(object, newdata = newdata, resp = resp, ...)
   }
   
   # The default `ref_predfun` from projpred does not set `allow_new_levels`, so


### PR DESCRIPTION
This fixes a bug in `get_refmodel.brmsfit()` for Bernoulli models having a `factor`-like response:
```r
# Data --------------------------------------------------------------------

data("df_gaussian", package = "projpred")
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
set.seed(457211)
icpt <- -0.42
dat$y <- rbinom(nrow(dat), size = 1,
                prob = binomial()$linkinv(icpt + 0.8 * dat$X1))
dat$y <- as.factor(paste0("resp", dat$y))

# Fit ---------------------------------------------------------------------

library(brms)
options(mc.cores = parallel::detectCores(logical = FALSE))
fit <- brm(y ~ X1 + X2 + X3 + X4 + X5,
           data = dat,
           family = bernoulli(),
           control = list(adapt_delta = 0.95,
                          max_treedepth = 15L),
           refresh = 0,
           seed = 1140350788)

# projpred ----------------------------------------------------------------

library(projpred)
refm <- get_refmodel(fit)

d_test_dummy <- list(type = "test",
                     y = refm$y,
                     test_points = seq_along(refm$y),
                     data = refm$fetch_data(),
                     weights = refm$wobs,
                     offset = refm$offset)
vs <- varsel(refm, d_test = d_test_dummy,
             nterms_max = 2, nclusters = 2, nclusters_pred = 3, seed = 123)
## --> Gives:
# Error: New factor levels are not allowed.
# Levels allowed: 'resp0', 'resp1'
# Levels found: '0', '1'
##

cvvs <- cv_varsel(refm, cv_method = "kfold", K = 2,
                  nterms_max = 2, nclusters = 2, nclusters_pred = 3, seed = 123)
## --> Gives:
# Error: New factor levels are not allowed.
# Levels allowed: 'resp0', 'resp1'
# Levels found: '0', '1'
##
```
At first, I tried to set `check_response = FALSE` in the `posterior_linpred()` call which is performed in `ref_predfun()`, but I got the error `formal argument "check_response" matched by multiple actual arguments`. So the changes from this PR are kind of a workaround.

As may be seen from the first of the two commits included here, this fix is not only important for Bernoulli models with a `factor`-like response, but also for the upcoming augmented-data approach in projpred.