### PR TITLE
Fix PW stan code.

### DIFF
--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -638,8 +638,8 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
     if (has_pw) {
       str_add(out$model_prior) <- glue(
-        "  for (n in 1:N_{id}) {{\n",
-        "    target += PW_{id}[n] * std_normal_{lpdf}(to_vector(z_{id}[,n]));\n",
+        "  for (j in 1:N_{id}) {{\n",
+        "    target += PW_{id}[j] * std_normal_{lpdf}(z_{id}[, j]);\n",
         "  }\n"
       )
     } else {
@@ -737,10 +737,10 @@ stan_re <- function(bframe, prior, normalize, ...) {
       "  // standardized group-level effects\n"
     )
     if (has_pw) {
-      str_add(out$model_prior) <- paste0(
-        cglue("  for (n in 1:N_{id}) {{\n"),
-        cglue("    target += PW_{id}[n] * std_normal_{lpdf}(z_{id}[{seq_rows(r)}][n]);\n"),
-        paste("  }\n")
+      str_add(out$model_prior) <- glue(
+        "  for (j in 1:N_{id}) {{\n",
+        cglue("    target += PW_{id}[j] * std_normal_{lpdf}(z_{id}[{seq_rows(r)}, j]);\n"),
+        "  }\n"
       )
     } else {
       str_add(out$model_prior) <- cglue(

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -638,7 +638,9 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
     if (has_pw) {
       str_add(out$model_prior) <- glue(
-        "  target += PW_{id} * std_normal_{lpdf}(to_vector(z_{id}));\n"
+        "  for (n in 1:N_{id}) {{\n",
+        "    target += PW_{id}[n] * std_normal_{lpdf}(to_vector(z_{id}[,n]));\n",
+        "  }\n"
       )
     } else {
       str_add(out$model_prior) <- glue(
@@ -735,8 +737,10 @@ stan_re <- function(bframe, prior, normalize, ...) {
       "  // standardized group-level effects\n"
     )
     if (has_pw) {
-      str_add(out$model_prior) <- cglue(
-        "  target += PW_{id} * std_normal_{lpdf}(z_{id}[{seq_rows(r)}]);\n"
+      str_add(out$model_prior) <- paste0(
+        cglue("  for (n in 1:N_{id}) {{\n"),
+        cglue("    target += PW_{id}[n] * std_normal_{lpdf}(z_{id}[{seq_rows(r)}][n]);\n"),
+        paste("  }\n")
       )
     } else {
       str_add(out$model_prior) <- cglue(

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -2769,7 +2769,7 @@ test_that("Grouping prior weights are added to the Stan code", {
     data = wtd_epilepsy, family = gaussian()
   )
   expect_match2(scode, "vector[N_1] PW_1;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_1[n] * std_normal_lpdf(to_vector(z_1[,n]));")
+  expect_match2(scode, "target += PW_1[j] * std_normal_lpdf(z_1[, j]);")
 
   # Check for multiple grouping variables, varying intercept and slope
   wtd_epilepsy[['random_group']]     <- rep(4:1, times = 59)
@@ -2781,8 +2781,8 @@ test_that("Grouping prior weights are added to the Stan code", {
     data = wtd_epilepsy, family = gaussian()
   )
   expect_match2(scode, "vector[N_2] PW_2;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_1[n] * std_normal_lpdf(to_vector(z_1[,n]));")
-  expect_match2(scode, "target += PW_2[n] * std_normal_lpdf(z_2[1][n]);")
+  expect_match2(scode, "target += PW_1[j] * std_normal_lpdf(z_1[, j]);")
+  expect_match2(scode, "target += PW_2[j] * std_normal_lpdf(z_2[1, j]);")
 
   # Check for multivariate model
   dat <- data.frame(
@@ -2802,10 +2802,10 @@ test_that("Grouping prior weights are added to the Stan code", {
            prior(horseshoe(2), resp = "y2")
   scode <- stancode(form, dat, prior = prior)
   expect_match2(scode, "vector[N_4] PW_4;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_4[n] * std_normal_lpdf(z_4[1][n]);")
+  expect_match2(scode, "target += PW_4[j] * std_normal_lpdf(z_4[1, j]);")
 
   # multi-membership model
   scode <- stancode(y1 ~ x + (x | mm(g1, g2, pw = g2wgt)), data = dat)
   expect_match2(scode, "vector[N_1] PW_1;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_1[n] * std_normal_lpdf(to_vector(z_1[,n]));")
+  expect_match2(scode, "target += PW_1[j] * std_normal_lpdf(z_1[, j]);")
 })

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -2769,7 +2769,7 @@ test_that("Grouping prior weights are added to the Stan code", {
     data = wtd_epilepsy, family = gaussian()
   )
   expect_match2(scode, "vector[N_1] PW_1;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_1 * std_normal_lpdf(to_vector(z_1));")
+  expect_match2(scode, "target += PW_1[n] * std_normal_lpdf(to_vector(z_1[,n]));")
 
   # Check for multiple grouping variables, varying intercept and slope
   wtd_epilepsy[['random_group']]     <- rep(4:1, times = 59)
@@ -2781,8 +2781,8 @@ test_that("Grouping prior weights are added to the Stan code", {
     data = wtd_epilepsy, family = gaussian()
   )
   expect_match2(scode, "vector[N_2] PW_2;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_1 * std_normal_lpdf(to_vector(z_1));")
-  expect_match2(scode, "target += PW_2 * std_normal_lpdf(z_2[1]);")
+  expect_match2(scode, "target += PW_1[n] * std_normal_lpdf(to_vector(z_1[,n]));")
+  expect_match2(scode, "target += PW_2[n] * std_normal_lpdf(z_2[1][n]);")
 
   # Check for multivariate model
   dat <- data.frame(
@@ -2802,10 +2802,10 @@ test_that("Grouping prior weights are added to the Stan code", {
            prior(horseshoe(2), resp = "y2")
   scode <- stancode(form, dat, prior = prior)
   expect_match2(scode, "vector[N_4] PW_4;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_4 * std_normal_lpdf(z_4[1]);")
+  expect_match2(scode, "target += PW_4[n] * std_normal_lpdf(z_4[1][n]);")
 
   # multi-membership model
   scode <- stancode(y1 ~ x + (x | mm(g1, g2, pw = g2wgt)), data = dat)
   expect_match2(scode, "vector[N_1] PW_1;  // weights for group contribution to the prior")
-  expect_match2(scode, "target += PW_1 * std_normal_lpdf(to_vector(z_1));")
+  expect_match2(scode, "target += PW_1[n] * std_normal_lpdf(to_vector(z_1[,n]));")
 })


### PR DESCRIPTION
# Summary
Hi Paul,

I'm sorry to bother you with more on this prior-weights functionality from #1719. In applying this functionality to a different dataset from the 'survey' package, I realized there was a problem in the Stan code I wrote for this, linked here:

https://github.com/paul-buerkner/brms/blob/c741df7b008a9fccfff1b4d04a8102e0e8e6c1d7/R/stan-predictor.R#L641
https://github.com/paul-buerkner/brms/blob/c741df7b008a9fccfff1b4d04a8102e0e8e6c1d7/R/stan-predictor.R#L739

The problem is that `std_normal_lpdf()` function in Stan evaluates to a scalar, not a vector. So multiplying its output by the weights vector is incorrect. Instead, the code should have specified a loop over each group, adding the weights and the likelihood contribution from each group separately. 

This small PR fixes that issue by changing the Stan code to do this loop, and it also updates the unit tests accordingly.

# Reproducible Example to Illustrate the Problem

To illustrate the problem, I fit a model where the group-level weights are all equal to 1. The resulting estimates should be equivalent to fitting an unweighted model. But from the reprex below, we can see that we get very different estimates for the variance component `sd(Intercept)` depending on whether we specify group-level weights.

```r
remotes::install_github("paul-buerkner/brms@c741df7", upgrade=FALSE, force=TRUE)
library(brms)
library(survey)
data(api, package = 'survey')

wtd_fit <- brm(
  formula = api00 ~ ell + (1 | gr(dnum, pw = dwgt)),
  data    = apiclus1 |> transform(dwgt = 1), 
  family  = gaussian(),
  seed    = 1999,
  iter    = 5000,
  backend = "cmdstanr"
)

unwtd_fit <- brm(
  formula = api00 ~ ell + (1 | gr(dnum)),
  data    = apiclus1, 
  family  = gaussian(),
  seed    = 1999,
  iter    = 5000,
  backend = "cmdstanr"
)
summary(wtd_fit)
summary(unwtd_fit)
```

From the weighted fit, we have:
```r
#> Multilevel Hyperparameters:
#> ~dnum (Number of levels: 15) 
#>               Estimate Est.Error l-95% CI u-95% CI Rhat Bulk_ESS Tail_ESS
#> sd(Intercept)   259.66     55.61   172.90   387.21 1.00     2450     3840
```

From the unweighted fit, we have:
```r
#> Multilevel Hyperparameters:
#> ~dnum (Number of levels: 15) 
#>               Estimate Est.Error l-95% CI u-95% CI Rhat Bulk_ESS Tail_ESS
#> sd(Intercept)    73.23     16.40    47.62   112.38 1.00     2605     3988
```

After this pull request, we have output for the weighted fit that is equivalent to the unweighted fit:

```r
#> Multilevel Hyperparameters:
#> ~dnum (Number of levels: 15) 
#>               Estimate Est.Error l-95% CI u-95% CI Rhat Bulk_ESS Tail_ESS
#> sd(Intercept)    73.64     16.69    48.29   111.67 1.00     2168     4060
```