### PR TITLE
add loo_pit_ecdf to aps_types

### DIFF
--- a/R/pp_check.R
+++ b/R/pp_check.R
@@ -125,6 +125,7 @@ pp_check.brmsfit <- function(object, type, ndraws = NULL, prefix = c("ppc", "ppd
       "intervals", "intervals_grouped",
       "loo_intervals", "loo_pit", "loo_pit_overlay",
       "loo_pit_qq", "loo_ribbon",
+      "loo_pit_ecdf",
       'pit_ecdf', 'pit_ecdf_grouped',
       "ribbon", "ribbon_grouped",
       "rootogram", "scatter_avg", "scatter_avg_grouped",


### PR DESCRIPTION
`ppc_loo_pit_ecdf` was recently added to `bayesplot`. This PR will add "loo_pit_ecdf" to aps_types, so that by default all posterior draws are used to make the plot. Otherwise, using github version of `bayesplot` `pp_check(fit, type="loo_pit_ecdf")` works already