### PR TITLE
Failure of `r_eff_helper` check in tests.brmsfit-methods.R

### DIFF
--- a/R/loo.R
+++ b/R/loo.R
@@ -747,10 +747,7 @@ subset.psis <- function(x, subset, ...) {
 # @param allow_na allow NA values in the output?
 # @return numeric vector of relative efficiencies, length NCOL(x) or nobs for function
 r_eff_helper <- function(x, chain_id, allow_na = TRUE, ...) {
-  # if pointwise=TRUE, x is a function else it is a matrix of draws
-  x <- if (is.function(x)) list(...)$draws else x
-
-  if (anyNA(x) || any(is.infinite(x))) {
+  if (!is.function(x) && (anyNA(x) || any(is.infinite(x)))) {
     warning2("Ignoring relative efficiencies due to NA or infinte inputs.")
     return(rep(1, NCOL(x)))
   }


### PR DESCRIPTION
## Description
I was noticinv that the tests for `tests.brmsfit-methods.R` currently fail with the error message:
```
Error in `r_eff_helper(lik_fun, chain_id = chain_id, draws = draws, allow_na = allow_na, ...)`: anyNA() applied to non-(list or vector) of type 'closure'
```
After debugging I assume that the origin of the failure is that the function `r_eff_helper(x, chain_id, allow_na = TRUE, ...)` checks `(anyNA(x) || any(is.infinite(x))`. However, if `pointwise = TRUE` the argument x is a function in which case the check yields the above error message. 

## Proposed solution

Including a !is.function(x) in check to differentiate between different cases (x is function / x is matrix with posterior draws).

## TODOs
+ [x] modify check
+ [x] update function documentation
+ [x] ensure that checks pass now 