### PR TITLE
validate_newdata(): ignore levels missing in new/old data

### DIFF
--- a/R/data-helpers.R
+++ b/R/data-helpers.R
@@ -494,12 +494,12 @@ validate_newdata <- function(
         if (!is.factor(new_factor)) {
           new_factor <- factor(new_factor)
         }
-        old_levels <- levels(factors[[i]])
+        old_levels <- levels(droplevels(factors[[i]]))
         if (length(old_levels) <= 1L) {
           # contrasts are not defined for factors with 1 or fewer levels
           next
         }
-        new_levels <- levels(new_factor)
+        new_levels <- levels(droplevels(new_factor))
         old_contrasts <- contrasts(factors[[i]])
         old_ordered <- is.ordered(factors[[i]])
         to_zero <- is.na(new_factor) | new_factor %in% "zero__"


### PR DESCRIPTION
I've run into an issue when applying the fit model to a new data, because one of the factors had the levels there were not present in the data used to fit the model.
However, the new data contained no actual observations with the factor set to that level, so it was a false alarm.

OTOH, when looking at the code of `validate_newdata()`, it seems the false no-alarm may also happen -- the training data may lack some specific levels of the factor (and the corresponding effects too), but the check will consider that it is there.

This PR should fix both errors by calling `droplevels(factorvar)` for new and old data to ignore the levels that are not actually present in the dataset.