### PR TITLE
require testthat (>= 3.1.9) in Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Imports:
     grDevices,
     backports
 Suggests:
-    testthat (>= 0.9.1),
+    testthat (>= 3.1.9),
     emmeans (>= 1.4.2),
     cmdstanr (>= 0.5.0),
     projpred (>= 2.0.0),


### PR DESCRIPTION
Update testthat version in Suggests to >= 3.1.9, since recent tests depend on it.

Closes #1796.