### PR TITLE
Minor improvements for `get_refmodel.brmsfit()`

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -94,7 +94,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   not_ok_term_types <- setdiff(all_term_types(), c("fe", "re", "offset", "sm"))
   if (any(not_ok_term_types %in% names(bterms$dpars$mu))) {
-    stop2("Projpred only supports standard multilevel terms and offsets.")
+    stop2("Projpred only supports standard multilevel and smoothing terms as ",
+          "well as offsets.")
   }
 
   # only use the raw formula for selection of terms

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -49,6 +49,7 @@
 get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
                                  cvfun = NULL, brms_seed = NULL, ...) {
   require_package("projpred")
+  object <- restructure(object)
   resp <- validate_resp(resp, object, multiple = FALSE)
   formula <- formula(object)
   if (!is.null(resp)) {

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -143,8 +143,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
 
   if (utils::packageVersion("projpred") <= "2.0.2" && NROW(object$ranef)) {
-    warning2("Under projpred version <= 2.0.2, projpred's K-fold CV results ",
-             "may not be reproducible for multilevel brms reference models.")
+    warning2("In projpred versions <= 2.0.2, projpred's K-fold CV results may ",
+             "not be reproducible for multilevel brms reference models.")
   }
 
   # extract a list of K-fold sub-models


### PR DESCRIPTION
This is just a collection of three minor improvements for `get_refmodel.brmsfit()`.

Note that a local `R CMD check` gave:
```
❯ checking Rd \usage sections ... WARNING
  Undocumented arguments in documentation object 'Wiener'
    ‘x’
  
  Functions with \usage entries need to have the appropriate \alias
  entries, and all their arguments documented.
  The \usage entries must correspond to syntactically valid R code.
  See chapter ‘Writing R documentation files’ in the ‘Writing R
  Extensions’ manual.
```
and the following test failure:
```
── Error (tests.make_stancode.R:470:3): self-defined functions appear in the Stan code ──
Error in `rstan::stanc(model_code = model, ...)`: failed to parse Stan model 'model' due to the above error.
```
However, after commenting lines https://github.com/paul-buerkner/brms/blob/309191e1efd84760c3506e88d9a2de797c107a15/tests/testthat/tests.make_stancode.R#L469-L475, at least the tests passed (the Wiener warning still appeared, of course).