### PR TITLE
change default prior for von_mises mu tan_half link

### DIFF
--- a/R/family-lists.R
+++ b/R/family-lists.R
@@ -350,7 +350,14 @@
     ybounds = c(-pi, pi), closed = c(TRUE, TRUE),
     ad = c("weights", "subset", "cens", "trunc", "mi", "index"),
     include = c("fun_tan_half.stan", "fun_von_mises.stan"),
-    normalized = ""
+    normalized = "",
+    # experimental use of default priors stored in families #1614
+    prior = function(dpar, link = "identity", ...) {
+      if (dpar == "mu" && link == "tan_half") {
+        return("student_t(1, 0, 1)")
+      }
+      NULL
+    }
   )
 }
 

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -113,6 +113,8 @@ test_that("specified priors appear in the Stan code", {
   # tests use of default priors stored in families #1614
   scode <- stancode(y ~ x1, dat, family = negbinomial())
   expect_match2(scode, "lprior += inv_gamma_lpdf(shape | 0.4, 0.3);")
+  scode <- stancode(y ~ x2, dat, family = von_mises())
+  expect_match2(scode, "lprior += student_t_lpdf(Intercept | 1, 0, 1);")
 
   prior <- prior(gamma(0, 1), coef = x1)
   expect_warning(stancode(y ~ x1, dat, prior = prior),


### PR DESCRIPTION
Closes #1631 by placing a student_t(1, 0, 1) prior on mu in the von_mises family when a tan_half link is used. This corresponds to a uniform prior over the constrained scale from -pi to pi.

The family-specific prior feature you implemented is really neat and made this super easy!

For what is worth, in my testing the prior change only had a meaningfull effects for very low numbers of observations and low precision (kappa) - otherwise results were pretty much identical.

This only affects the prior for the tan-half link - should the identity link prior be left as is? the current prior has a slight bump at 0, but its otherwise unimodal and weakly informative.