### PR TITLE
Set `called_from_cvrefbuilder = TRUE` within `get_refmodel.brmsfit()`'s `cvrefbuilder` function

### DIFF
--- a/R/projpred.R
+++ b/R/projpred.R
@@ -187,7 +187,8 @@ get_refmodel.brmsfit <- function(object, newdata = NULL, resp = NULL,
       brms_seed_k <- brms_seed + cvfit$projpred_k
     }
     projpred::get_refmodel(cvfit, resp = resp, dis = dis, latent = latent,
-                           brms_seed = brms_seed_k, ...)
+                           brms_seed = brms_seed_k,
+                           called_from_cvrefbuilder = TRUE, ...)
   }
 
   # prepare data passed to projpred


### PR DESCRIPTION
This sets `called_from_cvrefbuilder = TRUE` within `get_refmodel.brmsfit()`'s `cvrefbuilder` function to suppress some warnings when building the fold-wise reference model objects (so far, argument `called_from_cvrefbuilder` only exists in projpred's current development version, but setting this argument within brms already now doesn't harm as unnecessary extra arguments are swallowed up by `projpred::init_refmodel()`).