### PR TITLE
Check projpred version for latent projection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@ via the `hurdle_cumulative` family thanks to Stephen Wild. (#1448)
 in post-processing methods that require a compiled Stan model.
 * Extend control over the `point_estimate` feature in `prepare_predictions`
 via the new argument `ndraws_point_estimate`.
-* Add support for the latent projection available in **projpred** versions >
-2.3.0.
+* Add support for the latent projection available in **projpred** versions >=
+2.4.0.
 
 ### Bug Fixes
 

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -207,6 +207,10 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
       )
     }
   } else if (latent) {
+    if (utils::packageVersion("projpred") <= "2.3.0") {
+      stop2("For the latent projection, a projpred version > 2.3.0 is ",
+            "required.")
+    }
     if (family$family == "cumulative") {
       args$latent_ilink <- latent_ilink_cumulative(
         object = object, family = family, bterms = bterms, resp = resp

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -17,7 +17,8 @@
 #'   \code{\link[projpred:init_refmodel]{init_refmodel}}, but leave this at
 #'   \code{NULL} unless \pkg{projpred} complains about it.
 #' @param latent See argument \code{latent} of
-#'   \code{\link[projpred:extend_family]{extend_family}}.
+#'   \code{\link[projpred:extend_family]{extend_family}}. Setting this to
+#'   \code{TRUE} requires a \pkg{projpred} version > 2.3.0.
 #' @param brms_seed A seed used to infer seeds for \code{\link{kfold.brmsfit}}
 #'   and for sampling group-level effects for new levels (in multilevel models).
 #' @param ... Further arguments passed to

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -18,7 +18,7 @@
 #'   \code{NULL} unless \pkg{projpred} complains about it.
 #' @param latent See argument \code{latent} of
 #'   \code{\link[projpred:extend_family]{extend_family}}. Setting this to
-#'   \code{TRUE} requires a \pkg{projpred} version > 2.3.0.
+#'   \code{TRUE} requires a \pkg{projpred} version >= 2.4.0.
 #' @param brms_seed A seed used to infer seeds for \code{\link{kfold.brmsfit}}
 #'   and for sampling group-level effects for new levels (in multilevel models).
 #' @param ... Further arguments passed to
@@ -207,10 +207,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
       )
     }
   } else if (latent) {
-    if (utils::packageVersion("projpred") <= "2.3.0") {
-      stop2("For the latent projection, a projpred version > 2.3.0 is ",
-            "required.")
-    }
+    require_package("projpred", "2.4.0")
     if (family$family == "cumulative") {
       args$latent_ilink <- latent_ilink_cumulative(
         object = object, family = family, bterms = bterms, resp = resp

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -37,7 +37,8 @@ based on \code{\link{kfold.brmsfit}}.}
 \code{NULL} unless \pkg{projpred} complains about it.}
 
 \item{latent}{See argument \code{latent} of
-\code{\link[projpred:extend_family]{extend_family}}.}
+\code{\link[projpred:extend_family]{extend_family}}. Setting this to
+\code{TRUE} requires a \pkg{projpred} version > 2.3.0.}
 
 \item{brms_seed}{A seed used to infer seeds for \code{\link{kfold.brmsfit}}
 and for sampling group-level effects for new levels (in multilevel models).}

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -38,7 +38,7 @@ based on \code{\link{kfold.brmsfit}}.}
 
 \item{latent}{See argument \code{latent} of
 \code{\link[projpred:extend_family]{extend_family}}. Setting this to
-\code{TRUE} requires a \pkg{projpred} version > 2.3.0.}
+\code{TRUE} requires a \pkg{projpred} version >= 2.4.0.}
 
 \item{brms_seed}{A seed used to infer seeds for \code{\link{kfold.brmsfit}}
 and for sampling group-level effects for new levels (in multilevel models).}


### PR DESCRIPTION
I realized that in #1451, I could have checked the projpred version that is required for the latent projection directly in the code. Sorry, I have implemented this now (and also added corresponding documentation at argument `latent`; #1451 did so only in the `NEWS` entry).