### PR TITLE
Improved posterior density approximation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,8 +46,7 @@ Imports:
     utils,
     parallel,
     grDevices,
-    backports,
-    logspline
+    backports
 Suggests:
     testthat (>= 0.9.1),
     emmeans (>= 1.4.2),
@@ -73,7 +72,8 @@ Suggests:
     gtable,
     shiny,
     knitr,
-    rmarkdown
+    rmarkdown,
+    KernSmooth
 Description: Fit Bayesian generalized (non-)linear multivariate multilevel models
     using 'Stan' for full Bayesian inference. A wide range of distributions
     and link functions are supported, allowing users to fit -- among others --

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,8 @@ Imports:
     utils,
     parallel,
     grDevices,
-    backports
+    backports,
+    logspline
 Suggests:
     testthat (>= 0.9.1),
     emmeans (>= 1.4.2),

--- a/R/hypothesis.R
+++ b/R/hypothesis.R
@@ -447,8 +447,7 @@ density_ratio <- function(x, y = NULL, point = 0, n = 4096, ...) {
     } else if (to < point) {
       to <- point + sd(x) / 4
     }
-    dens <- do_call(density, c(nlist(x, from, to), dots))
-    return(spline(dens$x, dens$y, xout = point)$y)
+    logspline::dlogspline(point, logspline::logspline(x, lbound = from, ubound = to))
   }
 
   out <- ulapply(point, eval_density, x = x)

--- a/R/hypothesis.R
+++ b/R/hypothesis.R
@@ -332,8 +332,8 @@ eval_hypothesis <- function(h, x, class, alpha, robust, name = NULL) {
   # summarize hypothesis
   wsign <- switch(sign, "=" = "equal", "<" = "less", ">" = "greater")
   probs <- switch(sign,
-    "=" = c(alpha / 2, 1 - alpha / 2),
-    "<" = c(alpha, 1 - alpha), ">" = c(alpha, 1 - alpha)
+                  "=" = c(alpha / 2, 1 - alpha / 2),
+                  "<" = c(alpha, 1 - alpha), ">" = c(alpha, 1 - alpha)
   )
   if (robust) {
     measures <- c("median", "mad")
@@ -447,7 +447,8 @@ density_ratio <- function(x, y = NULL, point = 0, n = 4096, ...) {
     } else if (to < point) {
       to <- point + sd(x) / 4
     }
-    logspline::dlogspline(point, logspline::logspline(x, lbound = from, ubound = to))
+    density <- KernSmooth::bkde(x, range.x = c(from,to), gridsize = n)
+    stats::approx(density$x, density$y, xout = point)$y
   }
 
   out <- ulapply(point, eval_density, x = x)


### PR DESCRIPTION
Resolve #1816 by improving the density approximation in `density_ratio`. Following [Deng & Wickham (2011)](https://vita.had.co.nz/papers/density-estimation.pdf) I suggest to implement the density approximation implemented in the `KernSmoot.h` package.

Specifically, I changed the density approximation from `stats::density` to `KernSmooth::bkde` and then approximated the density at the required `point` using `stats::approx`.

Initially, I implemented the density approximation with the `logspline` package, but the examples of the `hypothesis` function threw some warnings, and I thought this would not be ideal.

Let me know, what you think of these changes and if I should run some additional tests.