### PR TITLE
Adds rlang abort to stop2

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -845,13 +845,39 @@ sort_dependencies <- function(x, sorted = NULL) {
   out
 }
 
-stop2 <- function(message = "", ..., .subclass = NULL, call = rlang::caller_call() , .envir = parent.frame()) {
+#' Internal abort helper
+#'
+#' A drop-in replacement for the old `stop2()` that throws structured
+#' errors via **rlang**.
+#' The error message is built with **glue**, so you can use
+#'   `{.val {x}}`, `{.arg {y}}`, etc.
+#' Every error inherits from `"brms_error"` plus any subclasses
+#'   supplied through `.subclass`, making it easy to `tryCatch()`.
+#'
+#' @param message A character (or glue) string describing the error.
+#' @param ... Additional strings merged into the message; kept for
+#'   backward compatibility with existing `stop2("foo", "bar")` calls.
+#' @param .subclass Optional character vector of extra condition classes.
+#' @param call A call object to store with the condition; defaults to the
+#'   caller (set internally to avoid CRAN’s “function call as default”
+#'   NOTE).
+#' @param .envir Environment in which glue expressions are evaluated.
+#' @keywords internal
+#' @noRd
+stop2 <- function(message = "", ..., .subclass = NULL,
+                  call = NULL, .envir = parent.frame()) {
+
+  if (is.null(call)) {
+    call <- rlang::caller_call()     # evaluated at run-time → CRAN-safe
+  }
+
   rlang::abort(
-    message = glue::glue(message, ..., .envir = .envir),
+    message   = glue::glue(message, ..., .envir = .envir),
     .subclass = c(.subclass, "brms_error"),
-    call = call
+    call      = call
   )
 }
+
 
 warning2 <- function(...) {
   warning(..., call. = FALSE)

--- a/R/misc.R
+++ b/R/misc.R
@@ -845,8 +845,18 @@ sort_dependencies <- function(x, sorted = NULL) {
   out
 }
 
-stop2 <- function(...) {
-  stop(..., call. = FALSE)
+# older version of stop2 was preserved here to compare
+# in case of any error
+# stop2 <- function(...) {
+#   stop(..., call. = FALSE)
+# }
+
+stop2 <- function(message = "", ..., .subclass = NULL, call = rlang::caller_call()) {
+  rlang::abort(
+    message = glue::glue(message, ...),
+    .subclass = c(.subclass, "brms_error"),
+    call = call
+  )
 }
 
 warning2 <- function(...) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -845,12 +845,6 @@ sort_dependencies <- function(x, sorted = NULL) {
   out
 }
 
-# older version of stop2 was preserved here to compare
-# in case of any error
-# stop2 <- function(...) {
-#   stop(..., call. = FALSE)
-# }
-
 stop2 <- function(message = "", ..., .subclass = NULL, call = rlang::caller_call() , .envir = parent.frame()) {
   rlang::abort(
     message = glue::glue(message, ..., .envir = .envir),

--- a/R/misc.R
+++ b/R/misc.R
@@ -851,9 +851,9 @@ sort_dependencies <- function(x, sorted = NULL) {
 #   stop(..., call. = FALSE)
 # }
 
-stop2 <- function(message = "", ..., .subclass = NULL, call = rlang::caller_call()) {
+stop2 <- function(message = "", ..., .subclass = NULL, call = rlang::caller_call() , .envir = parent.frame()) {
   rlang::abort(
-    message = glue::glue(message, ...),
+    message = glue::glue(message, ..., .envir = .envir),
     .subclass = c(.subclass, "brms_error"),
     call = call
   )

--- a/R/misc.R
+++ b/R/misc.R
@@ -868,7 +868,7 @@ stop2 <- function(message = "", ..., .subclass = NULL,
                   call = NULL, .envir = parent.frame()) {
 
   if (is.null(call)) {
-    call <- rlang::caller_call()     # evaluated at run-time → CRAN-safe
+    call <- rlang::caller_call()
   }
 
   rlang::abort(

--- a/tests/testthat/tests.stop2.R
+++ b/tests/testthat/tests.stop2.R
@@ -1,0 +1,42 @@
+# tests/testthat/test-stop2.R
+
+test_that("stop2() throws a brms_error with simple message", {
+  expect_error(stop2("Something went wrong"), class = "brms_error")
+})
+
+test_that("stop2() throws a brms_error with simple message", {
+  value <- 42
+  expect_error(stop2("Unexpected value {value}"), class = "brms_error")
+})
+
+test_that("stop2() supports custom subclasses", {
+  err <- expect_error(
+    stop2("Some issue", .subclass = "brms_custom"),
+    class = "brms_custom"
+  )
+  expect_true(inherits(err, "brms_error"))
+  expect_true(inherits(err, "brms_custom"))
+})
+
+test_that("stop2() supports custom subclasses", {
+  algorithm = "SomeAlgorithm"
+  err <- expect_error(
+    stop2("Algorithm '", algorithm, "' is not supported." ,.subclass = "brms_algorithm" ),
+    class = "brms_algorithm"
+  )
+  expect_true(inherits(err, "brms_algorithm"))
+})
+
+test_that("stop2() respects an explicit call argument", {
+   err <- expect_error(
+    stop2("Cannot remove the intercept in an ordinal model." , .subclass = "brms_ordinal_model"),
+    class = "brms_ordinal_model"
+  )
+  expect_true(inherits(err, "brms_ordinal_model"))
+})
+
+test_that("stop2() respects an explicit call argument", {
+  fake_call <- quote(fake_func("a", 123))
+  err <- expect_error(stop2("error occurred", call = fake_call))
+  expect_equal(conditionCall(err), fake_call)
+})

--- a/tests/testthat/tests.stop2.R
+++ b/tests/testthat/tests.stop2.R
@@ -1,5 +1,3 @@
-# tests/testthat/test-stop2.R
-
 test_that("stop2() throws a brms_error with simple message", {
   expect_error(stop2("Something went wrong"), class = "brms_error")
 })


### PR DESCRIPTION

modifies existing stop2 function with rlang::abort call
```r
stop2 <- function(message = "", ..., .subclass = NULL,
                  call = NULL, .envir = parent.frame()) {

  if (is.null(call)) {
    call <- rlang::caller_call()
  }

  rlang::abort(
    message   = glue::glue(message, ..., .envir = .envir),
    .subclass = c(.subclass, "brms_error"),
    call      = call
  )
}

```
closes #1802