### PR TITLE
second attempt to fix #1562

### DIFF
--- a/inst/chunks/fun_scale_r_cor_by.stan
+++ b/inst/chunks/fun_scale_r_cor_by.stan
@@ -7,7 +7,7 @@
   * Returns:
   *   matrix of scaled group-level effects
   */
-  matrix scale_r_cor_by(matrix z, matrix SD, matrix[] L, int[] Jby) {
+  matrix scale_r_cor_by(matrix z, matrix SD, array[] matrix L, array[] int Jby) {
     // r is stored in another dimension order than z
     matrix[cols(z), rows(z)] r;
     array[size(L)] matrix[rows(L[1]), cols(L[1])] LC;

--- a/inst/chunks/fun_scale_r_cor_by_cov.stan
+++ b/inst/chunks/fun_scale_r_cor_by_cov.stan
@@ -9,8 +9,7 @@
   * Returns:
   *   matrix of scaled group-level effects
   */
-  matrix scale_r_cor_by_cov(matrix z, matrix SD, matrix[] L,
-                            int[] Jby, matrix Lcov) {
+  matrix scale_r_cor_by_cov(matrix z, matrix SD, array[] matrix L, array[] int Jby, matrix Lcov) {
     vector[num_elements(z)] z_flat = to_vector(z);
     vector[num_elements(z)] r = rep_vector(0, num_elements(z));
     array[size(L)] matrix[rows(L[1]), cols(L[1])] LC;


### PR DESCRIPTION
In order to fix #1562 I adjusted to the new array notation:
- "inst/chunks/fun_scale_r_cor_by.stan"
- "inst/chunks/fun_scale_r_cor_by_cov.stan"
This fixes my problem. I couldn't test whether this creates issues with the RStan version on CRAN, as I have a newer version than that.

Also note that a quick search in the repo indicates there's a few additional places where the old type[] notation is still used: https://github.com/search?q=repo%3Apaul-buerkner%2Fbrms+%22int%5B%5D%22&type=code