### PR TITLE
Updated default prior for phi to inv_gamma(0.4, 0.3)

### DIFF
--- a/R/family-lists.R
+++ b/R/family-lists.R
@@ -513,7 +513,14 @@
     ad = c("weights", "subset", "cens", "trunc", "index"),
     include = "fun_hurdle_negbinomial.stan",
     specials = c("sbi_log", "sbi_hu_logit"),
-    normalized = ""
+    normalized = "",
+    # experimental use of default priors stored in families #1614
+    prior = function(dpar, link = "identity", ...) {
+      if (dpar == "shape" && link == "identity") {
+        return("inv_gamma(0.4, 0.3)")
+      }
+      NULL
+    }
   )
 }
 
@@ -578,7 +585,14 @@
     ad = c("weights", "subset", "cens", "trunc", "index"),
     include = "fun_zero_inflated_negbinomial.stan",
     specials = c("sbi_log", "sbi_zi_logit"),
-    normalized = ""
+    normalized = "",
+    # experimental use of default priors stored in families #1614
+    prior = function(dpar, link = "identity", ...) {
+      if (dpar == "shape" && link == "identity") {
+        return("inv_gamma(0.4, 0.3)")
+      }
+      NULL
+    }
   )
 }
 

--- a/R/priors.R
+++ b/R/priors.R
@@ -1105,7 +1105,7 @@ def_dpar_prior <- function(x, dpar) {
     out <- switch(dpar_class, "",
       mu = def_scale_prior(x, center = FALSE, dpar = dpar),
       sigma = def_scale_prior(x),
-      shape = "gamma(0.01, 0.01)",
+      shape = "inv_gamma(0.4, 0.3)",
       nu = "gamma(2, 0.1)",
       phi = "gamma(0.01, 0.01)",
       kappa = "gamma(2, 0.01)",


### PR DESCRIPTION
Updated default prior for negative binomial's phi was previously overseen for zero-inflated and hurdle models. I have added the new prior to the family-lists.R(experimental) and also to priors.R. The documentation should already be accurate, mentioning inv_gamma(0.4, 0.3) for negative binomial families.