### PR TITLE
Document option `cmdstanr_write_stan_file_dir` for `update.brmsfit()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,4 +93,4 @@ Additional_repositories:
 VignetteBuilder:
     knitr,
     R.rsp
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/R/update.R
+++ b/R/update.R
@@ -62,7 +62,6 @@
 #'                       file = "fit_cmdstanr")
 #'   upd_cmdstanr <- update(fit_cmdstanr,
 #'                          formula. = rate ~ conc)
-#'   file.remove("fit_cmdstanr.rds")
 #' }
 #' }
 #'

--- a/R/update.R
+++ b/R/update.R
@@ -14,6 +14,13 @@
 #'   arguments to be ignored.
 #' @param ... Other arguments passed to \code{\link{brm}}.
 #'
+#' @details When updating a \code{brmsfit} created with the \pkg{cmdstanr}
+#'   backend in a different \R session, a recompilation will be triggered
+#'   because by default, \pkg{cmdstanr} writes the model executable to a
+#'   temporary directory. To avoid that, set option
+#'   \code{"cmdstanr_write_stan_file_dir"} to a path of your choice before
+#'   creating the original \code{brmsfit} (see section 'Examples' below).
+#'
 #' @examples
 #' \dontrun{
 #' fit1 <- brm(time | cens(censored) ~ age * sex + disease + (1|patient),
@@ -34,6 +41,29 @@
 #' fit4 <- update(fit1, family = weibull(), init = "0",
 #'                prior = set_prior("normal(0,5)"))
 #' summary(fit4)
+#'
+#' ## to avoid a recompilation when updating a 'cmdstanr'-backend fit in a fresh
+#' ## R session, set option 'cmdstanr_write_stan_file_dir' before creating the
+#' ## initial 'brmsfit'
+#' ## CAUTION: the following code creates some permanent files (two
+#' ## 'model_<hash>.stan' files and one 'model_<hash>(.exe)' executable) in the
+#' ## current working directory, additionally to file 'fit_cmdstanr.rds' (which
+#' ## is deleted afterwards)
+#' if (!file.exists("fit_cmdstanr.rds")) {
+#'   options(cmdstanr_write_stan_file_dir = getwd())
+#'   fit_cmdstanr <- brm(rate ~ conc + state,
+#'                       data = Puromycin,
+#'                       backend = "cmdstanr",
+#'                       file = "fit_cmdstanr")
+#'   # now restart the R session and run the following (after attaching 'brms')
+#'   fit_cmdstanr <- brm(rate ~ conc + state,
+#'                       data = Puromycin,
+#'                       backend = "cmdstanr",
+#'                       file = "fit_cmdstanr")
+#'   upd_cmdstanr <- update(fit_cmdstanr,
+#'                          formula. = rate ~ conc)
+#'   file.remove("fit_cmdstanr.rds")
+#' }
 #' }
 #'
 #' @export

--- a/R/update.R
+++ b/R/update.R
@@ -45,24 +45,25 @@
 #' ## to avoid a recompilation when updating a 'cmdstanr'-backend fit in a fresh
 #' ## R session, set option 'cmdstanr_write_stan_file_dir' before creating the
 #' ## initial 'brmsfit'
-#' ## CAUTION: the following code creates some permanent files (two
-#' ## 'model_<hash>.stan' files and one 'model_<hash>(.exe)' executable) in the
-#' ## current working directory, additionally to file 'fit_cmdstanr.rds' (which
-#' ## is deleted afterwards)
-#' if (!file.exists("fit_cmdstanr.rds")) {
-#'   options(cmdstanr_write_stan_file_dir = getwd())
-#'   fit_cmdstanr <- brm(rate ~ conc + state,
-#'                       data = Puromycin,
-#'                       backend = "cmdstanr",
-#'                       file = "fit_cmdstanr")
-#'   # now restart the R session and run the following (after attaching 'brms')
-#'   fit_cmdstanr <- brm(rate ~ conc + state,
-#'                       data = Puromycin,
-#'                       backend = "cmdstanr",
-#'                       file = "fit_cmdstanr")
-#'   upd_cmdstanr <- update(fit_cmdstanr,
-#'                          formula. = rate ~ conc)
-#' }
+#' ## CAUTION: the following code creates some files in the current working
+#' ## directory: two 'model_<hash>.stan' files, one 'model_<hash>(.exe)'
+#' ## executable, and one 'fit_cmdstanr_<some_number>.rds' file
+#' set.seed(7)
+#' fname <- paste0("fit_cmdstanr_", sample.int(.Machine$integer.max, 1))
+#' options(cmdstanr_write_stan_file_dir = getwd())
+#' fit_cmdstanr <- brm(rate ~ conc + state,
+#'                     data = Puromycin,
+#'                     backend = "cmdstanr",
+#'                     file = fname)
+#' # now restart the R session and run the following (after attaching 'brms')
+#' set.seed(7)
+#' fname <- paste0("fit_cmdstanr_", sample.int(.Machine$integer.max, 1))
+#' fit_cmdstanr <- brm(rate ~ conc + state,
+#'                     data = Puromycin,
+#'                     backend = "cmdstanr",
+#'                     file = fname)
+#' upd_cmdstanr <- update(fit_cmdstanr,
+#'                        formula. = rate ~ conc)
 #' }
 #'
 #' @export

--- a/man/AsymLaplace.Rd
+++ b/man/AsymLaplace.Rd
@@ -40,12 +40,10 @@ rasym_laplace(n, mu = 0, sigma = 1, quantile = 0.5)
 \item{quantile}{Asymmetry parameter corresponding to quantiles
 in quantile regression (hence the name).}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{p}{Vector of probabilities.}
 

--- a/man/BetaBinomial.Rd
+++ b/man/BetaBinomial.Rd
@@ -22,12 +22,10 @@ rbeta_binomial(n, size, mu, phi)
 
 \item{phi}{Vector of precisions.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{n}{Number of draws to sample from the distribution.}
 }

--- a/man/Dirichlet.Rd
+++ b/man/Dirichlet.Rd
@@ -16,8 +16,6 @@ rdirichlet(n, alpha)
 \item{alpha}{Matrix of positive shape parameters. Each row corresponds to one
 probability vector.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
-
 \item{n}{Number of draws to sample from the distribution.}
 }
 \description{

--- a/man/ExGaussian.Rd
+++ b/man/ExGaussian.Rd
@@ -22,12 +22,10 @@ rexgaussian(n, mu, sigma, beta)
 
 \item{beta}{Vector of scales of the exponential component.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{n}{Number of draws to sample from the distribution.}
 }

--- a/man/Frechet.Rd
+++ b/man/Frechet.Rd
@@ -25,12 +25,10 @@ rfrechet(n, loc = 0, scale = 1, shape = 1)
 
 \item{shape}{Vector of shapes.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{p}{Vector of probabilities.}
 

--- a/man/GenExtremeValue.Rd
+++ b/man/GenExtremeValue.Rd
@@ -29,12 +29,10 @@ rgen_extreme_value(n, mu = 0, sigma = 1, xi = 0)
 
 \item{xi}{Vector of shapes.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{n}{Number of draws to sample from the distribution.}
 }

--- a/man/Hurdle.Rd
+++ b/man/Hurdle.Rd
@@ -29,18 +29,14 @@ dhurdle_lognormal(x, mu, sigma, hu, log = FALSE)
 phurdle_lognormal(q, mu, sigma, hu, lower.tail = TRUE, log.p = FALSE)
 }
 \arguments{
-\item{x}{Vector of quantiles.}
+\item{x, q}{Vector of quantiles.}
 
 \item{hu}{hurdle probability}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
-
-\item{q}{Vector of quantiles.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{mu, lambda}{location parameter}
 

--- a/man/InvGaussian.Rd
+++ b/man/InvGaussian.Rd
@@ -20,12 +20,10 @@ rinv_gaussian(n, mu = 1, shape = 1)
 
 \item{shape}{Vector of shapes.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{n}{Number of draws to sample from the distribution.}
 }

--- a/man/LogisticNormal.Rd
+++ b/man/LogisticNormal.Rd
@@ -21,8 +21,6 @@ each row is taken to be a quantile.}
 \item{refcat}{A single integer indicating the reference category.
 Defaults to \code{1}.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
-
 \item{check}{Logical; Indicates whether several input checks
 should be performed. Defaults to \code{FALSE} to improve
 efficiency.}

--- a/man/MultiNormal.Rd
+++ b/man/MultiNormal.Rd
@@ -18,8 +18,6 @@ each row is taken to be a quantile.}
 
 \item{Sigma}{Covariance matrix.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
-
 \item{check}{Logical; Indicates whether several input checks
 should be performed. Defaults to \code{FALSE} to improve
 efficiency.}

--- a/man/MultiStudentT.Rd
+++ b/man/MultiStudentT.Rd
@@ -20,8 +20,6 @@ each row is taken to be a quantile.}
 
 \item{Sigma}{Covariance matrix.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
-
 \item{check}{Logical; Indicates whether several input checks
 should be performed. Defaults to \code{FALSE} to improve
 efficiency.}

--- a/man/Shifted_Lognormal.Rd
+++ b/man/Shifted_Lognormal.Rd
@@ -39,12 +39,10 @@ rshifted_lnorm(n, meanlog = 0, sdlog = 1, shift = 0)
 
 \item{shift}{Vector of shifts.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{p}{Vector of probabilities.}
 

--- a/man/SkewNormal.Rd
+++ b/man/SkewNormal.Rd
@@ -58,12 +58,10 @@ If \code{NULL} (the default), will be computed internally.}
 \item{omega}{Optional vector of scale values.
 If \code{NULL} (the default), will be computed internally.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{p}{Vector of probabilities.}
 

--- a/man/VonMises.Rd
+++ b/man/VonMises.Rd
@@ -20,12 +20,10 @@ rvon_mises(n, mu, kappa)
 
 \item{kappa}{Vector of precision values.}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{acc}{Accuracy of numerical approximations.}
 

--- a/man/Wiener.Rd
+++ b/man/Wiener.Rd
@@ -28,8 +28,6 @@ rwiener(
 )
 }
 \arguments{
-\item{x}{Vector of quantiles.}
-
 \item{alpha}{Boundary separation parameter.}
 
 \item{tau}{Non-decision time parameter.}
@@ -42,8 +40,6 @@ rwiener(
 If no character vector, it is coerced to logical
 where \code{TRUE} indicates \code{"upper"} and
 \code{FALSE} indicates \code{"lower"}.}
-
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{backend}{Name of the package to use as backend for the computations.
 Either \code{"Rwiener"} (the default) or \code{"rtdists"}.

--- a/man/ZeroInflated.Rd
+++ b/man/ZeroInflated.Rd
@@ -43,18 +43,14 @@ dzero_inflated_beta(x, shape1, shape2, zi, log = FALSE)
 pzero_inflated_beta(q, shape1, shape2, zi, lower.tail = TRUE, log.p = FALSE)
 }
 \arguments{
-\item{x}{Vector of quantiles.}
+\item{x, q}{Vector of quantiles.}
 
 \item{zi}{zero-inflation probability}
 
-\item{log}{Logical; If \code{TRUE}, values are returned on the log scale.}
-
-\item{q}{Vector of quantiles.}
+\item{log, log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{lower.tail}{Logical; If \code{TRUE} (default), return P(X <= x).
 Else, return P(X > x) .}
-
-\item{log.p}{Logical; If \code{TRUE}, values are returned on the log scale.}
 
 \item{mu, lambda}{location parameter}
 

--- a/man/update.brmsfit.Rd
+++ b/man/update.brmsfit.Rd
@@ -58,24 +58,25 @@ summary(fit4)
 ## to avoid a recompilation when updating a 'cmdstanr'-backend fit in a fresh
 ## R session, set option 'cmdstanr_write_stan_file_dir' before creating the
 ## initial 'brmsfit'
-## CAUTION: the following code creates some permanent files (two
-## 'model_<hash>.stan' files and one 'model_<hash>(.exe)' executable) in the
-## current working directory, additionally to file 'fit_cmdstanr.rds' (which
-## is deleted afterwards)
-if (!file.exists("fit_cmdstanr.rds")) {
-  options(cmdstanr_write_stan_file_dir = getwd())
-  fit_cmdstanr <- brm(rate ~ conc + state,
-                      data = Puromycin,
-                      backend = "cmdstanr",
-                      file = "fit_cmdstanr")
-  # now restart the R session and run the following (after attaching 'brms')
-  fit_cmdstanr <- brm(rate ~ conc + state,
-                      data = Puromycin,
-                      backend = "cmdstanr",
-                      file = "fit_cmdstanr")
-  upd_cmdstanr <- update(fit_cmdstanr,
-                         formula. = rate ~ conc)
-}
+## CAUTION: the following code creates some files in the current working
+## directory: two 'model_<hash>.stan' files, one 'model_<hash>(.exe)'
+## executable, and one 'fit_cmdstanr_<some_number>.rds' file
+set.seed(7)
+fname <- paste0("fit_cmdstanr_", sample.int(.Machine$integer.max, 1))
+options(cmdstanr_write_stan_file_dir = getwd())
+fit_cmdstanr <- brm(rate ~ conc + state,
+                    data = Puromycin,
+                    backend = "cmdstanr",
+                    file = fname)
+# now restart the R session and run the following (after attaching 'brms')
+set.seed(7)
+fname <- paste0("fit_cmdstanr_", sample.int(.Machine$integer.max, 1))
+fit_cmdstanr <- brm(rate ~ conc + state,
+                    data = Puromycin,
+                    backend = "cmdstanr",
+                    file = fname)
+upd_cmdstanr <- update(fit_cmdstanr,
+                       formula. = rate ~ conc)
 }
 
 }

--- a/man/update.brmsfit.Rd
+++ b/man/update.brmsfit.Rd
@@ -26,6 +26,14 @@ arguments to be ignored.}
 \description{
 This method allows to update an existing \code{brmsfit} object.
 }
+\details{
+When updating a \code{brmsfit} created with the \pkg{cmdstanr}
+  backend in a different \R session, a recompilation will be triggered
+  because by default, \pkg{cmdstanr} writes the model executable to a
+  temporary directory. To avoid that, set option
+  \code{"cmdstanr_write_stan_file_dir"} to a path of your choice before
+  creating the original \code{brmsfit} (see section 'Examples' below).
+}
 \examples{
 \dontrun{
 fit1 <- brm(time | cens(censored) ~ age * sex + disease + (1|patient),
@@ -46,6 +54,29 @@ summary(fit3)
 fit4 <- update(fit1, family = weibull(), init = "0",
                prior = set_prior("normal(0,5)"))
 summary(fit4)
+
+## to avoid a recompilation when updating a 'cmdstanr'-backend fit in a fresh
+## R session, set option 'cmdstanr_write_stan_file_dir' before creating the
+## initial 'brmsfit'
+## CAUTION: the following code creates some permanent files (two
+## 'model_<hash>.stan' files and one 'model_<hash>(.exe)' executable) in the
+## current working directory, additionally to file 'fit_cmdstanr.rds' (which
+## is deleted afterwards)
+if (!file.exists("fit_cmdstanr.rds")) {
+  options(cmdstanr_write_stan_file_dir = getwd())
+  fit_cmdstanr <- brm(rate ~ conc + state,
+                      data = Puromycin,
+                      backend = "cmdstanr",
+                      file = "fit_cmdstanr")
+  # now restart the R session and run the following (after attaching 'brms')
+  fit_cmdstanr <- brm(rate ~ conc + state,
+                      data = Puromycin,
+                      backend = "cmdstanr",
+                      file = "fit_cmdstanr")
+  upd_cmdstanr <- update(fit_cmdstanr,
+                         formula. = rate ~ conc)
+  file.remove("fit_cmdstanr.rds")
+}
 }
 
 }

--- a/man/update.brmsfit.Rd
+++ b/man/update.brmsfit.Rd
@@ -75,7 +75,6 @@ if (!file.exists("fit_cmdstanr.rds")) {
                       file = "fit_cmdstanr")
   upd_cmdstanr <- update(fit_cmdstanr,
                          formula. = rate ~ conc)
-  file.remove("fit_cmdstanr.rds")
 }
 }
 


### PR DESCRIPTION
This documents how cmdstanr's option `cmdstanr_write_stan_file_dir` can be used to avoid a recompilation when calling `update.brmsfit()` on a cmdstanr-backend fit in a fresh R session, thereby solving #1135 completely (without the need for further changes in cmdstanr).

I wasn't sure how to clean up the files which are currently created permanently by the new example (two `model_<hash>.stan` files and one `model_<hash>(.exe)` executable). Deleting all regexp'ed `^model_.*\\.stan` files and corresponding executables after running the example would be dangerous. Less dangerous alternatives would be to

1. diff the list of files before and after running the new example and delete all files created in between;
2. extend the `if (!file.exists("fit_cmdstanr.rds"))` condition to only run the new example if no `^model_.*\\.stan` files and no such executables exist in the current working directory. Then after running the example, we could simply remove all `^model_.*\\.stan` files and corresponding executables.

What do you think?

**EDIT:** Clarified the wording for cleaning up the files.
