### PR TITLE
Error for response-specific formulas (`categorical()` family)

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -94,6 +94,10 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   bterms <- brmsterms(formula)
   if (length(bterms$dpars) > 1L && !conv_cats_dpars(family)) {
     stop2("Projpred does not support distributional models.")
+  } else if (length(bterms$dpars) > 1L && conv_cats_dpars(family) &&
+             length(formula$pforms)) {
+    stop2("Projpred does not support response-specific formulas for the ",
+          family$family, " family.")
   }
   if (length(bterms$nlpars) > 0L) {
     stop2("Projpred does not support non-linear models.")


### PR DESCRIPTION
This PR adds an error message in case of response-specific formulas for the `categorical()` family (supported only by the augmented-data projection).

Reason: Users might be tempted to try something like this:
```r
options(mc.cores = parallel::detectCores(logical = FALSE))
set.seed(856824715)

data(VA, package = "MASS")
levels(VA$cell) <- paste0("lvl", levels(VA$cell))
offs_mat <- matrix(rnorm(nrow(VA) * nlevels(VA$cell)),
                   nrow = nrow(VA))
VA <- cbind(VA, offs = offs_mat)
VA[["offs.1"]] <- NULL

bfit <- brms::brm(
  formula = brms::brmsformula(
    cell ~ 1,
    mulvl2 ~ treat + age + Karn + offset(offs.2),
    mulvl3 ~ treat + age + Karn + offset(offs.3),
    mulvl4 ~ treat + age + Karn + offset(offs.4)
  ),
  data = VA,
  family = brms::categorical(),
  refresh = 0,
  seed = 255696126
)

library(projpred)
refm <- get_refmodel(bfit)
```
Previously, this code ran through with the resulting `refm$formula` being `cell ~ 1`. With this PR, the `get_refmodel()` call throws an error.