### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Status](https://codecov.io/github/paul-buerkner/brms/coverage.svg?branch=master)
 [![CRAN
 Version](https://www.r-pkg.org/badges/version/brms)](https://cran.r-project.org/package=brms)
 [![Downloads](https://cranlogs.r-pkg.org/badges/brms?color=brightgreen)](https://CRAN.R-project.org/package=brms)
+[![gitcgr](https://gitcgr.com/badge/paul-buerkner/brms.svg)](https://gitcgr.com/paul-buerkner/brms)
 
 ## Overview
 


### PR DESCRIPTION
Someone visualized your repository on [gitcgr.com](https://gitcgr.com/paul-buerkner/brms)! This badge lets visitors explore your codebase as an interactive graph.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/paul-buerkner/brms.svg)](https://gitcgr.com/paul-buerkner/brms)

Clicking the badge takes users to an interactive visualization of your code structure — functions, classes, modules, and their relationships.