### PR TITLE
Add compress parameter to brm and write_brmsfit

### DIFF
--- a/R/brm.R
+++ b/R/brm.R
@@ -208,8 +208,8 @@
 #'   files won't be overwritten, you have to manually remove the file in order
 #'   to refit and save the model under an existing file name. The file name
 #'   is stored in the \code{brmsfit} object for later usage.
-#' @param compress A character string, one of \code{"gzip"}, \code{"xz"}, or
-#'   \code{"bzip2"} (default \code{"gzip"}). If the \code{file} parameter is
+#' @param compress A character string, one of the compression algorithms supported
+#'   by \code{saveRDS} (default \code{"gzip"}). If the \code{file} parameter is
 #'   passed, this compression will be used when saving the fitted model object.
 #' @param file_refit Modifies when the fit stored via the \code{file} parameter
 #'   is re-used. Can be set globally for the current \R session via the

--- a/R/brm.R
+++ b/R/brm.R
@@ -445,7 +445,8 @@ brm <- function(formula, data, family = gaussian(), prior = NULL,
                 backend = getOption("brms.backend", "rstan"),
                 future = getOption("future", FALSE), silent = 1,
                 seed = NA, save_model = NULL, stan_model_args = list(),
-                file = NULL, file_refit = getOption("brms.file_refit", "never"),
+                file = NULL, compress = 'gzip',
+                file_refit = getOption("brms.file_refit", "never"),
                 empty = FALSE, rename = TRUE, ...) {
 
   # optionally load brmsfit from file
@@ -594,7 +595,7 @@ brm <- function(formula, data, family = gaussian(), prior = NULL,
     x <- rename_pars(x)
   }
   if (!is.null(file)) {
-    x <- write_brmsfit(x, file)
+    x <- write_brmsfit(x, file, compress = compress)
   }
   x
 }

--- a/R/brm.R
+++ b/R/brm.R
@@ -445,7 +445,7 @@ brm <- function(formula, data, family = gaussian(), prior = NULL,
                 backend = getOption("brms.backend", "rstan"),
                 future = getOption("future", FALSE), silent = 1,
                 seed = NA, save_model = NULL, stan_model_args = list(),
-                file = NULL, compress = 'gzip',
+                file = NULL, compress = "gzip",
                 file_refit = getOption("brms.file_refit", "never"),
                 empty = FALSE, rename = TRUE, ...) {
 

--- a/R/brm.R
+++ b/R/brm.R
@@ -208,10 +208,11 @@
 #'   files won't be overwritten, you have to manually remove the file in order
 #'   to refit and save the model under an existing file name. The file name
 #'   is stored in the \code{brmsfit} object for later usage.
-#' @param compress A character string, one of the compression algorithms supported
-#'   by \code{saveRDS} (default \code{"gzip"}). If the \code{file} parameter is
-#'   passed, this compression will be used when saving the fitted model object.
-#' @param file_refit Modifies when the fit stored via the \code{file} parameter
+#' @param file_compress Logical or a character string, specifying one of the
+#'   compression algorithms supported by \code{\link{saveRDS}}. If the
+#'   \code{file} argument is provided, this compression will be used when saving
+#'   the fitted model object.
+#' @param file_refit Modifies when the fit stored via the \code{file} argument
 #'   is re-used. Can be set globally for the current \R session via the
 #'   \code{"brms.file_refit"} option (see \code{\link{options}}).
 #'   For \code{"never"} (default) the fit is always loaded if it
@@ -448,7 +449,7 @@ brm <- function(formula, data, family = gaussian(), prior = NULL,
                 backend = getOption("brms.backend", "rstan"),
                 future = getOption("future", FALSE), silent = 1,
                 seed = NA, save_model = NULL, stan_model_args = list(),
-                file = NULL, compress = "gzip",
+                file = NULL, file_compress = TRUE,
                 file_refit = getOption("brms.file_refit", "never"),
                 empty = FALSE, rename = TRUE, ...) {
 
@@ -598,7 +599,7 @@ brm <- function(formula, data, family = gaussian(), prior = NULL,
     x <- rename_pars(x)
   }
   if (!is.null(file)) {
-    x <- write_brmsfit(x, file, compress = compress)
+    x <- write_brmsfit(x, file, compress = file_compress)
   }
   x
 }

--- a/R/brm.R
+++ b/R/brm.R
@@ -208,6 +208,9 @@
 #'   files won't be overwritten, you have to manually remove the file in order
 #'   to refit and save the model under an existing file name. The file name
 #'   is stored in the \code{brmsfit} object for later usage.
+#' @param compress A character string, one of \code{"gzip"}, \code{"xz"}, or
+#'   \code{"bzip2"} (default \code{"gzip"}). If the \code{file} parameter is
+#'   passed, this compression will be used when saving the fitted model object.
 #' @param file_refit Modifies when the fit stored via the \code{file} parameter
 #'   is re-used. Can be set globally for the current \R session via the
 #'   \code{"brms.file_refit"} option (see \code{\link{options}}).

--- a/R/brm_multiple.R
+++ b/R/brm_multiple.R
@@ -29,6 +29,10 @@
 #'   result is re-used and all arguments modifying the model code or data are
 #'   ignored. It is not recommended to use this argument directly, but to call
 #'   the \code{\link[brms:update.brmsfit_multiple]{update}} method, instead.
+#' @param compress A character string, one of the compression algorithms supported
+#'   by \code{saveRDS} (default \code{"gzip"}). If the \code{file} parameter is
+#'   passed, this compression will be used when saving the combined fitted model 
+#'   object.
 #' @param ... Further arguments passed to \code{\link{brm}}.
 #'
 #' @details The combined model may issue false positive convergence warnings, as
@@ -75,7 +79,8 @@ brm_multiple <- function(formula, data, family = gaussian(), prior = NULL,
                          stan_funs = NULL, silent = 1, recompile = FALSE,
                          combine = TRUE, fit = NA,
                          algorithm = getOption("brms.algorithm", "sampling"),
-                         seed = NA, file = NULL, file_refit = "never", ...) {
+                         seed = NA, file = NULL, compress = "gzip",
+                         file_refit = "never", ...) {
 
   combine <- as_one_logical(combine)
   file_refit <- match.arg(file_refit, file_refit_options())
@@ -167,7 +172,7 @@ brm_multiple <- function(formula, data, family = gaussian(), prior = NULL,
     class(fits) <- c("brmsfit_multiple", class(fits))
   }
   if (!is.null(file)) {
-    fits <- write_brmsfit(fits, file)
+    fits <- write_brmsfit(fits, file, compress)
   }
   fits
 }

--- a/R/brm_multiple.R
+++ b/R/brm_multiple.R
@@ -29,10 +29,6 @@
 #'   result is re-used and all arguments modifying the model code or data are
 #'   ignored. It is not recommended to use this argument directly, but to call
 #'   the \code{\link[brms:update.brmsfit_multiple]{update}} method, instead.
-#' @param compress A character string, one of the compression algorithms supported
-#'   by \code{saveRDS} (default \code{"gzip"}). If the \code{file} parameter is
-#'   passed, this compression will be used when saving the combined fitted model 
-#'   object.
 #' @param ... Further arguments passed to \code{\link{brm}}.
 #'
 #' @details The combined model may issue false positive convergence warnings, as
@@ -79,8 +75,9 @@ brm_multiple <- function(formula, data, family = gaussian(), prior = NULL,
                          stan_funs = NULL, silent = 1, recompile = FALSE,
                          combine = TRUE, fit = NA,
                          algorithm = getOption("brms.algorithm", "sampling"),
-                         seed = NA, file = NULL, compress = "gzip",
-                         file_refit = "never", ...) {
+                         seed = NA, file = NULL, file_compress = TRUE,
+                         file_refit = getOption("brms.file_refit", "never"),
+                         ...) {
 
   combine <- as_one_logical(combine)
   file_refit <- match.arg(file_refit, file_refit_options())
@@ -172,7 +169,7 @@ brm_multiple <- function(formula, data, family = gaussian(), prior = NULL,
     class(fits) <- c("brmsfit_multiple", class(fits))
   }
   if (!is.null(file)) {
-    fits <- write_brmsfit(fits, file, compress)
+    fits <- write_brmsfit(fits, file, compress = file_compress)
   }
   fits
 }

--- a/R/brmsfit-helpers.R
+++ b/R/brmsfit-helpers.R
@@ -1003,11 +1003,11 @@ read_brmsfit <- function(file) {
 # @param x a brmsfit object
 # @param file path to an rds file
 # @return NULL
-write_brmsfit <- function(x, file) {
+write_brmsfit <- function(x, file, compress = 'gzip') {
   stopifnot(is.brmsfit(x))
   file <- check_brmsfit_file(file)
   x$file <- file
-  saveRDS(x, file = file)
+  saveRDS(x, file = file, compress = compress)
   invisible(x)
 }
 

--- a/R/brmsfit-helpers.R
+++ b/R/brmsfit-helpers.R
@@ -1003,7 +1003,7 @@ read_brmsfit <- function(file) {
 # @param x a brmsfit object
 # @param file path to an rds file
 # @return NULL
-write_brmsfit <- function(x, file, compress = 'gzip') {
+write_brmsfit <- function(x, file, compress = "gzip") {
   stopifnot(is.brmsfit(x))
   file <- check_brmsfit_file(file)
   x$file <- file

--- a/R/brmsfit-helpers.R
+++ b/R/brmsfit-helpers.R
@@ -1002,9 +1002,9 @@ read_brmsfit <- function(file) {
 # write a brmsfit object to a file
 # @param x a brmsfit object
 # @param file path to an rds file
-# @param compress compression format supported by \code{saveRDS}
+# @param compress compression format supported by saveRDS
 # @return NULL
-write_brmsfit <- function(x, file, compress = "gzip") {
+write_brmsfit <- function(x, file, compress = TRUE) {
   stopifnot(is.brmsfit(x))
   file <- check_brmsfit_file(file)
   x$file <- file

--- a/R/brmsfit-helpers.R
+++ b/R/brmsfit-helpers.R
@@ -1002,6 +1002,7 @@ read_brmsfit <- function(file) {
 # write a brmsfit object to a file
 # @param x a brmsfit object
 # @param file path to an rds file
+# @param compress compression format supported by \code{saveRDS}
 # @return NULL
 write_brmsfit <- function(x, file, compress = "gzip") {
   stopifnot(is.brmsfit(x))

--- a/man/brm.Rd
+++ b/man/brm.Rd
@@ -42,6 +42,7 @@ brm(
   save_model = NULL,
   stan_model_args = list(),
   file = NULL,
+  file_compress = TRUE,
   file_refit = getOption("brms.file_refit", "never"),
   empty = FALSE,
   rename = TRUE,
@@ -284,7 +285,12 @@ files won't be overwritten, you have to manually remove the file in order
 to refit and save the model under an existing file name. The file name
 is stored in the \code{brmsfit} object for later usage.}
 
-\item{file_refit}{Modifies when the fit stored via the \code{file} parameter
+\item{file_compress}{Logical or a character string, specifying one of the
+compression algorithms supported by \code{\link{saveRDS}}. If the
+\code{file} argument is provided, this compression will be used when saving
+the fitted model object.}
+
+\item{file_refit}{Modifies when the fit stored via the \code{file} argument
 is re-used. Can be set globally for the current \R session via the
 \code{"brms.file_refit"} option (see \code{\link{options}}).
 For \code{"never"} (default) the fit is always loaded if it

--- a/man/brm_multiple.Rd
+++ b/man/brm_multiple.Rd
@@ -24,7 +24,8 @@ brm_multiple(
   algorithm = getOption("brms.algorithm", "sampling"),
   seed = NA,
   file = NULL,
-  file_refit = "never",
+  file_compress = TRUE,
+  file_refit = getOption("brms.file_refit", "never"),
   ...
 )
 }
@@ -159,7 +160,12 @@ files won't be overwritten, you have to manually remove the file in order
 to refit and save the model under an existing file name. The file name
 is stored in the \code{brmsfit} object for later usage.}
 
-\item{file_refit}{Modifies when the fit stored via the \code{file} parameter
+\item{file_compress}{Logical or a character string, specifying one of the
+compression algorithms supported by \code{\link{saveRDS}}. If the
+\code{file} argument is provided, this compression will be used when saving
+the fitted model object.}
+
+\item{file_refit}{Modifies when the fit stored via the \code{file} argument
 is re-used. Can be set globally for the current \R session via the
 \code{"brms.file_refit"} option (see \code{\link{options}}).
 For \code{"never"} (default) the fit is always loaded if it


### PR DESCRIPTION
RDS objects containing brmsfit objects can be quite large depending on the model. Currently, brms uses saveRDS's default compression, gzip, to save models to disk. However, saveRDS also supports xz and bzip2. I found that simply using xz instead of gzip can result in a dramatic reduction in needed disk space, tested by reading in a saved model and just reexporting it with `saveRDS(object, file, compress = "xz")`. While the write process is noticeably slower, I tested with two models and observed these reductions in file size:

- 141 MB -> 73 MB
- 395 MB -> 205 MB

This reduced the model sizes to a little over half of the original size, which seems like a pretty good savings.

This pull request adds a `compress` parameter to `brm` and `write_brmsfit` that gets passed along to `saveRDS` to allow the user to specify the compression algorithm to use. The default value is the current default for `saveRDS`, which is `gzip`.