### PR TITLE
Allow read_csv_as_stanfit to work when inv_metric is not recorded

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -833,21 +833,25 @@ read_csv_as_stanfit <- function(files, variables = NULL, sampler_diagnostics = N
     rownames(attr(samples[[i]], "sampler_params")) <- seq_rows(diagnostics[[i]])
 
     # reformat back to text
-    if (is_equal(sampler_t, "NUTS(dense_e)")) {
-      mmatrix_txt <- "\n# Elements of inverse mass matrix:\n# "
-      mmat <- paste0(apply(csfit$inv_metric[[i]], 1, paste0, collapse = ", "),
-                     collapse = "\n# ")
+    if (length(csfit$inv_metric)) {
+      if (is_equal(sampler_t, "NUTS(dense_e)")) {
+        mmatrix_txt <- "\n# Elements of inverse mass matrix:\n# "
+        mmat <- paste0(apply(csfit$inv_metric[[i]], 1, paste0, collapse = ", "),
+                       collapse = "\n# ")
+      } else {
+        mmatrix_txt <- "\n# Diagonal elements of inverse mass matrix:\n# "
+        mmat <- paste0(csfit$inv_metric[[i]], collapse = ", ")
+      }
+
+      adapt_info[[i]] <- paste0("# Step size = ",
+                                csfit$step_size[[i]],
+                                mmatrix_txt,
+                                mmat, "\n# ")
+      attr(samples[[i]], "adaptation_info") <- adapt_info[[i]]
     } else {
-      mmatrix_txt <- "\n# Diagonal elements of inverse mass matrix:\n# "
-      mmat <- paste0(csfit$inv_metric[[i]], collapse = ", ")
+      attr(samples[[i]], "adaptation_info") <- character(0)
     }
 
-    adapt_info[[i]] <- paste0("# Step size = ",
-                              csfit$step_size[[i]],
-                              mmatrix_txt,
-                              mmat, "\n# ")
-
-    attr(samples[[i]], "adaptation_info") <- adapt_info[[i]]
 
     attr(samples[[i]], "args") <- list(sampler_t = sampler_t, chain_id = i)
 


### PR DESCRIPTION
This is a very minor change to the read_csv_as_stanfit function. It adds a check if csfit$inv_metric is not an empty list before reading in that information. This is rarely needed, but I am working on a checkpointing mechanism, and sometimes we read in incomplete warmup draws. In that case the current function fails because csfit$inv_metric[[i]] gives an error, because inv_metric is an empty list().