### PR TITLE
Update translation of silent argument to fix cmdstanr breakage

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -278,7 +278,8 @@ fit_model <- function(model, backend, ...) {
       iter_warmup = warmup,
       chains, thin,
       parallel_chains = cores,
-      show_messages = !silent,
+      show_messages = silent < 2,
+      show_exceptions = silent == 0,
       fixed_param = algorithm == "fixed_param"
     )
     out <- do_call(model$sample, args)


### PR DESCRIPTION
Updates the `silent` -> `show_messages`,`show_exceptions` translation for `cmdstanr` to the following mapping:

- `silent=0` suppress nothing (`show_messages=TRUE, show_exceptions=TRUE`)
- `silent=1` suppress only exceptions (`show_messages=TRUE, show_exceptions=FALSE`)
- `silent=2` suppress messages and exceptions (`show_messages=FALSE, show_exceptions = FALSE`)