### PR TITLE
compress plots in vignettes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,7 +77,8 @@ Suggests:
     gtable,
     shiny,
     knitr,
-    rmarkdown
+    rmarkdown,
+    ragg
 Description: Fit Bayesian generalized (non-)linear multivariate multilevel models
     using 'Stan' for full Bayesian inference. A wide range of distributions
     and link functions are supported, allowing users to fit -- among others --
@@ -102,6 +103,7 @@ URL: https://github.com/paul-buerkner/brms, https://discourse.mc-stan.org/, http
 BugReports: https://github.com/paul-buerkner/brms/issues
 Additional_repositories:
     https://stan-dev.r-universe.dev/
+SystemRequirements: pngquant
 VignetteBuilder:
     knitr,
     R.rsp

--- a/vignettes/brms_customfamilies.Rmd
+++ b/vignettes/brms_customfamilies.Rmd
@@ -16,7 +16,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,

--- a/vignettes/brms_customfamilies.Rmd
+++ b/vignettes/brms_customfamilies.Rmd
@@ -16,17 +16,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(brms)
 ggplot2::theme_set(theme_default())

--- a/vignettes/brms_distreg.Rmd
+++ b/vignettes/brms_distreg.Rmd
@@ -16,7 +16,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,

--- a/vignettes/brms_distreg.Rmd
+++ b/vignettes/brms_distreg.Rmd
@@ -16,17 +16,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(brms)
 ggplot2::theme_set(theme_default())

--- a/vignettes/brms_missings.Rmd
+++ b/vignettes/brms_missings.Rmd
@@ -17,17 +17,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(brms)
 ggplot2::theme_set(theme_default())

--- a/vignettes/brms_missings.Rmd
+++ b/vignettes/brms_missings.Rmd
@@ -17,7 +17,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,

--- a/vignettes/brms_monotonic.Rmd
+++ b/vignettes/brms_monotonic.Rmd
@@ -16,7 +16,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,

--- a/vignettes/brms_monotonic.Rmd
+++ b/vignettes/brms_monotonic.Rmd
@@ -16,17 +16,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(brms)
 ggplot2::theme_set(theme_default())

--- a/vignettes/brms_multivariate.Rmd
+++ b/vignettes/brms_multivariate.Rmd
@@ -16,7 +16,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,

--- a/vignettes/brms_multivariate.Rmd
+++ b/vignettes/brms_multivariate.Rmd
@@ -16,17 +16,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(brms)
 ggplot2::theme_set(theme_default())

--- a/vignettes/brms_nonlinear.Rmd
+++ b/vignettes/brms_nonlinear.Rmd
@@ -16,7 +16,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,

--- a/vignettes/brms_nonlinear.Rmd
+++ b/vignettes/brms_nonlinear.Rmd
@@ -16,17 +16,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(brms)
 ggplot2::theme_set(theme_default())

--- a/vignettes/brms_phylogenetics.Rmd
+++ b/vignettes/brms_phylogenetics.Rmd
@@ -16,7 +16,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,

--- a/vignettes/brms_phylogenetics.Rmd
+++ b/vignettes/brms_phylogenetics.Rmd
@@ -16,17 +16,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(brms)
 ggplot2::theme_set(theme_default())

--- a/vignettes/brms_threading.Rmd
+++ b/vignettes/brms_threading.Rmd
@@ -16,17 +16,20 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
+knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,
   warning = FALSE,
   eval = if (isTRUE(exists("params"))) params$EVAL else FALSE,
-  dev = "jpeg",
-  dpi = 100,
+  dev = "ragg_png",
+  dpi = 72,
+  fig.retina = 1.5,
   fig.asp = 0.8,
   fig.width = 5,
   out.width = "60%",
-  fig.align = "center"
+  fig.align = "center",
+  pngquant = "--speed=1 --quality=50"
 )
 library(ggplot2)
 library(brms)

--- a/vignettes/brms_threading.Rmd
+++ b/vignettes/brms_threading.Rmd
@@ -16,7 +16,7 @@ params:
 ```{r, SETTINGS-knitr, include=FALSE}
 stopifnot(require(knitr))
 options(width = 90)
-knitr::knit_hooks$set(pngquant = knitr::hook_pngquant)
+knit_hooks$set(pngquant = knitr::hook_pngquant)
 opts_chunk$set(
   comment = NA,
   message = FALSE,


### PR DESCRIPTION
I noticed that the brms package size is quite large, which is due to the rendered vignettes to a large extent. The proposed changes implement best practices I have come to learn on the net. The trick implemented uses the pngquant engine to compress the plots substantially. For example, the non-linear vignette has a size of 580 kb with the released version of brms while the version rendered with the changes on this PR reduces this to just 164 kb.

As I lack some dependencies to build the entire package, I can't report the total reduction of the final package (currently about 4MB), but I'd expect that the size will go down quite a bit. So please, do make a check to build the package and compare the gains before merging.

Given on how many servers the R package is replicated to, I'd guess that the size savings are worthwhile. However note that this makes `pngquant` a dependency. This is available from homebrew for macOS - and I guess there are various other sources for it for the different OSes, etc..