### PR TITLE
Support all pp_check types for censored y

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,8 @@ thanks to Urs Kalbitzer. (#1280)
 `projpred`'s K-fold CV. (#1286)
 * Fix response values in `make_standata` for `bernoulli` families
 when only 1s are present thanks to Facundo Munoz. (#1298)
-* Fix `pp_check` for censored responses to work for all plot types. (#1327) 
+* Fix `pp_check` for censored responses to work for all plot types
+thanks to Hayden Rabel. (#1327) 
 
 # brms 2.16.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ thanks to Urs Kalbitzer. (#1280)
 `projpred`'s K-fold CV. (#1286)
 * Fix response values in `make_standata` for `bernoulli` families
 when only 1s are present thanks to Facundo Munoz. (#1298)
+* Fix `pp_check` for censored responses to work for all plot types. (#1327) 
 
 # brms 2.16.3
 

--- a/tests/local/setup_local_tests.R
+++ b/tests/local/setup_local_tests.R
@@ -14,4 +14,6 @@ expect_range <- function(object, lower = -Inf, upper = Inf, ...) {
   testthat::expect_true(all(object >= lower & object <= upper), ...)
 }
 
+SW <- suppressWarnings
+
 context("local tests")

--- a/tests/local/tests.models_new.R
+++ b/tests/local/tests.models_new.R
@@ -76,12 +76,27 @@ test_that("Survival model from brm doc works correctly", {
   me3 <- conditional_effects(fit3, method = "predict")
   expect_ggplot(plot(me3, ask = FALSE)[[2]])
   expect_range(LOO(fit3)$estimates[3, 1], 650, 740)
-
+  
+  # posterior checks of the censored model
+  expect_ggplot(SW(pp_check(
+    fit3, type = 'dens_overlay_grouped', group = 'sex', ndraws = 10
+  )))
+  expect_ggplot(SW(pp_check(
+    fit3, type = 'intervals', x = 'patient', ndraws = NULL
+  )))
+  expect_ggplot(SW(pp_check(fit3, type = 'loo_intervals', ndraws = NULL)))
+  expect_ggplot(SW(pp_check(fit3, type = 'loo_pit_overlay', ndraws = 10)))
+  
   # enables rstan specific functionality
   fit3 <- add_rstan_model(fit3)
   expect_range(LOO(fit3, moment_match = TRUE)$estimates[3, 1], 650, 740)
   bridge <- bridge_sampler(fit3)
   expect_true(is.numeric(bridge$logml))
+  
+  testthat::skip_if_not_installed("ggfortify")
+  expect_ggplot(SW(pp_check(
+    fit3, type = 'km_overlay', status_y = kidney$censored, ndraws = 10
+  )))
 })
 
 test_that("Binomial model from brm doc works correctly", {


### PR DESCRIPTION
Hopefully addresses https://github.com/paul-buerkner/brms/issues/1326.

The diff got a bit confused, it's mostly just moving the `ppc_arg` assignments, like `group,lw,x,psis` above the censor check, then subsetting them there if they are used.

Also allows censored values for the `type = "km_overlay"` plot (https://mc-stan.org/bayesplot/reference/PPC-censoring.html).

`sysdata.rda` just has `brms:::brmsfit_example7` included for the censored tests, I didn't re-run the other example fits.

Re-running some of the examples in the issue:

``` r
library(brms)
data(kidney)
fit <- brm(
  formula = time | cens(censored) ~ age * sex + disease + (1 | patient),
  data = kidney, family = lognormal(),
  prior = c(set_prior("normal(0, 5)", class = "b"),
            set_prior("cauchy(0, 2)", class = "sd")),
  seed = 0, warmup = 1000, iter = 2000, chains = 4,
  control = list(adapt_delta = 0.95)
)
#> Compiling Stan program...
#> Start sampling
#> ...

pp_check(fit, type = 'dens_overlay_grouped', group = 'sex')
#> Using 10 posterior draws for ppc type 'dens_overlay_grouped' by default.
#> Warning: Censored responses are not shown in 'pp_check'.
```

![](https://i.imgur.com/5iblep2.png)

``` r
pp_check(fit, status_y = kidney$censored, type = 'km_overlay')
#> Using 10 posterior draws for ppc type 'km_overlay' by default.
```

![](https://i.imgur.com/yeUfEEP.png)

``` r
pp_check(fit, x = 'patient', group = 'sex', type = 'intervals_grouped')
#> Using all posterior draws for ppc type 'intervals_grouped' by default.
#> Warning: Censored responses are not shown in 'pp_check'.
```

![](https://i.imgur.com/PmOwSdF.png)

``` r
pp_check(fit, type = 'loo_intervals')
#> Using all posterior draws for ppc type 'loo_intervals' by default.
#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.

#> Warning: Censored responses are not shown in 'pp_check'.
#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
```

![](https://i.imgur.com/jhG3hXW.png)

``` r
pp_check(fit, type = 'loo_pit_overlay')
#> Using 10 posterior draws for ppc type 'loo_pit_overlay' by default.
#> Warning: Not enough tail samples to fit the generalized Pareto distribution in some or all columns of matrix of log importance ratios. Skipping the following columns: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ... [66 more not printed].

#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
#> Warning: Censored responses are not shown in 'pp_check'.
#> NOTE: The kernel density estimate assumes continuous observations and is not optimal for discrete observations.
```

![](https://i.imgur.com/tyuVnRB.png)

``` r
pp_check(fit, type = 'loo_pit_qq')
#> Using 10 posterior draws for ppc type 'loo_pit_qq' by default.
#> Warning: Not enough tail samples to fit the generalized Pareto distribution in some or all columns of matrix of log importance ratios. Skipping the following columns: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ... [66 more not printed].
#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
#> Warning: Censored responses are not shown in 'pp_check'.
```

![](https://i.imgur.com/CimKbs7.png)

<sup>Created on 2022-03-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>