### PR TITLE
store original bounday factor L for approximate GPs

### DIFF
--- a/R/brmsframe.R
+++ b/R/brmsframe.R
@@ -384,7 +384,7 @@ frame_basis_sm <- function(x, data, ...) {
 frame_basis_gp <- function(x, data, ...) {
   stopifnot(is.btl(x))
   out <- data_gp(x, data, internal = TRUE)
-  out <- out[grepl("^((Xgp)|(dmax)|(cmeans))", names(out))]
+  out <- out[grepl("^((Xgp)|(dmax)|(cmeans)|(L))", names(out))]
   out
 }
 

--- a/R/data-predictor.R
+++ b/R/data-predictor.R
@@ -642,19 +642,24 @@ data_gp <- function(bframe, data, internal = FALSE, ...) {
     out[[paste0("cmeans", sfx)]] <- cmeans
     # required to compute inverse-gamma priors for length-scales
     out[[paste0("Xgp_prior", sfx)]] <- Xgp
-    # required to compute eigenfunctions of approximate GPs with new data
-    out[[paste0("Lgp", sfx)]] <- choose_L(Xgp, c = c)
   }
   if (!isNA(k)) {
     # basis function approach requires centered variables
     Xgp <- sweep(Xgp, 2, cmeans)
     D <- NCOL(Xgp)
+
     if (length(basis)) {
-      # compute boundary factor L
       L <- basis[[paste0("Lgp", sfx)]]
     } else {
+      # compute boundary factor L
       L <- choose_L(Xgp, c = c)
     }
+
+    if (internal) {
+      # required to compute eigenfunctions of approximate GPs with new data
+      out[[paste0("Lgp", sfx)]] <- L
+    }
+
     Ks <- as.matrix(do_call(expand.grid, repl(seq_len(k), D)))
     XgpL <- matrix(nrow = NROW(Xgp), ncol = NROW(Ks))
     slambda <- matrix(nrow = NROW(Ks), ncol = D)

--- a/R/data-predictor.R
+++ b/R/data-predictor.R
@@ -642,12 +642,19 @@ data_gp <- function(bframe, data, internal = FALSE, ...) {
     out[[paste0("cmeans", sfx)]] <- cmeans
     # required to compute inverse-gamma priors for length-scales
     out[[paste0("Xgp_prior", sfx)]] <- Xgp
+    # required to compute eigenfunctions of approximate GPs with new data
+    out[[paste0("Lgp", sfx)]] <- choose_L(Xgp, c = c)
   }
   if (!isNA(k)) {
     # basis function approach requires centered variables
     Xgp <- sweep(Xgp, 2, cmeans)
     D <- NCOL(Xgp)
-    L <- choose_L(Xgp, c = c)
+    if (length(basis)) {
+      # compute boundary factor L
+      L <- basis[[paste0("Lgp", sfx)]]
+    } else {
+      L <- choose_L(Xgp, c = c)
+    }
     Ks <- as.matrix(do_call(expand.grid, repl(seq_len(k), D)))
     XgpL <- matrix(nrow = NROW(Xgp), ncol = NROW(Ks))
     slambda <- matrix(nrow = NROW(Ks), ncol = D)


### PR DESCRIPTION
Storing and re-using the originally computed boundary factor `L` will ensure that predictions for new covariate values work appropriately when predicting from approximate GPs