### PR TITLE
update read_csv_as_stanfit() to work with rstan::get_hmc_diagnostics()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ These changes may be reverted once the underlying causes of this
 issue have been fixed. (#1658)
 * Align the definition of the R function `step()` with the definition in Stan,
 such that `step(0) == 1` thanks to Daniel Sabanes Bov. (#1734)
+* Make `read_csv_as_stanfit()` store `adapt_delta` and `max_treedepth` values in
+`$control` so rstan can find these values. Thanks to Tristan Mahr (#1767).
 
 ### Other Changes
 

--- a/R/backends.R
+++ b/R/backends.R
@@ -755,7 +755,7 @@ read_csv_as_stanfit <- function(files, variables = NULL, sampler_diagnostics = N
   )
 
   # @model_name
-  model_name = gsub(".csv", "", basename(files[[1]]))
+  model_name <- gsub(".csv", "", basename(files[[1]]))
 
   # @model_pars
   model_pars <- csfit$metadata$stan_variables
@@ -1001,7 +1001,12 @@ read_csv_as_stanfit <- function(files, variables = NULL, sampler_diagnostics = N
     adaptation_info = NA, # add in loop
     has_time = is.numeric(csfit$metadata$time$total),
     time_info = NA, # add in loop
-    sampler_t = sampler_t
+    sampler_t = sampler_t,
+    # rstan looks in @stan_args$control for some metadata
+    control = list(
+      adapt_delta = csfit$metadata$adapt_delta,
+      max_treedepth = csfit$metadata$max_treedepth
+    )
   )
 
   sargs_rep <- replicate(n_chains, sargs, simplify = FALSE)

--- a/R/priors.R
+++ b/R/priors.R
@@ -1248,6 +1248,11 @@ validate_prior <- function(prior, formula, data, family = gaussian(),
   } else if (!is.brmsprior(prior)) {
     stop2("Argument 'prior' must be a 'brmsprior' object.")
   }
+  if (!"tag" %in% names(prior)) {
+    # the tag column was added in version 2.22.11 (#1724)
+    # manually adding it retains compatibility with old brmsprior objects
+    prior$tag <- ""
+  }
   # when updating existing priors, invalid priors should be allowed
   allow_invalid_prior <- isTRUE(attr(prior, "allow_invalid_prior"))
   # temporarily exclude priors that should not be checked

--- a/tests/testthat/tests.brmsfit-methods.R
+++ b/tests/testthat/tests.brmsfit-methods.R
@@ -670,7 +670,7 @@ test_that("pp_check has reasonable outputs", {
                  group = "visit", newdata = fit1$data[1:10, ])
   expect_ggplot(pp)
 
-  pp <- SW(pp_check(fit1, type = "loo_pit", cores = 1))
+  pp <- SW(pp_check(fit1, type = "loo_pit_qq", cores = 1))
   expect_ggplot(pp)
 
   # ppd plots work

--- a/tests/testthat/tests.distributions.R
+++ b/tests/testthat/tests.distributions.R
@@ -114,6 +114,8 @@ test_that("inv_gaussian distribution functions run without errors", {
 })
 
 test_that("beta_binomial distribution functions run without errors", {
+  skip_if_not_installed("extraDistr")
+
   n <- 10
   x <- rpois(n, lambda = 1)
 
@@ -152,6 +154,7 @@ test_that("asym_laplace distribution functions run without errors", {
 })
 
 test_that("zero-inflated distribution functions run without errors", {
+  skip_if_not_installed("extraDistr")
   n <- 10
   x <- rpois(n, lambda = 1)
 
@@ -208,6 +211,8 @@ test_that("hurdle distribution functions run without errors", {
 })
 
 test_that("wiener distribution functions run without errors", {
+  skip_if_not_installed("RWiener")
+
   set.seed(1234)
   n <- 10
   x <- seq(0.1, 1, 0.1)

--- a/tests/testthat/tests.emmeans.R
+++ b/tests/testthat/tests.emmeans.R
@@ -1,5 +1,5 @@
 context("Tests for emmeans support")
-
+skip_if_not_installed("emmeans")
 skip_on_cran()
 
 require(emmeans)
@@ -11,6 +11,8 @@ fit4 <- rename_pars(brms:::brmsfit_example4)
 fit6 <- rename_pars(brms:::brmsfit_example6)
 
 test_that("emmeans returns expected output structure", {
+  skip_if_not_installed("emmeans")
+
   em <- summary(emmeans(fit1, "Age", by = "Trt"))
   expect_equal(nrow(em), 2)
 
@@ -31,6 +33,8 @@ test_that("emmeans returns expected output structure", {
 })
 
 test_that("emmeans supports 'epred' predictions", {
+  skip_if_not_installed("emmeans")
+
   em <- summary(emmeans(fit2, "Age", epred = TRUE))
   expect_equal(nrow(em), 1)
 
@@ -43,6 +47,8 @@ test_that("emmeans supports 'epred' predictions", {
 })
 
 test_that("emmeans supports multilevel terms", {
+  skip_if_not_installed("emmeans")
+
   em <- summary(emmeans(fit1, "Age", by = "Trt", re_formula = NULL))
   expect_equal(nrow(em), 2)
 

--- a/tests/testthat/tests.emmeans.R
+++ b/tests/testthat/tests.emmeans.R
@@ -11,8 +11,6 @@ fit4 <- rename_pars(brms:::brmsfit_example4)
 fit6 <- rename_pars(brms:::brmsfit_example6)
 
 test_that("emmeans returns expected output structure", {
-  skip_if_not_installed("emmeans")
-
   em <- summary(emmeans(fit1, "Age", by = "Trt"))
   expect_equal(nrow(em), 2)
 
@@ -33,8 +31,6 @@ test_that("emmeans returns expected output structure", {
 })
 
 test_that("emmeans supports 'epred' predictions", {
-  skip_if_not_installed("emmeans")
-
   em <- summary(emmeans(fit2, "Age", epred = TRUE))
   expect_equal(nrow(em), 1)
 
@@ -47,8 +43,6 @@ test_that("emmeans supports 'epred' predictions", {
 })
 
 test_that("emmeans supports multilevel terms", {
-  skip_if_not_installed("emmeans")
-
   em <- summary(emmeans(fit1, "Age", by = "Trt", re_formula = NULL))
   expect_equal(nrow(em), 2)
 

--- a/tests/testthat/tests.log_lik.R
+++ b/tests/testthat/tests.log_lik.R
@@ -177,6 +177,8 @@ test_that("log_lik for FCOR models runs without errors", {
 })
 
 test_that("log_lik for count and survival models works correctly", {
+  skip_if_not_installed("extraDistr")
+
   ns <- 25
   nobs <- 10
   trials <- sample(10:30, nobs, replace = TRUE)
@@ -337,6 +339,7 @@ test_that("log_lik for circular models runs without errors", {
 })
 
 test_that("log_lik for zero-inflated and hurdle models runs without erros", {
+  skip_if_not_installed("extraDistr")
   ns <- 50
   nobs <- 8
   trials <- sample(10:30, nobs, replace = TRUE)
@@ -422,6 +425,7 @@ test_that("log_lik for ordinal models runs without erros", {
 })
 
 test_that("log_lik for categorical and related models runs without erros", {
+  skip_if_not_installed("extraDistr")
   ns <- 50
   nobs <- 8
   ncat <- 3
@@ -493,6 +497,7 @@ test_that("censored and truncated log_lik run without errors", {
 })
 
 test_that("log_lik for the wiener diffusion model runs without errors", {
+  skip_if_not_installed("RWiener")
   ns <- 5
   nobs <- 3
   prep <- structure(list(ndraws = ns, nobs = nobs), class = "brmsprep")
@@ -507,6 +512,7 @@ test_that("log_lik for the wiener diffusion model runs without errors", {
 })
 
 test_that("log_lik for the xbeta model runs without errors", {
+  skip_if_not_installed("betareg")
   ns <- 50
   nobs <- 8
   prep <- structure(list(ndraws = ns, nobs = nobs), class = "brmsprep")

--- a/tests/testthat/tests.posterior_predict.R
+++ b/tests/testthat/tests.posterior_predict.R
@@ -212,6 +212,8 @@ test_that("posterior_predict for bernoulli and beta models works correctly", {
 })
 
 test_that("posterior_predict for xbeta models works correctly", {
+  skip_if_not_installed("betareg")
+
   ns <- 17
   nobs <- 10
   prep <- structure(list(ndraws = ns, nobs = nobs), class = "brmsprep")

--- a/tests/testthat/tests.priorsense.R
+++ b/tests/testthat/tests.priorsense.R
@@ -1,8 +1,8 @@
 context("Tests for priorsense support")
+skip_if_not_installed("priorsense")
+skip_on_cran()
 
 SW <- suppressWarnings
-
-skip_on_cran()
 
 require(priorsense)
 

--- a/tests/testthat/tests.read_csv_as_stanfit.R
+++ b/tests/testthat/tests.read_csv_as_stanfit.R
@@ -120,10 +120,7 @@ test_that("rstan can locate max_treedepth", {
     max_treedepth = 2,
     adapt_delta = .1
   )
-  fit <- fit_treedepth$output_files() |>
-    read_csv_as_stanfit()
-  fit |>
-    rstan::check_treedepth() |>
-    expect_message("depth of 2")
+  fit <- read_csv_as_stanfit(fit_treedepth$output_files())
+  expect_message(rstan::check_treedepth(fit), "depth of 2")
 })
 

--- a/tests/testthat/tests.read_csv_as_stanfit.R
+++ b/tests/testthat/tests.read_csv_as_stanfit.R
@@ -23,23 +23,24 @@ fit <- mod$sample(parallel_chains = 2,
 fit_warmup <- mod$sample(parallel_chains = 2,
                          iter_warmup = 200,
                          iter_sampling=200,
-                         save_warmup = T)
+                         save_warmup = TRUE)
 
 fit_dense_warmup <- mod$sample(parallel_chains = 4,
                                iter_warmup = 200,
                                iter_sampling=200,
                                metric = "dense_e",
-                               save_warmup = T)
+                               save_warmup = TRUE)
 
 fit_nosampling <- mod$sample(parallel_chains = 4,
                              iter_warmup = 200,
                              iter_sampling = 0,
-                             save_warmup = T)
+                             save_warmup = TRUE)
 
 fit_thinned <-  mod$sample(parallel_chains = 4,
                            iter_warmup = 200,
                            iter_sampling = 200,
                            thin = 5)
+
 
 fit_variational <- mod$variational()
 
@@ -108,5 +109,21 @@ test_that("read methods identical: variational inference", {
   # comparison of parameters and their draws may fail because
   # of CSV preprocessing done differently by rstan and cmdstanr
   compare_functions(test_set$VI, check_pars = FALSE)
+})
+
+
+test_that("rstan can locate max_treedepth", {
+  fit_treedepth <- mod$sample(
+    parallel_chains = 2,
+    iter_warmup = 200,
+    iter_sampling = 200,
+    max_treedepth = 2,
+    adapt_delta = .1
+  )
+  fit <- fit_treedepth$output_files() |>
+    read_csv_as_stanfit()
+  fit |>
+    rstan::check_treedepth() |>
+    expect_message("depth of 2")
 })
 

--- a/tests/testthat/tests.standata.R
+++ b/tests/testthat/tests.standata.R
@@ -1015,6 +1015,7 @@ test_that("data for multinomial, dirichlet_multinomial and dirichlet models is c
 })
 
 test_that("standata handles cox models correctly", {
+  skip_if_not_installed("splines2")
   data <- data.frame(y = rexp(100), x = rnorm(100),
                      g = sample(1:3, 100, TRUE))
 


### PR DESCRIPTION
I searched the rstan codebase for any cases where they accessed `@stan_args$control` for values and I made sure those fields were populated during `read_csv_as_stanfit()`. Those fields were `adapt_delta` and `max_treedepth`.

I also fixed a failing bayesplot test and added more `skip_if_not_installed()` for Suggested packages that I did not have installed. 

Closes #1767 