### PR TITLE
Fix #1457 (projpred `newdata` requiring more variables than necessary)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: brms
 Encoding: UTF-8
 Type: Package
 Title: Bayesian Regression Models using 'Stan'
-Version: 2.18.7
-Date: 2023-01-17
+Version: 2.18.8
+Date: 2023-02-14
 Authors@R:
     c(person("Paul-Christian", "Bürkner", email = "paul.buerkner@gmail.com",
              role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ via the new argument `ndraws_point_estimate`.
 * Fix a Stan syntax error in threaded models with `lasso` priors. (#1427)
 * Fix Stan compilation issues for some of the more special 
 link functions such as `cauchit` or `softplus`.
+* Fix a bug for predictions in **projpred**, previously requiring more variables
+in `newdata` than necessary. (#1457, #1459)
 
 
 # brms 2.18.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ in post-processing methods that require a compiled Stan model.
 * Extend control over the `point_estimate` feature in `prepare_predictions`
 via the new argument `ndraws_point_estimate`.
 * Add support for the latent projection available in **projpred** versions >=
-2.4.0.
+2.4.0. (#1451)
 
 ### Bug Fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@ via the `hurdle_cumulative` family thanks to Stephen Wild. (#1448)
 in post-processing methods that require a compiled Stan model.
 * Extend control over the `point_estimate` feature in `prepare_predictions`
 via the new argument `ndraws_point_estimate`.
-* Add support for the latent projection available in **projpred** versions >=
-2.4.0. (#1451)
+* Add support for the latent projection available in 
+**projpred** versions >= 2.4.0. (#1451)
 
 ### Bug Fixes
 

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -237,16 +237,14 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     formula <- formula$forms[[resp]]
   }
   bterms <- brmsterms(formula)
+  y <- NULL
   if (extract_y) {
-    respform <- bterms$respform
     data <- current_data(
       object, newdata, resp = resp, check_response = TRUE,
       allow_new_levels = TRUE, req_vars = character()
     )
-    y <- unname(model.response(model.frame(respform, data,
-                                           na.action = na.pass)))
-  } else {
-    y <- NULL
+    y <- model.response(model.frame(bterms$respform, data, na.action = na.pass))
+    y <- unname(y)
   }
 
   # extract relevant auxiliary data (offsets and weights (or numbers of trials))

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -267,10 +267,11 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   sdata <- do_call(standata, args)
 
   usc_resp <- usc(resp)
+  N <- sdata[[paste0("N", usc_resp)]]
   weights <- as.vector(sdata[[paste0("weights", usc_resp)]])
   trials <- as.vector(sdata[[paste0("trials", usc_resp)]])
   if (is_binary(formula)) {
-    trials <- rep(1, sdata[["N"]])
+    trials <- rep(1, N)
   }
   if (!is.null(trials)) {
     if (!is.null(weights)) {
@@ -279,11 +280,11 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     weights <- trials
   }
   if (is.null(weights)) {
-    weights <- rep(1, sdata[["N"]])
+    weights <- rep(1, N)
   }
   offset <- as.vector(sdata[[paste0("offsets", usc_resp)]])
   if (is.null(offset)) {
-    offset <- rep(0, sdata[["N"]])
+    offset <- rep(0, N)
   }
   nlist(y, weights, offset)
 }

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -263,7 +263,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
     internal = TRUE,
     req_vars = req_vars
   )
-  # TODO: Missing weights don't cause an error here (but they probably should):
+  # NOTE: Missing weights don't cause an error here (see #1459)
   sdata <- do_call(standata, args)
 
   usc_resp <- usc(resp)

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -61,8 +61,8 @@ it manually yourself.
 }
 \details{
 Note that the \code{extract_model_data} function used internally by
-  \code{get_refmodel.brmsfit} ignores arguments \code{wrhs}, \code{orhs}, and
-  \code{extract_y}. This is relevant for
+  \code{get_refmodel.brmsfit} ignores arguments \code{wrhs} and \code{orhs}.
+  This is relevant for
   \code{\link[projpred:predict.refmodel]{predict.refmodel}}, for example.
 }
 \examples{


### PR DESCRIPTION
This fixes issue #1457. See the commit messages for details. If you don't want to increase the version number, you can revert that of course.

I have also added a `TODO` comment in [this line](https://github.com/fweber144/brms/blob/79d55b1861cd252d832913d286eb7ec77952661b/R/projpred.R#L268) because I experienced a slight inconsistency while testing this fix: If *weights* (i.e., from `resp_weights()`) are missing in `newdata` (and listed in `req_vars`), no error is triggered, but such an error is triggered if *numbers of trials* (i.e., from `resp_trials()`) are missing in `newdata` (and listed in `req_vars`). Already from a conceptual point of view, I think it would be desirable to also throw an error if weights are missing. Tell me if you need a reprex for this (but I think this would be a different issue and furthermore, this is not projpred-related).