### PR TITLE
Add the brms_seed to loo_R2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fit extended-support Beta models via family `xbeta` 
 thanks to Ioannis Kosmidis. (#1698)
+* Add the `brms_seed` argument to `loo_R2` thanks to
+Marco Colombo. (#1713)
 
 ### Bug Fixes
 

--- a/R/loo_predict.R
+++ b/R/loo_predict.R
@@ -213,7 +213,8 @@ E_loo_value <- function(x, psis_object, type = "mean", probs = 0.5) {
 #' @export loo_R2
 #' @export
 loo_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
-                           robust = FALSE, probs = c(0.025, 0.975), ...) {
+                           robust = FALSE, probs = c(0.025, 0.975),
+                           brms_seed = NULL, ...) {
   contains_draws(object)
   object <- restructure(object)
   resp <- validate_resp(resp, object)
@@ -239,6 +240,16 @@ loo_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
       "'loo_R2' which is likely invalid for ordinal families."
     )
   }
+
+  # set the random seed if required
+  if (!is.null(brms_seed)) {
+    if (exists(".Random.seed", envir = .GlobalEnv)) {
+      rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
+      on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+    }
+    set.seed(brms_seed)
+  }
+
   args_y <- list(object, warn = TRUE, ...)
   args_ypred <- list(object, sort = TRUE, ...)
   R2 <- named_list(paste0("R2", resp))

--- a/man/loo_R2.brmsfit.Rd
+++ b/man/loo_R2.brmsfit.Rd
@@ -11,6 +11,7 @@
   summary = TRUE,
   robust = FALSE,
   probs = c(0.025, 0.975),
+  brms_seed = NULL,
   ...
 )
 }


### PR DESCRIPTION
This allows to fix the seed in `loo_R2` and restore the RNG state when leaving the function. The implementation and the choice of the argument name follow what is already done in `get_refmodel.brmsfit`.

Fixes  #1713.