### PR TITLE
Fix documentation for `...` in `kfold.brmsfit()`

### DIFF
--- a/R/kfold.R
+++ b/R/kfold.R
@@ -38,6 +38,7 @@
 #' @param future_args A list of further arguments passed to
 #'   \code{\link[future:future]{future}} for additional control over parallel
 #'   execution if activated.
+#' @param ... Further arguments passed to \code{\link{brm}}.
 #'
 #' @return \code{kfold} returns an object that has a similar structure as the
 #'   objects returned by the \code{loo} and \code{waic} methods and

--- a/brms.Rproj
+++ b/brms.Rproj
@@ -4,7 +4,6 @@ RestoreWorkspace: Default
 SaveWorkspace: Default
 AlwaysSaveHistory: Default
 
-StripTrailingWhitespace: Yes
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes
 NumSpacesForTab: 2
@@ -12,6 +11,8 @@ Encoding: UTF-8
 
 RnwWeave: knitr
 LaTeX: pdfLaTeX
+
+StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes

--- a/man/kfold.brmsfit.Rd
+++ b/man/kfold.brmsfit.Rd
@@ -23,10 +23,7 @@
 \arguments{
 \item{x}{A \code{brmsfit} object.}
 
-\item{...}{More \code{brmsfit} objects or further arguments
-passed to the underlying post-processing functions.
-In particular, see \code{\link{prepare_predictions}} for further
-supported arguments.}
+\item{...}{Further arguments passed to \code{\link{brm}}.}
 
 \item{K}{The number of subsets of equal (if possible) size
 into which the data will be partitioned for performing


### PR DESCRIPTION
This fixes the documentation for `...` in `kfold.brmsfit()` because `kfold.brmsfit()` allows to pass arguments to `brm()` (see <https://github.com/paul-buerkner/brms/issues/1378#issue-1300775618>).

Here, I have copied the `...` documentation from `brm_multiple()` instead of inheriting it from `loo.brmsfit()`. But I'm not sure if it actually contains everything that is needed for `...` in `kfold.brmsfit()`. You might have to mention more functions (apart from `brm()`) that can get arguments from `...`.