### PR TITLE
remove outdated include statement

### DIFF
--- a/R/family-lists.R
+++ b/R/family-lists.R
@@ -349,7 +349,7 @@
     dpars = c("mu", "kappa"), type = "real",
     ybounds = c(-pi, pi), closed = c(TRUE, TRUE),
     ad = c("weights", "subset", "cens", "trunc", "mi", "index"),
-    include = c("fun_tan_half.stan", "fun_von_mises.stan"),
+    include = c("fun_tan_half.stan"),
     normalized = "",
     # experimental use of default priors stored in families #1614
     prior = function(dpar, link = "identity", ...) {


### PR DESCRIPTION
After the change for #1633 I got an error that file "fun_von_mises.stan" could not be found. There was a left over include statement in the .family_von_mises() function. Removing it fixes the problem.