### PR TITLE
Clarification of role of seed argument for point hypotheses

### DIFF
--- a/R/hypothesis.R
+++ b/R/hypothesis.R
@@ -31,7 +31,8 @@
 #'  output of \code{\link{coef.brmsfit}} and \code{\link{ranef.brmsfit}},
 #'  respectively.
 #' @param seed A single numeric value passed to \code{\link{set.seed}}
-#'  to make results reproducible.
+#'  to make results reproducible. This is currently only relevant for point 
+#'  hypotheses that scope over at least two parameters (see Details). 
 #' @param ... Currently ignored.
 #'
 #' @details Among others, \code{hypothesis} computes an evidence ratio
@@ -41,7 +42,7 @@
 #'   \code{a > b}, the evidence ratio is the ratio of the posterior probability
 #'   of \code{a > b} and the posterior probability of \code{a < b}. In this
 #'   example, values greater than one indicate that the evidence in favor of
-#'   \code{a > b} is larger than evidence in favor of \code{a < b}. For an
+#'   \code{a > b} is larger than evidence in favor of \code{a < b}. For a
 #'   two-sided (point) hypothesis, the evidence ratio is a Bayes factor between
 #'   the hypothesis and its alternative computed via the Savage-Dickey density
 #'   ratio method. That is the posterior density at the point of interest
@@ -51,14 +52,25 @@
 #'   related to the hypothesis must have proper priors and argument
 #'   \code{sample_prior} of function \code{brm} must be set to \code{"yes"}.
 #'   Otherwise \code{Evid.Ratio} (and \code{Post.Prob}) will be \code{NA}.
-#'   Please note that, for technical reasons, we cannot sample from priors of
-#'   certain parameters classes. Most notably, these include overall intercept
-#'   parameters (prior class \code{"Intercept"}) as well as group-level
-#'   coefficients. When interpreting Bayes factors, make sure that your priors
-#'   are reasonable and carefully chosen, as the result will depend heavily on
-#'   the priors. In particular, avoid using default priors.
+#'   
+#'   Please note that the Savage-Dickey density ratio as implemented here provides 
+#'   only a very basic test of point hypotheses. It is recommended that you use 
+#'   bridge sampling instead (via \code{\link{bayes_factor}} which relies on the 
+#'   \pkg{bridgesampling} package). When interpreting Bayes factors for point 
+#'   hypotheses, make sure that your priors are reasonable and carefully chosen, 
+#'   as the result will depend heavily on the priors. In particular, avoid using 
+#'   default priors. Additionally, note that point hypotheses that scope over more 
+#'   than one parameter (e.g., when testing equality between two parameters) involve
+#'   random sampling of the priors over those parameters (to accommodate the 
+#'   the assumption that priors for different parameters are independent of each other). 
+#'   This introduces an element of randomness into such hypothesis tests. Consider 
+#'   repeating the test to assure results are sufficiently stable, and use the argument 
+#'   \code{seed} for reproducibility. Finally, note that, for technical reasons, we 
+#'   cannot sample from priors of certain parameters classes. Most notably, these include 
+#'   overall intercept parameters (prior class \code{"Intercept"}) as well as group-level
+#'   coefficients. 
 #'
-#'   The \code{Evid.Ratio} may sometimes be \code{0} or \code{Inf} implying very
+#'   For one-sided hypotheses, the \code{Evid.Ratio} may sometimes be \code{0} or \code{Inf} implying very
 #'   small or large evidence, respectively, in favor of the tested hypothesis.
 #'   For one-sided hypotheses pairs, this basically means that all posterior
 #'   draws are on the same side of the value dividing the two hypotheses. In


### PR DESCRIPTION
Clarified that seed argument only affects point hypotheses that scope over more than one parameter. I also reordered that clarifications about the Savage-Dickey method under Details a bit. Finally, as suggested by Paul, I clarified that users should consider bridge sampling instead of the denisty_ratio method.

See conversation at https://github.com/paul-buerkner/brms/issues/1750#issuecomment-2850200193.