### PR TITLE
Use brms.iter option (#1705)

### DIFF
--- a/R/brm.R
+++ b/R/brm.R
@@ -126,7 +126,8 @@
 #' @param inits (Deprecated) Alias of \code{init}.
 #' @param chains Number of Markov chains (defaults to 4).
 #' @param iter Number of total iterations per chain (including warmup; defaults
-#'   to 2000).
+#'   to 2000). Can be set globally for the current \R session via the
+#'   \code{"brms.iter"} option (see \code{\link{options}}).
 #' @param warmup A positive integer specifying number of warmup (aka burnin)
 #'   iterations. This also specifies the number of iterations used for stepsize
 #'   adaptation, so warmup draws should not be used for inference. The number
@@ -440,7 +441,8 @@ brm <- function(formula, data, family = gaussian(), prior = NULL,
                 drop_unused_levels = TRUE, stanvars = NULL, stan_funs = NULL,
                 fit = NA, save_pars = getOption("brms.save_pars", NULL),
                 save_ranef = NULL, save_mevars = NULL, save_all_pars = NULL,
-                init = NULL, inits = NULL, chains = 4, iter = 2000,
+                init = NULL, inits = NULL, chains = 4, 
+                iter = getOption("brms.iter", 2000),
                 warmup = floor(iter / 2), thin = 1,
                 cores = getOption("mc.cores", 1),
                 threads = getOption("brms.threads", NULL),

--- a/man/brm.Rd
+++ b/man/brm.Rd
@@ -26,7 +26,7 @@ brm(
   init = NULL,
   inits = NULL,
   chains = 4,
-  iter = 2000,
+  iter = getOption("brms.iter", 2000),
   warmup = floor(iter/2),
   thin = 1,
   cores = getOption("mc.cores", 1),
@@ -183,7 +183,8 @@ values you can consult the documentation of the selected \code{backend}.}
 \item{chains}{Number of Markov chains (defaults to 4).}
 
 \item{iter}{Number of total iterations per chain (including warmup; defaults
-to 2000).}
+to 2000). Can be set globally for the current \R session via the
+\code{"brms.iter"} option (see \code{\link{options}}).}
 
 \item{warmup}{A positive integer specifying number of warmup (aka burnin)
 iterations. This also specifies the number of iterations used for stepsize


### PR DESCRIPTION
Changes the default `brm(iter = 2000)` to `brm(iter = getOption("brms.iter", 2000))` (#1705) & revises associated documentation.

I tested this locally using examples in README.Rmd, but did not add tests because other similar arguments in `brm()` are not tested either.

Going forward it might make sense to think about using `options()` for e.g. `brm(control = <x>)` and others.