### PR TITLE
replace model_params with variables

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -767,7 +767,7 @@ read_csv_as_stanfit <- function(files, variables = NULL, sampler_diagnostics = N
   names(par_dims) <- model_pars
   par_dims <- lapply(par_dims, function(x) integer(0))
   pdims_num <- ulapply(model_pars, function(x)
-    sum(grepl(paste0("^", x, "\\[.*\\]$"), csfit$metadata$model_params))
+    sum(grepl(paste0("^", x, "\\[.*\\]$"), csfit$metadata$variables))
   )
   par_dims[pdims_num != 0] <-
     csfit$metadata$stan_variable_sizes[model_pars][pdims_num != 0]


### PR DESCRIPTION
Closes #1864 

cmdstanr now recommends using `variables` instead of `model_params`. I didn't add any new tests, assuming (hoping) that at least one existing test would fail if this breaks something. But it shouldn't break anything since they are identical in cmdstanr: 

https://github.com/stan-dev/cmdstanr/blob/0c31c1b628ad9106a1349a53a9114b7dfe7f44e2/R/csv.R#L331

In the future we will remove `model_params` from cmdstanr so this PR will ensure that nothing is broken when that happens.  