### PR TITLE
Allow data validation to be skipped to improve `posterior_predict` performance with `newdata`

### DIFF
--- a/R/data-helpers.R
+++ b/R/data-helpers.R
@@ -618,11 +618,12 @@ validate_newdata2 <- function(newdata2, object, ...) {
 }
 
 # extract the current data
-current_data <- function(object, newdata = NULL, skip_validate_data = FALSE, ...) {
+current_data <- function(object, newdata = NULL, skip_validation = FALSE, ...) {
   stopifnot(is.brmsfit(object))
+  skip_validation <- as_one_logical(skip_validation)
   if (is.null(newdata)) {
     data <- object$data
-  } else if(skip_validate_data) {
+  } else if (skip_validation) {
     data <- newdata
   } else {
     data <- validate_newdata(newdata, object = object, ...)
@@ -631,11 +632,12 @@ current_data <- function(object, newdata = NULL, skip_validate_data = FALSE, ...
 }
 
 # extract the current data2
-current_data2 <- function(object, newdata2 = NULL, skip_validate_data = FALSE, ...) {
+current_data2 <- function(object, newdata2 = NULL, skip_validation = FALSE, ...) {
   stopifnot(is.brmsfit(object))
+  skip_validation <- as_one_logical(skip_validation)
   if (is.null(newdata2)) {
     data2 <- object$data2
-  } else if(skip_validate_data) {
+  } else if (skip_validation) {
     data2 <- newdata2
   } else {
     data2 <- validate_newdata2(newdata2, object = object, ...)

--- a/R/data-helpers.R
+++ b/R/data-helpers.R
@@ -618,11 +618,11 @@ validate_newdata2 <- function(newdata2, object, ...) {
 }
 
 # extract the current data
-current_data <- function(object, newdata = NULL, skip_validate = FALSE, ...) {
+current_data <- function(object, newdata = NULL, skip_validate_data = FALSE, ...) {
   stopifnot(is.brmsfit(object))
   if (is.null(newdata)) {
     data <- object$data
-  } else if(skip_validate) {
+  } else if(skip_validate_data) {
     data <- newdata
   } else {
     data <- validate_newdata(newdata, object = object, ...)
@@ -631,10 +631,12 @@ current_data <- function(object, newdata = NULL, skip_validate = FALSE, ...) {
 }
 
 # extract the current data2
-current_data2 <- function(object, newdata2 = NULL, ...) {
+current_data2 <- function(object, newdata2 = NULL, skip_validate_data = FALSE, ...) {
   stopifnot(is.brmsfit(object))
   if (is.null(newdata2)) {
     data2 <- object$data2
+  } else if(skip_validate_data) {
+    data2 <- newdata2
   } else {
     data2 <- validate_newdata2(newdata2, object = object, ...)
   }

--- a/R/data-helpers.R
+++ b/R/data-helpers.R
@@ -618,10 +618,12 @@ validate_newdata2 <- function(newdata2, object, ...) {
 }
 
 # extract the current data
-current_data <- function(object, newdata = NULL, ...) {
+current_data <- function(object, newdata = NULL, skip_validate = FALSE, ...) {
   stopifnot(is.brmsfit(object))
   if (is.null(newdata)) {
     data <- object$data
+  } else if(skip_validate) {
+    data <- newdata
   } else {
     data <- validate_newdata(newdata, object = object, ...)
   }

--- a/R/make_standata.R
+++ b/R/make_standata.R
@@ -148,7 +148,7 @@ standata.brmsfit <- function(object, newdata = NULL, re_formula = NULL,
   bterms <- brmsterms(formula)
 
   newdata2 <- use_alias(newdata2, new_objects)
-  data2 <- current_data2(object, newdata2)
+  data2 <- current_data2(object, newdata2, ...)
   data <- current_data(
     object, newdata, newdata2 = data2,
     re_formula = re_formula, ...

--- a/R/projpred.R
+++ b/R/projpred.R
@@ -197,7 +197,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   data <- current_data(
     object, newdata, resp = resp, check_response = TRUE,
-    allow_new_levels = TRUE
+    allow_new_levels = TRUE, ...
   )
   attr(data, "terms") <- NULL
   args <- nlist(
@@ -250,7 +250,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   if (extract_y) {
     data <- current_data(
       object, newdata, resp = resp, check_response = TRUE,
-      allow_new_levels = TRUE, req_vars = all.vars(bterms$respform)
+      allow_new_levels = TRUE, req_vars = all.vars(bterms$respform), ...
     )
     y <- model.response(model.frame(bterms$respform, data, na.action = na.pass))
     y <- unname(y)


### PR DESCRIPTION
When `posterior_predict` is called with `newdata`, `validate_newdata` will be called and this represents a non-trivial amount of the total execution time. Advanced users may want to skip this step when they know their data already has the proper structure.

As there are different kinds of validation functions in the package, the proposed argument name is `skip_validate_data`.

```r
library(brms)
fit <- brm(time | cens(censored) ~ age + sex + (1 + age || patient),
           data = kidney, family = "exponential", init = "0",
           backend = "cmdstanr")

microbenchmark::microbenchmark(
  posterior_predict(fit, newdata = fit$data),
  posterior_predict(fit, newdata = fit$data, skip_validate_data = TRUE)
)
# Unit: milliseconds
#                                          expr      min       lq     mean   median       uq      max neval
#                             posterior_predict 228.1443 252.5301 274.1673 266.1105 277.0043 570.7657   100
#  posterior_predict(skip_validate_data = TRUE) 130.8804 149.5136 158.3647 155.1540 163.1465 414.9703   100
```

The change is made for both `current_data` and `current_data2` and should work without issue when passed via `...` from `standata` and `pp_check` calls.

Two calls of `current_data` in `get_refmodel` had `...` added so the argument can also be used there.

There is one `current_data2` call left without passing `...` as it's inside `validate_newdata` so it'd be pointless there.