### PR TITLE
Fix PR #1314

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -214,14 +214,6 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     allow_new_levels = TRUE
   )
   y <- unname(model.response(model.frame(respform, data, na.action = na.pass)))
-  aug_data <- is_categorical(formula) || is_ordinal(formula)
-  if (aug_data) {
-    y_lvls <- levels(as.factor(y))
-    if (!is_equal(y_lvls, get_cats(formula))) {
-      stop2("The augmented data approach requires all response categories to ",
-            "be present in the data passed to projpred.")
-    }
-  }
 
   # extract relevant auxiliary data
   # call standata to ensure the correct format of the data


### PR DESCRIPTION
In PR #1314, I didn't realize that your changes are not quite equivalent to my original code: The check which is now performed in lines https://github.com/paul-buerkner/brms/blob/6b3c626672a1bf25514da4b7268dedfe7add9de0/R/projpred.R#L218-L224 of `brms:::.extract_model_data()` fails for non-factor responses (of a categorical or ordinal model) if `newdata` does not contain all unique values from the original dataset. That's why I performed that check in `get_refmodel.brmsfit()` based on the original dataset (lines https://github.com/paul-buerkner/brms/blob/55490722db4346fe6a3ed510f4054e584d6f5ca6/R/projpred.R#L119-L122), but in [this comment](https://github.com/paul-buerkner/brms/pull/1314#issuecomment-1065947185) I forgot about non-factor responses. Sorry for that.

With this PR, I decided to omit that check completely as it is error-prone and because I will perform it in a more general way within projpred.

Btw, I saw that PR #1318 trimmed all trailing whitespace, but `brms.Rproj` does not have `StripTrailingWhitespace: Yes`. So when using RStudio's indentation mechanism, the current `brms.Rproj` might introduce new trailing whitespace.
