### PR TITLE
Fully delegate canonicalisation to cmdstanr

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: macOS-latest,   r: 'release', rtools: ''}
+          - {os: windows-latest, r: 'release', rtools: '42'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release', rtools: ''}
+          - {os: ubuntu-latest,   r: 'release', rtools: ''}
+          - {os: ubuntu-latest,   r: 'oldrel-1', rtools: ''}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -35,9 +35,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@v2.2.6
         with:
           r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.rtools }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
 Suggests:
     testthat (>= 0.9.1),
     emmeans (>= 1.4.2),
-    cmdstanr (>= 0.4.0),
+    cmdstanr (>= 0.5.0),
     projpred (>= 2.0.0),
     RWiener,
     rtdists,

--- a/R/backends.R
+++ b/R/backends.R
@@ -621,10 +621,11 @@ file_refit_options <- function() {
 
 .canonicalize_stan_model <- function(stan_file, overwrite_file = TRUE) {
   cmdstan_mod <- cmdstanr::cmdstan_model(stan_file, compile = FALSE)
-  out <- capture.output(
+  out <- utils::capture.output(
     cmdstan_mod$format(canonicalize = list("deprecations",
                                           "braces",
                                           "parentheses"),
-                      overwrite_file = overwrite_file))
+                      overwrite_file = overwrite_file,
+                      backup = FALSE))
   paste0(out, collapse = "\n")
 }

--- a/R/backends.R
+++ b/R/backends.R
@@ -620,32 +620,11 @@ file_refit_options <- function() {
 }
 
 .canonicalize_stan_model <- function(stan_file, overwrite_file = TRUE) {
-  if (os_is_windows()) {
-    stanc_cmd <- "bin/stanc.exe"
-  } else {
-    stanc_cmd <- "bin/stanc"
-  }
-  stanc_flags <- c(
-    "--auto-format",
-    "--canonicalize=deprecations,braces,parentheses"
-  )
-  if (cmdstanr::cmdstan_version() >= "2.29.0") {
-    require_package("processx")
-    res <- processx::run(
-      command = stanc_cmd,
-      args = c(stan_file, stanc_flags),
-      wd = cmdstanr::cmdstan_path(),
-      echo = FALSE,
-      echo_cmd = FALSE,
-      spinner = FALSE,
-      stderr_callback = function(x, p) {
-        message(x)
-      },
-      error_on_status = TRUE
-    )
-    if (overwrite_file) {
-      cat(res$stdout, file = stan_file, sep = "\n")
-    }
-  }
-  res$stdout
+  cmdstan_mod <- cmdstanr::cmdstan_model(stan_file, compile = FALSE)
+  out <- capture.output(
+    cmdstan_mod$format(canonicalize = list("deprecations",
+                                          "braces",
+                                          "parentheses"),
+                      overwrite_file = overwrite_file))
+  paste0(out, collapse = "\n")
 }


### PR DESCRIPTION
This PR updates the Stan model canonicalisation process to be fully delegated to `cmdstanr`, rather than manually calling `stanc`. This is to allow for compatibility with the new WSL functionality in `cmdstanr`, (which is unfortunately not currently compatible with `brms` due to the manual `stanc` call)

Let me know if I can add any other clarifications/changes here!

Cheers,
Andrew