### PR TITLE
extend documentation on parallelisation and suggest use of mirai via future.mirai

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,7 +82,9 @@ Suggests:
     knitr,
     rmarkdown,
     ragg,
-    colorspace
+    colorspace,
+    mirai,
+    future.mirai
 Description: Fit Bayesian generalized (non-)linear multivariate multilevel models
     using 'Stan' for full Bayesian inference. A wide range of distributions
     and link functions are supported, allowing users to fit -- among others --

--- a/R/brm.R
+++ b/R/brm.R
@@ -306,6 +306,8 @@
 #'   usually be larger than the current default of \code{10}. For more details
 #'   on the \code{control} argument see \code{\link[rstan:stan]{stan}}.
 #'
+#' @template parallelization
+#'
 #' @references
 #' Paul-Christian Buerkner (2017). brms: An R Package for Bayesian Multilevel
 #' Models Using Stan. \emph{Journal of Statistical Software}, 80(1), 1-28.
@@ -416,8 +418,15 @@
 #' # use the future package for more flexible parallelization
 #' library(future)
 #' plan(multisession, workers = 4)
-#' fit7 <- update(fit7, future = TRUE)
+#' fit7a <- update(fit7, future = TRUE)
 #'
+#' # we may also use mirai allowing the use of remote machines as
+#' # well, including the use of computer clusters managed by queuing
+#' # systems
+#' mirai::daemons(4) # distributed computing with url and remote argument
+#' plan(future.mirai::mirai_cluster)
+#' fit7b <- update(fit7, future = TRUE)
+#' mirai::daemons(0) # shuts down the 4 workers
 #'
 #' # fit a model manually via rstan
 #' scode <- stancode(count ~ Trt, data = epilepsy)

--- a/R/brm_multiple.R
+++ b/R/brm_multiple.R
@@ -38,6 +38,8 @@
 #'   to the individual models and then run convergence diagnostics.
 #'   See Examples below for details.
 #'
+#' @template parallelization
+#'
 #' @return If \code{combine = TRUE} a \code{brmsfit_multiple} object, which
 #'   inherits from class \code{brmsfit} and behaves essentially the same. If
 #'   \code{combine = FALSE} a list of \code{brmsfit} objects.

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -96,6 +96,8 @@
 #'   \code{"cmdstanr_write_stan_file_dir"} to a nontemporary path of your choice
 #'   before creating the original \code{brmsfit} (see section 'Examples' below).
 #'
+#' @template parallelization
+#'
 #' @examples
 #' \dontrun{
 #' fit1 <- brm(count ~ zAge + zBase * Trt + (1|patient) + (1|obs),

--- a/R/reloo.R
+++ b/R/reloo.R
@@ -43,6 +43,8 @@
 #' previous estimates from these \eqn{J} observations that are stored in the
 #' original \code{loo} object.
 #'
+#' @template parallelization
+#'
 #' @seealso \code{\link{loo}}, \code{\link{kfold}}
 #'
 #' @examples

--- a/man-roxygen/parallelization.R
+++ b/man-roxygen/parallelization.R
@@ -1,0 +1,34 @@
+#' @section Parallelization with multiple CPU cores:
+#'
+#' \pkg{brms} can make use of multiple CPU cores in parallel to speed
+#' up computations in various ways. For efficient use of the
+#' available resources it is recommended to only use parallelism to
+#' an extend such that the available physical CPUs are not
+#' oversubscribed. For example, when you have 8 CPU cores locally
+#' available, then you may consider to run 4 chains with 2 threads
+#' per chain for best performance if you happen to just run a single
+#' model. In case you run a simulation study which requires to run
+#' many times a given model, then neither chain nor within-chain
+#' parallelization is advisable as the computational resources are
+#' already exhausted by the simulation study and any further
+#' parallelization beyond the simulation study itself will in fact
+#' slow down the overall runtime. Please be aware that for
+#' historical reasons the nomenclature of the arguments is possibly
+#' confusing. The \code{cores} argument refers to running different
+#' chains in parallel and the within-chain parallelization will
+#' allocate for each chain as many threads as requested. The
+#' requested threads therefore increase the use of overall CPUs in a
+#' multiplicative way.
+#'
+#' For more advanced parallelization (including beyond single model
+#' fits), \pkg{brms} also integrates with the \pkg{future}
+#' package. Importantly, this enables seamless integration with the
+#' \pkg{mirai} parallelization framework through the use of the
+#' \pkg{future.mirai} adapter. With \pkg{mirai} local and remote
+#' machines can be used in a fully transparent manner to the
+#' user. This includes the possibility to use large number of remote
+#' machines running in the context of a computer cluster, which are
+#' managed with queuing systems. Please refer to the section on
+#' distributed computing of
+#' \code{\link[mirai:daemons]{mirai::daemons}}.
+#'

--- a/man/brm.Rd
+++ b/man/brm.Rd
@@ -398,6 +398,42 @@ Fit a generalized (non-)linear multivariate multilevel model via
   usually be larger than the current default of \code{10}. For more details
   on the \code{control} argument see \code{\link[rstan:stan]{stan}}.
 }
+\section{Parallelization with multiple CPU cores}{
+
+
+\pkg{brms} can make use of multiple CPU cores in parallel to speed
+up computations in various ways. For efficient use of the
+available resources it is recommended to only use parallelism to
+an extend such that the available physical CPUs are not
+oversubscribed. For example, when you have 8 CPU cores locally
+available, then you may consider to run 4 chains with 2 threads
+per chain for best performance if you happen to just run a single
+model. In case you run a simulation study which requires to run
+many times a given model, then neither chain nor within-chain
+parallelization is advisable as the computational resources are
+already exhausted by the simulation study and any further
+parallelization beyond the simulation study itself will in fact
+slow down the overall runtime. Please be aware that for
+historical reasons the nomenclature of the arguments is possibly
+confusing. The \code{cores} argument refers to running different
+chains in parallel and the within-chain parallelization will
+allocate for each chain as many threads as requested. The
+requested threads therefore increase the use of overall CPUs in a
+multiplicative way.
+
+For more advanced parallelization (including beyond single model
+fits), \pkg{brms} also integrates with the \pkg{future}
+package. Importantly, this enables seamless integration with the
+\pkg{mirai} parallelization framework through the use of the
+\pkg{future.mirai} adapter. With \pkg{mirai} local and remote
+machines can be used in a fully transparent manner to the
+user. This includes the possibility to use large number of remote
+machines running in the context of a computer cluster, which are
+managed with queuing systems. Please refer to the section on
+distributed computing of
+\code{\link[mirai:daemons]{mirai::daemons}}.
+}
+
 \examples{
 \dontrun{
 # Poisson regression for the number of seizures in epileptic patients
@@ -496,8 +532,15 @@ conditional_effects(fit7)
 # use the future package for more flexible parallelization
 library(future)
 plan(multisession, workers = 4)
-fit7 <- update(fit7, future = TRUE)
+fit7a <- update(fit7, future = TRUE)
 
+# we may also use mirai allowing the use of remote machines as
+# well, including the use of computer clusters managed by queuing
+# systems
+mirai::daemons(4) # distributed computing with url and remote argument
+plan(future.mirai::mirai_cluster)
+fit7b <- update(fit7, future = TRUE)
+mirai::daemons(0) # shuts down the 4 workers
 
 # fit a model manually via rstan
 scode <- stancode(count ~ Trt, data = epilepsy)

--- a/man/brm_multiple.Rd
+++ b/man/brm_multiple.Rd
@@ -205,6 +205,42 @@ The combined model may issue false positive convergence warnings, as
   to the individual models and then run convergence diagnostics.
   See Examples below for details.
 }
+\section{Parallelization with multiple CPU cores}{
+
+
+\pkg{brms} can make use of multiple CPU cores in parallel to speed
+up computations in various ways. For efficient use of the
+available resources it is recommended to only use parallelism to
+an extend such that the available physical CPUs are not
+oversubscribed. For example, when you have 8 CPU cores locally
+available, then you may consider to run 4 chains with 2 threads
+per chain for best performance if you happen to just run a single
+model. In case you run a simulation study which requires to run
+many times a given model, then neither chain nor within-chain
+parallelization is advisable as the computational resources are
+already exhausted by the simulation study and any further
+parallelization beyond the simulation study itself will in fact
+slow down the overall runtime. Please be aware that for
+historical reasons the nomenclature of the arguments is possibly
+confusing. The \code{cores} argument refers to running different
+chains in parallel and the within-chain parallelization will
+allocate for each chain as many threads as requested. The
+requested threads therefore increase the use of overall CPUs in a
+multiplicative way.
+
+For more advanced parallelization (including beyond single model
+fits), \pkg{brms} also integrates with the \pkg{future}
+package. Importantly, this enables seamless integration with the
+\pkg{mirai} parallelization framework through the use of the
+\pkg{future.mirai} adapter. With \pkg{mirai} local and remote
+machines can be used in a fully transparent manner to the
+user. This includes the possibility to use large number of remote
+machines running in the context of a computer cluster, which are
+managed with queuing systems. Please refer to the section on
+distributed computing of
+\code{\link[mirai:daemons]{mirai::daemons}}.
+}
+
 \examples{
 \dontrun{
 library(mice)

--- a/man/hypothesis.brmsfit.Rd
+++ b/man/hypothesis.brmsfit.Rd
@@ -59,7 +59,7 @@ the measure of variability. If \code{TRUE}, the median and the
 median absolute deviation (MAD) are applied instead.}
 
 \item{seed}{A single numeric value passed to \code{\link{set.seed}}
-to make results reproducible. This is currently only relevant for point 
+to make results reproducible. This is currently only relevant for point
 hypotheses that scope over at least two parameters (see Details).}
 
 \item{...}{Currently ignored.}
@@ -88,23 +88,23 @@ Among others, \code{hypothesis} computes an evidence ratio
   related to the hypothesis must have proper priors and argument
   \code{sample_prior} of function \code{brm} must be set to \code{"yes"}.
   Otherwise \code{Evid.Ratio} (and \code{Post.Prob}) will be \code{NA}.
-  
-  Please note that the Savage-Dickey density ratio as implemented here provides 
-  only a very basic test of point hypotheses. It is recommended that you use 
-  bridge sampling instead (via \code{\link{bayes_factor}} which relies on the 
-  \pkg{bridgesampling} package). When interpreting Bayes factors for point 
-  hypotheses, make sure that your priors are reasonable and carefully chosen, 
-  as the result will depend heavily on the priors. In particular, avoid using 
-  default priors. Additionally, note that point hypotheses that scope over more 
+
+  Please note that the Savage-Dickey density ratio as implemented here provides
+  only a very basic test of point hypotheses. It is recommended that you use
+  bridge sampling instead (via \code{\link{bayes_factor}} which relies on the
+  \pkg{bridgesampling} package). When interpreting Bayes factors for point
+  hypotheses, make sure that your priors are reasonable and carefully chosen,
+  as the result will depend heavily on the priors. In particular, avoid using
+  default priors. Additionally, note that point hypotheses that scope over more
   than one parameter (e.g., when testing equality between two parameters) involve
-  random sampling of the priors over those parameters (to accommodate the 
-  the assumption that priors for different parameters are independent of each other). 
-  This introduces an element of randomness into such hypothesis tests. Consider 
-  repeating the test to assure results are sufficiently stable, and use the argument 
-  \code{seed} for reproducibility. Finally, note that, for technical reasons, we 
-  cannot sample from priors of certain parameters classes. Most notably, these include 
+  random sampling of the priors over those parameters (to accommodate the
+  the assumption that priors for different parameters are independent of each other).
+  This introduces an element of randomness into such hypothesis tests. Consider
+  repeating the test to assure results are sufficiently stable, and use the argument
+  \code{seed} for reproducibility. Finally, note that, for technical reasons, we
+  cannot sample from priors of certain parameters classes. Most notably, these include
   overall intercept parameters (prior class \code{"Intercept"}) as well as group-level
-  coefficients. 
+  coefficients.
 
   For one-sided hypotheses, the \code{Evid.Ratio} may sometimes be \code{0} or \code{Inf} implying very
   small or large evidence, respectively, in favor of the tested hypothesis.

--- a/man/kfold.brmsfit.Rd
+++ b/man/kfold.brmsfit.Rd
@@ -139,6 +139,42 @@ The \code{kfold} function performs exact \eqn{K}-fold
   \code{"cmdstanr_write_stan_file_dir"} to a nontemporary path of your choice
   before creating the original \code{brmsfit} (see section 'Examples' below).
 }
+\section{Parallelization with multiple CPU cores}{
+
+
+\pkg{brms} can make use of multiple CPU cores in parallel to speed
+up computations in various ways. For efficient use of the
+available resources it is recommended to only use parallelism to
+an extend such that the available physical CPUs are not
+oversubscribed. For example, when you have 8 CPU cores locally
+available, then you may consider to run 4 chains with 2 threads
+per chain for best performance if you happen to just run a single
+model. In case you run a simulation study which requires to run
+many times a given model, then neither chain nor within-chain
+parallelization is advisable as the computational resources are
+already exhausted by the simulation study and any further
+parallelization beyond the simulation study itself will in fact
+slow down the overall runtime. Please be aware that for
+historical reasons the nomenclature of the arguments is possibly
+confusing. The \code{cores} argument refers to running different
+chains in parallel and the within-chain parallelization will
+allocate for each chain as many threads as requested. The
+requested threads therefore increase the use of overall CPUs in a
+multiplicative way.
+
+For more advanced parallelization (including beyond single model
+fits), \pkg{brms} also integrates with the \pkg{future}
+package. Importantly, this enables seamless integration with the
+\pkg{mirai} parallelization framework through the use of the
+\pkg{future.mirai} adapter. With \pkg{mirai} local and remote
+machines can be used in a fully transparent manner to the
+user. This includes the possibility to use large number of remote
+machines running in the context of a computer cluster, which are
+managed with queuing systems. Please refer to the section on
+distributed computing of
+\code{\link[mirai:daemons]{mirai::daemons}}.
+}
+
 \examples{
 \dontrun{
 fit1 <- brm(count ~ zAge + zBase * Trt + (1|patient) + (1|obs),

--- a/man/reloo.brmsfit.Rd
+++ b/man/reloo.brmsfit.Rd
@@ -84,6 +84,42 @@ to the total ELPD are then computed directly and substituted for the
 previous estimates from these \eqn{J} observations that are stored in the
 original \code{loo} object.
 }
+\section{Parallelization with multiple CPU cores}{
+
+
+\pkg{brms} can make use of multiple CPU cores in parallel to speed
+up computations in various ways. For efficient use of the
+available resources it is recommended to only use parallelism to
+an extend such that the available physical CPUs are not
+oversubscribed. For example, when you have 8 CPU cores locally
+available, then you may consider to run 4 chains with 2 threads
+per chain for best performance if you happen to just run a single
+model. In case you run a simulation study which requires to run
+many times a given model, then neither chain nor within-chain
+parallelization is advisable as the computational resources are
+already exhausted by the simulation study and any further
+parallelization beyond the simulation study itself will in fact
+slow down the overall runtime. Please be aware that for
+historical reasons the nomenclature of the arguments is possibly
+confusing. The \code{cores} argument refers to running different
+chains in parallel and the within-chain parallelization will
+allocate for each chain as many threads as requested. The
+requested threads therefore increase the use of overall CPUs in a
+multiplicative way.
+
+For more advanced parallelization (including beyond single model
+fits), \pkg{brms} also integrates with the \pkg{future}
+package. Importantly, this enables seamless integration with the
+\pkg{mirai} parallelization framework through the use of the
+\pkg{future.mirai} adapter. With \pkg{mirai} local and remote
+machines can be used in a fully transparent manner to the
+user. This includes the possibility to use large number of remote
+machines running in the context of a computer cluster, which are
+managed with queuing systems. Please refer to the section on
+distributed computing of
+\code{\link[mirai:daemons]{mirai::daemons}}.
+}
+
 \examples{
 \dontrun{
 fit1 <- brm(count ~ zAge + zBase * Trt + (1|patient),


### PR DESCRIPTION
Adds instructions for users how to consider parallelisation and suggests the use of mirai via future.mirai as it enables to push companions to a computer cluster.

Optionally we could also add a link to https://opensource.nibr.com/bamdd/src/03b_parallel.html where these things are detailed, but that is not yet in the text.