### PR TITLE
projpred-related seed fix and docs/NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,7 @@ over-dispersed and zero-inflated binomial response models thanks to Hayden
 Rabel. (#1319 & #1311)
 * Display `ppd_*` plots in `pp_check` via argument `prefix`. (#1313)
 * Support the `log` link in binomial and beta type families. (#1316)
+* Support **projpred**'s augmented-data projection. (#1292, #1294)
 
 ### Other changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ all additive predictor terms specified in the same formula. (#1492)
 and incompatible with the newly implemented global shrinkage prior framework.
 * No longer support multiple deprecated prior options for categorical and
 multivariate models after around 3 years of deprecation. (#1420)
+* Deprecate argument `newdata` of `get_refmodel.brmsfit()`. (#1502)
 
 ### Bug Fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,14 +22,6 @@ machine than where the model was originally fitted. Old spline models can be
 repaired via `restructure`. Special thanks to Simon Wood, Ruben Arslan, Marta
 Kołczyńska, Patrick Hogan, and Urs Kalbitzer. (#1465)
 * Fix a bunch of minor issues occuring for rare feature combinations.
-* When exiting `get_refmodel.brmsfit()`, the pseudorandom number generator
-(PRNG) state is reset (to the state before calling `get_refmodel.brmsfit()`)
-only if argument `brms_seed` is not `NULL`. Since `NULL` is the default for
-`brms_seed`, this means that previously, two repeated calls to
-`get_refmodel.brmsfit()` with no PRNG-using code between them would use the same
-PRNG state. With this bug fix, users may safely set a seed once before any calls
-to `get_refmodel.brmsfit()` (e.g., at the beginning of their script) and then
-leave `brms_seed` at its default. (#1502)
 
 
 # brms 2.19.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,14 @@ machine than where the model was originally fitted. Old spline models can be
 repaired via `restructure`. Special thanks to Simon Wood, Ruben Arslan, Marta
 Kołczyńska, Patrick Hogan, and Urs Kalbitzer. (#1465)
 * Fix a bunch of minor issues occuring for rare feature combinations.
+* When exiting `get_refmodel.brmsfit()`, the pseudorandom number generator
+(PRNG) state is reset (to the state before calling `get_refmodel.brmsfit()`)
+only if argument `brms_seed` is not `NULL`. Since `NULL` is the default for
+`brms_seed`, this means that previously, two repeated calls to
+`get_refmodel.brmsfit()` with no PRNG-using code between them would use the same
+PRNG state. With this bug fix, users may safely set a seed once before any calls
+to `get_refmodel.brmsfit()` (e.g., at the beginning of their script) and then
+leave `brms_seed` at its default. (#1502)
 
 
 # brms 2.19.0

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -191,6 +191,10 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
 
   # prepare data passed to projpred
+  if (!is.null(newdata)) {
+    warning2("Argument 'newdata' of get_refmodel.brmsfit() is deprecated and ",
+             "will be removed in the future.")
+  }
   data <- current_data(
     object, newdata, resp = resp, check_response = TRUE,
     allow_new_levels = TRUE

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -21,6 +21,9 @@
 #'   \code{TRUE} requires a \pkg{projpred} version >= 2.4.0.
 #' @param brms_seed A seed used to infer seeds for \code{\link{kfold.brmsfit}}
 #'   and for sampling group-level effects for new levels (in multilevel models).
+#'   If \code{NULL}, then \code{\link{set.seed}} is not called at all. If not
+#'   \code{NULL}, then the pseudorandom number generator (PRNG) state is reset
+#'   (to the state before calling this function) upon exiting this function.
 #' @param ... Further arguments passed to
 #' \code{\link[projpred:init_refmodel]{init_refmodel}}.
 #'

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -66,9 +66,11 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   # Infer "sub-seeds":
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
-    on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
   }
   if (!is.null(brms_seed)) {
+    if (exists(".Random.seed", envir = .GlobalEnv)) {
+      on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+    }
     set.seed(brms_seed)
   }
   kfold_seed <- sample.int(.Machine$integer.max, 1)

--- a/man/get_refmodel.brmsfit.Rd
+++ b/man/get_refmodel.brmsfit.Rd
@@ -41,7 +41,10 @@ based on \code{\link{kfold.brmsfit}}.}
 \code{TRUE} requires a \pkg{projpred} version >= 2.4.0.}
 
 \item{brms_seed}{A seed used to infer seeds for \code{\link{kfold.brmsfit}}
-and for sampling group-level effects for new levels (in multilevel models).}
+and for sampling group-level effects for new levels (in multilevel models).
+If \code{NULL}, then \code{\link{set.seed}} is not called at all. If not
+\code{NULL}, then the pseudorandom number generator (PRNG) state is reset
+(to the state before calling this function) upon exiting this function.}
 
 \item{...}{Further arguments passed to
 \code{\link[projpred:init_refmodel]{init_refmodel}}.}


### PR DESCRIPTION
This fixes a minor bug in PRNG usage of `get_refmodel.brmsfit()`: The PRNG state should be reset upon exit only if the user-supplied seed is not `NULL`. See the `NEWS.md` entry from 8db0bbde83033b4495438da43be7ba23459766b4 for details.

In principle, I would also recommend to replace `brms_seed = NULL` with `brms_seed = NA` (i.e., changing the default but also replacing `is.null(brms_seed)` with `is.na(brms_seed)` within the function—although length 1 would probably have to be asserted for `NA`—and adapting the code for `brms_seed_k` accordingly) because `NULL` has a special meaning for `set.seed()`'s argument `seed`, namely to generate completely unreproducible results (which might sometimes be desired by users). However, it seems like within brms, `NA` has a special meaning for seed arguments, namely that a seed will be set randomly (see `brms::brm()`). So in that regard, it's probably better to stick with `NULL` instead of `NA` (otherwise, all other seed arguments would have to be adapted for the sake of consistency).

In commit 0c5c8a5c550855870eeb936e1380118da6578c20, a `NEWS.md` entry for projpred's augmented-data projection is added at an older version (2.17.0). Back then, I didn't add a `NEWS.md` entry because projpred's CRAN version didn't support the augmented-data projection at that time. Now, users might be searching for "augmented-data projection" across this `NEWS.md` file to see when support for it was added (similarly to the latent projection, for which a `NEWS.md` entry was added at brms version 2.19.0). That's why I'm adding the augmented-data projection entry now.

Furthermore, I would still recommend to remove argument `newdata` of `get_refmodel.brmsfit()`. The last state of our discussion on this was at https://github.com/paul-buerkner/brms/pull/1292#issuecomment-1028682437. There, I said I needed to think about whether a reference model where fit and data don't match complies with projpred's understanding of a reference model. I have come to the conclusion that such a reference model does not comply with projpred's understanding of a reference model: In projpred, the reference model is inseparable from its parameter estimates and the data they are based on (so in case of new data, the reference model would have to be refitted). The corresponding rstanarm method (`get_refmodel.stanreg()`) also doesn't have a `newdata` argument. So if you are ok with this, then I would push a commit here that deprecates this argument.
