### PR TITLE
fix for summary.brmsfit when it does not have fit property

### DIFF
--- a/R/summary.R
+++ b/R/summary.R
@@ -44,7 +44,7 @@ summary.brmsfit <- function(object, priors = FALSE, prob = 0.95,
   class(out) <- "brmssummary"
 
   # check if the model contains any posterior draws
-  model_is_empty <- !length(object$fit@sim) ||
+  model_is_empty <- is.null(object$fit) || !length(object$fit@sim) ||
     isTRUE(object$fit@sim$iter <= object$fit@sim$warmup)
   if (model_is_empty) {
     return(out)

--- a/tests/testthat/tests.brmsfit-helpers.R
+++ b/tests/testthat/tests.brmsfit-helpers.R
@@ -106,6 +106,8 @@ test_that("brmsfit_needs_refit works correctly", {
   data_model1 <- data.frame(y = rnorm(10), x = rnorm(10))
   fake_fit <- brm(y ~ x, data = data_model1, empty = TRUE)
 
+  expect_error(summary(fake_fit), NA)
+
   fake_fit_file <- fake_fit
   # align windows with unix encoding of file paths
   fake_fit_file$file <- gsub("\\", "/", cache_tmp, fixed = TRUE)
@@ -120,6 +122,8 @@ test_that("brmsfit_needs_refit works correctly", {
 
   write_brmsfit(fake_fit, file = cache_tmp)
   cache_res <- read_brmsfit(file = cache_tmp)
+  expect_error(summary(cache_res), NA)
+
   expect_equal(cache_res, fake_fit_file)
 
   expect_false(brmsfit_needs_refit(


### PR DESCRIPTION
summary.brmsfit function gives error when it does not have object$fim@sim 

closes #1795
```R

library(brms)
# brms v2.21.0 

data_model1 <- data.frame(y = rnorm(10), x = rnorm(10))
fake_fit <- brm(y ~ x, data = data_model1, empty = TRUE)
summary(fake_fit )

Error in summary.brmsfit(x, ...) : 
   trying to get slot "sim" from an object of a basic class ("NULL") with no slots
  Called from: summary.brmsfit(x, ...)
```