### PR TITLE
Fix numerical issue in `softmax()`

### DIFF
--- a/R/brmsfit-helpers.R
+++ b/R/brmsfit-helpers.R
@@ -474,7 +474,7 @@ get_theta <- function(prep, i = NULL) {
     }
     theta <- abind(theta, along = 3)
     for (n in seq_len(dim(theta)[2])) {
-      theta[, n, ] <- softmax(slice(theta, 2, n))
+      theta[, n, ] <- exp(log_softmax(slice(theta, 2, n)))
     }
     if (length(i) == 1L) {
       dim(theta) <- dim(theta)[c(1, 3)]

--- a/R/brmsfit-helpers.R
+++ b/R/brmsfit-helpers.R
@@ -474,7 +474,7 @@ get_theta <- function(prep, i = NULL) {
     }
     theta <- abind(theta, along = 3)
     for (n in seq_len(dim(theta)[2])) {
-      theta[, n, ] <- exp(log_softmax(slice(theta, 2, n)))
+      theta[, n, ] <- softmax(slice(theta, 2, n))
     }
     if (length(i) == 1L) {
       dim(theta) <- dim(theta)[c(1, 3)]

--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -526,8 +526,8 @@
 #'   they are internally normalized to form a probability vector.
 #'   If one seeks to predict the mixing proportions, all but
 #'   one of the them has to be predicted, while the remaining one is used
-#'   as the reference category to identify the model. The \code{softmax}
-#'   function is applied on the linear predictor terms to form a
+#'   as the reference category to identify the model. The so-called 'softmax'
+#'   transformation is applied on the linear predictor terms to form a
 #'   probability vector.
 #'
 #'   For more information on mixture models, see

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -2088,10 +2088,9 @@ inv_link_categorical <- function(x, refcat = 1, log = FALSE) {
   if (!is.null(refcat)) {
     x <- insert_refcat(x, refcat = refcat)
   }
-  if (log) {
-    out <- log_softmax(x)
-  } else {
-    out <- softmax(x)
+  out <- log_softmax(x)
+  if (!log) {
+    out <- exp(out)
   }
   out
 }

--- a/R/numeric-helpers.R
+++ b/R/numeric-helpers.R
@@ -173,19 +173,6 @@ fabs <- function(x) {
   abs(x)
 }
 
-softmax <- function(x) {
-  ndim <- length(dim(x))
-  if (ndim <= 1) {
-    x <- matrix(x, nrow = 1)
-    ndim <- length(dim(x))
-  }
-  x <- exp(x)
-  dim_noncat <- dim(x)[-ndim]
-  marg_noncat <- seq_along(dim(x))[-ndim]
-  catsum <- array(apply(x, marg_noncat, sum), dim = dim_noncat)
-  sweep(x, marg_noncat, catsum, "/")
-}
-
 log_softmax <- function(x) {
   ndim <- length(dim(x))
   if (ndim <= 1) {

--- a/R/numeric-helpers.R
+++ b/R/numeric-helpers.R
@@ -185,6 +185,11 @@ log_softmax <- function(x) {
   sweep(x, marg_noncat, catsum, "-")
 }
 
+softmax <- function(x) {
+  # log_softmax is more numerically stable #1401
+  exp(log_softmax(x))
+}
+
 inv_odds <- function(x) {
   x / (1 + x)
 }

--- a/man/brmsformula.Rd
+++ b/man/brmsformula.Rd
@@ -555,8 +555,8 @@ models for all parameters of the assumed response distribution.
   they are internally normalized to form a probability vector.
   If one seeks to predict the mixing proportions, all but
   one of the them has to be predicted, while the remaining one is used
-  as the reference category to identify the model. The \code{softmax}
-  function is applied on the linear predictor terms to form a
+  as the reference category to identify the model. The so-called 'softmax'
+  transformation is applied on the linear predictor terms to form a
   probability vector.
 
   For more information on mixture models, see

--- a/tests/testthat/helpers/inv_link_categorical_ch.R
+++ b/tests/testthat/helpers/inv_link_categorical_ch.R
@@ -23,15 +23,14 @@ inv_link_categorical_ch <- function(x, log = FALSE, refcat_ins = TRUE) {
   ndraws <- dim(x)[1]
   nobsv <- dim(x)[2]
   ncat <- dim(x)[3]
-  .softmax <- if (log) {
-    log_softmax
-  } else {
-    softmax
-  }
   out <- aperm(
     array(
       sapply(seq_len(nobsv), function(i) {
-        .softmax(slice(x, 2, i))
+        out_i <- log_softmax(slice(x, 2, i))
+        if (!log) {
+          out_i <- exp(out_i)
+        }
+        out_i
       }, simplify = "array"),
       dim = c(ndraws, ncat, nobsv)
     ),


### PR DESCRIPTION
While working on extended unit tests for projpred's augmented-data projection, I realized that `inv_link_categorical([...], log = FALSE)` sometimes returned `NaN`. This PR fixes that by always calling `log_softmax()` and exponentiating afterwards (instead of calling `softmax()` directly).

Reprex (supplying the data as a [CSV](https://github.com/paul-buerkner/brms/files/9482419/softmax_arr_fail.csv) was the easiest way for this):
```r
# devtools::install_github("paul-buerkner/brms")
etas_i <- as.matrix(read.csv("softmax_arr_fail.csv"))
mus_i_direct <- brms:::inv_link_categorical(etas_i)
sum(is.na(mus_i_direct))
## [1] 3
mus_i_indirect <- exp(brms:::inv_link_categorical(etas_i, log = TRUE))
sum(is.na(mus_i_indirect))
## [1] 0
# Apart from the NAs, results are the same:
all.equal(mus_i_direct[!is.na(mus_i_direct)],
          mus_i_indirect[!is.na(mus_i_direct)],
          tolerance = 1e1 * .Machine$double.eps)
## [1] TRUE

# Restart R session -------------------------------------------------------

# devtools::install_github("fweber144/brms", ref = "softmax_log")
etas_i <- as.matrix(read.csv("softmax_arr_fail.csv"))
mus_i_direct <- brms:::inv_link_categorical(etas_i)
sum(is.na(mus_i_direct))
## [1] 0
mus_i_indirect <- exp(brms:::inv_link_categorical(etas_i, log = TRUE))
sum(is.na(mus_i_indirect))
## [1] 0
# Results are identical now:
identical(mus_i_direct, mus_i_indirect)
## [1] TRUE

```

Apart from the usage of `softmax()` in `inv_link_categorical([...], log = FALSE)`, I also handled all other occurrences of `softmax()` in the same way (i.e., using `exp(log_softmax([...]))` instead):

* In the unit tests (file `tests/testthat/helpers/inv_link_categorical_ch.R`).
* In line `theta[, n, ] <- softmax(slice(theta, 2, n))` of `get_theta()`.

There was also one related change in the documentation.

With these changes, I was able to remove `softmax()` (although you can add it back of course, if you want).

The reason for the numerical inaccuracies is probably that `exp(709)` is `8.218407e+307` whereas `exp(710)` is `Inf`, so somewhere between 709 and 710, `exp()` changes to returning `Inf`. And here,
```r
etas_i[which(apply(mus_i_direct, 1, anyNA)), ]
```
gives
```
           V1       V2
[1,] 719.0859 4.864410
[2,] 904.4810 2.521153
[3,] 926.7779 2.402898
```
and
```r
head(sort(etas_i, decreasing = TRUE))
```
gives
```
[1] 926.7779 904.4810 719.0859 639.7206 638.1539 625.9582
```
so the concerned values are exactly those which exceed that threshold between 709 and 710.