### PR TITLE
Revert some ellipses from #1521

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -197,7 +197,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   }
   data <- current_data(
     object, newdata, resp = resp, check_response = TRUE,
-    allow_new_levels = TRUE, ...
+    allow_new_levels = TRUE
   )
   attr(data, "terms") <- NULL
   args <- nlist(
@@ -250,7 +250,7 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
   if (extract_y) {
     data <- current_data(
       object, newdata, resp = resp, check_response = TRUE,
-      allow_new_levels = TRUE, req_vars = all.vars(bterms$respform), ...
+      allow_new_levels = TRUE, req_vars = all.vars(bterms$respform)
     )
     y <- model.response(model.frame(bterms$respform, data, na.action = na.pass))
     y <- unname(y)


### PR DESCRIPTION
This reverts the recent addition of the ellipsis (see #1521) to `current_data()` calls related to projpred. There are two such calls: One in `get_refmodel.brmsfit()` (when getting `data`) and one in `.extract_model_data()`. Apart from the fact that #1521 didn't document the extended use of `get_refmodel.brmsfit()`'s ellipsis, I also think that a double use of that ellipsis is dangerous for the future (because more arguments might be added to downstream functions either in projpred or in brms, increasing the risk of conflicts). In `.extract_model_data()`, the ellipsis can be removed because projpred never calls `extract_model_data()` with arguments other than those specified in projpred's documentation (in particular, the user doesn't have the possibility to pass arguments to `extract_model_data()`).

In summary (for the projpred-related features of brms), I don't think the improvement in terms of speed is worth the increased risk of bugs.