### PR TITLE
Fix creating stanfit from csv when rstan not loaded

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -979,8 +979,10 @@ read_csv_as_stanfit <- function(files, variables = NULL, sampler_diagnostics = N
   }
 
   # @stanmodel
+  cxxdso_class <- "cxxdso"
+  attr(cxxdso_class, "package") <- "rstan"
   null_dso <- new(
-    "cxxdso", sig = list(character(0)), dso_saved = FALSE,
+    cxxdso_class, sig = list(character(0)), dso_saved = FALSE,
     dso_filename = character(0), modulename = character(0),
     system = R.version$system, cxxflags = character(0),
     .CXXDSOMISC = new.env(parent = emptyenv())


### PR DESCRIPTION
Reported by @ave, using `cmdstanr` backend is giving error in some cases:
```
Error in getClass(Class, where = topenv(parent.frame())) : 
  “cxxdso” is not a defined class
```

Which is caused by the CSV processing attempting to use a class from the `rstan` package when it's not loaded. This PR updates the class lookup to specify that it should be found in `rstan`