### PR TITLE
Fix Bayesian R2 computation for normal and Bernoulli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Authors@R:
       person("Noa", "Kallioinen", role = c("ctb")),
       person("Wellington J.", "Silva", role = c("ctb")),
       person("Luiz", "Carvalho", role = c("ctb")),
-      person("Sermet", "Pekin", role = c("ctb")))
+      person("Sermet", "Pekin", role = c("ctb")),
+      person("Florence", "Bockting", role = c("ctb")))
 Depends:
     R (>= 3.6.0),
     Rcpp (>= 0.12.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@ Thanks to Sermet Pekin. (#1790)
 
 ### Bug Fixes
 
+* `bayes_R2` now uses model-based residual variances for Gaussian and Bernoulli 
+models and falls back to residual-based computation for other families. This 
+change may lead to changes in plotting results. (#1815)
 * Avoid the creation of zombie workers when executing `log_lik`
 in parallel thanks to Aki Vehtari and Noa Kallioinen. 
 For now, `log_lik` will use PSOCK clusters if run
@@ -28,7 +31,6 @@ These changes may be reverted once the underlying causes of this
 issue have been fixed. (#1658)
 * Align the definition of the R function `step()` with the definition in Stan,
 such that `step(0) == 1` thanks to Daniel Sabanes Bov. (#1734)
-* `bayes_R2` now uses model-based residual variances for Gaussian and Bernoulli models (using Tjur's pseudo-variance for Bernoulli), and warns before falling back to residual-based computation for other families, aligning `bayes_R2` with the Bayes-R2 definition in the reference paper for supported families. (#1815)
 * Make `read_csv_as_stanfit()` store `adapt_delta` and `max_treedepth` values in
 `$control` so rstan can find these values. Thanks to Tristan Mahr (#1767).
 * Enable updating argument `data2` for `brmsfit_multiple` objects. (#1776)

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ These changes may be reverted once the underlying causes of this
 issue have been fixed. (#1658)
 * Align the definition of the R function `step()` with the definition in Stan,
 such that `step(0) == 1` thanks to Daniel Sabanes Bov. (#1734)
+* `bayes_R2` now uses model-based residual variances for Gaussian and Bernoulli models (using Tjur's pseudo-variance for Bernoulli), and warns before falling back to residual-based computation for other families, aligning `bayes_R2` with the Bayes-R2 definition in the reference paper for supported families. (#1815)
 * Make `read_csv_as_stanfit()` store `adapt_delta` and `max_treedepth` values in
 `$control` so rstan can find these values. Thanks to Tristan Mahr (#1767).
 * Enable updating argument `data2` for `brmsfit_multiple` objects. (#1776)

--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -15,10 +15,10 @@
 #'
 #' @details For an introduction to the approach, see Gelman et al. (2019)
 #'  and \url{https://github.com/jgabry/bayes_R2/}.
-#'  For Gaussian and Bernoulli models, \code{bayes_R2} uses model-based
-#'  residual variances as proposed in Gelman et al. (2019), with Bernoulli
-#'  models using Tjur's pseudo-variance. For other families, \code{bayes_R2}
-#'  warns and falls back to residual-based variances.
+#'  For Gaussian (homoscedastic sigma) and Bernoulli models, \code{bayes_R2} 
+#'  uses model-based residual variances as proposed in Gelman et al. (2019), 
+#'  with Bernoulli models using Tjur's pseudo-variance. For other families, 
+#'  \code{bayes_R2} warns and falls back to residual-based variances.
 #'
 #' @references Andrew Gelman, Ben Goodrich, Jonah Gabry & Aki Vehtari. (2019).
 #'   R-squared for Bayesian regression models, \emph{The American Statistician},
@@ -77,6 +77,9 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
   args_ypred <- list(object, sort = TRUE, ...)
   R2 <- named_list(paste0("R2", resp))
   warned_families <- character(0)
+  
+  fallback_msg <- "Falling back to residual-based R2 computation."
+  
   for (i in seq_along(R2)) {
     # assumes expectations of different responses to be independent
     args_ypred$resp <- resp[i]
@@ -89,17 +92,28 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
       args_sigma <- args_ypred
       args_sigma$dpar <- "sigma"
       sigma <- do_call(posterior_epred, args_sigma)
-      var_res <- .bayes_R2_var_res_gaussian(sigma)
-      R2[[i]] <- .bayes_R2_model(ypred, var_res)
+      is_heteroscedastic <- any(
+        matrixStats::rowVars(sigma) > .Machine$double.eps * matrixStats::rowMeans2(sigma)^2
+      )
+      if (is_heteroscedastic) {
+        warning2(
+          "Detected heteroscedastic sigma. The model-based Bayes R\u00b2 is ",
+          "not yet implemented\nfor the heteroscedastic case. ", fallback_msg
+        )
+        y <- do_call(get_y, c(list(object, warn = TRUE, resp = resp[i]), list(...)))
+        R2[[i]] <- .bayes_R2_res(y, ypred)
+      } else {
+        var_res <- matrixStats::rowMeans2(sigma)^2
+        R2[[i]] <- .bayes_R2_model(ypred, var_res)
+      }
     } else if (family_name %in% "bernoulli") {
-      var_res <- .bayes_R2_var_res_bernoulli(ypred)
+      var_res <- matrixStats::rowMeans2(ypred * (1 - ypred))
       R2[[i]] <- .bayes_R2_model(ypred, var_res)
     } else {
       if (!family_name %in% warned_families) {
         warning2(
           "No model-based residual variance is currently implemented for ",
-          "family '", family_name, "' in 'bayes_R2'. Falling back ",
-          "to residual-based R2 computation."
+          "family '", family_name, "'\nin 'bayes_R2'. ", fallback_msg
         )
         warned_families <- c(warned_families, family_name)
       }
@@ -127,13 +141,4 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
 .bayes_R2_model <- function(ypred, var_res, ...) {
   var_ypred <- matrixStats::rowVars(ypred)
   as.matrix(var_ypred / (var_ypred + var_res))
-}
-
-.bayes_R2_var_res_gaussian <- function(sigma, ...) {
-  sigma <- as.matrix(sigma)
-  matrixStats::rowMeans2(sigma^2)
-}
-
-.bayes_R2_var_res_bernoulli <- function(ypred, ...) {
-  matrixStats::rowMeans2(ypred * (1 - ypred))
 }

--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -5,7 +5,7 @@
 #' @inheritParams predict.brmsfit
 #' @param method Character string specifying how R2 is computed. Either
 #'   `"model"` to use the model-based variances, or `"residual"` to
-#'   use the residual-based variances. If `NULL` (the default), the
+#'   use the residual-based variances. If `NULL` (default), the
 #'   model-based R2 is computed where possible, falling back to residual-based
 #'   R2 for families without current support of model-based variances.
 #' @param ... Further arguments passed to
@@ -91,7 +91,8 @@ bayes_R2.brmsfit <- function(object, resp = NULL, method = NULL, summary = TRUE,
   args_ypred <- list(object, sort = TRUE, ...)
   R2 <- named_list(paste0("R2", resp))
   warned_families <- character(0)
-  supported_model_variances <- c("gaussian", "bernoulli")
+  # TODO: find supported families automatically once more are supported
+  model_variance_families <- c("gaussian", "bernoulli")
   
   for (i in seq_along(R2)) {
     # assumes expectations of different responses to be independent
@@ -101,25 +102,27 @@ bayes_R2.brmsfit <- function(object, resp = NULL, method = NULL, summary = TRUE,
       ypred <- ordinal_probs_continuous(ypred)
     }
     family_name <- family(object, resp = resp[i])$family
-    
-    if (!is.null(method) && method == "residual") {
-      R2[[i]] <- .residual_r2(i, object, resp, ypred)
-    } else {
-      if (family_name == "gaussian") {
-        R2[[i]] <- .gaussian_r2(ypred, posterior_epred, args_ypred)
-      } else if (family_name == "bernoulli") {
-        R2[[i]] <- .bernoulli_r2(ypred)
-      } else if (!family_name %in% supported_model_variances) {
-        if (!family_name %in% warned_families) {
-          warning2(
-            "No model-based residual variance is currently implemented for ",
-            "family '", family_name, "'\nin 'bayes_R2'. ",
-            "Falling back to residual-based R2 computation."
-          )
-          warned_families <- c(warned_families, family_name)
-        }
-        R2[[i]] <- .residual_r2(i, object, resp, ypred)
+
+    method_i <- method
+    if (is.null(method_i)) {
+      method_i <- str_if(
+        family_name %in% model_variance_families, 
+        "model", "residual"
+      )
+      if (method_i == "residual") {
+        warning2(
+          "No model-based residual variance is currently implemented for ",
+          "family '", family_name, "'\nin 'bayes_R2'. ",
+          "Falling back to residual-based R2 computation."
+        )
+        warned_families <- c(warned_families, family_name)
       }
+    }
+    
+    if (method_i == "model") {
+      R2[[i]] <- bayes_R2_model(ypred, family_name, args_ypred = args_ypred, ...)
+    } else if (method_i == "residual") {
+      R2[[i]] <- bayes_R2_residual(ypred, object, resp = resp[i], ...)
     }
   }
 
@@ -131,39 +134,35 @@ bayes_R2.brmsfit <- function(object, resp = NULL, method = NULL, summary = TRUE,
   R2
 }
 
-# internal function of bayes_R2.brmsfit
-# see https://github.com/jgabry/bayes_R2/blob/master/bayes_R2.pdf
-.bayes_R2_res <- function(y, ypred, ...) {
-  e <- -1 * sweep(ypred, 2, y)
-  var_ypred <- matrixStats::rowVars(ypred)
-  var_e <- matrixStats::rowVars(e)
-  as.matrix(var_ypred / (var_ypred + var_e))
+bayes_R2_model <- function(ypred, family_name, ...) {
+  var_res_fun <- get(paste0(".var_res_", family_name), mode = "function")
+  var_res <- var_res_fun(ypred, ...)
+  .bayes_R2(ypred, var_res)
 }
 
-.bayes_R2_model <- function(ypred, var_res, ...) {
+bayes_R2_residual <- function(ypred, object, resp, ...) {
+  y <- do_call(get_y, c(list(object, warn = TRUE, resp = resp), list(...)))
+  res <- -1 * sweep(ypred, 2, y)
+  var_res <- matrixStats::rowVars(res)
+  .bayes_R2(ypred, var_res)
+}
+
+.bayes_R2 <- function(ypred, var_res) {
   var_ypred <- matrixStats::rowVars(ypred)
   as.matrix(var_ypred / (var_ypred + var_res))
 }
 
-.residual_r2 <- function(i, object, resp, ypred, ...) {
-  y <- do_call(get_y, c(list(object, warn = TRUE, resp = resp[i]), list(...)))
-  .bayes_R2_res(y, ypred)
-}
-
-# ------------------- family specific model-based R2 functions -----------------
-
-.gaussian_r2 <- function(ypred, posterior_epred, args_ypred) {
+# ------------------- family-specific residual variances -----------------
+.var_res_gaussian <- function(ypred, args_ypred, ...) {
   args_sigma <- args_ypred
   args_sigma$dpar <- "sigma"
   sigma <- do_call(posterior_epred, args_sigma)
   # use mean of heteroscedastic sigma as approximate 
   # (see Tjur (2009) for discussion)
-  var_res <- matrixStats::rowMeans2(sigma)^2
-  .bayes_R2_model(ypred, var_res)
+  matrixStats::rowMeans2(sigma)^2
 }
 
-.bernoulli_r2 <- function(ypred) {
-  var_res <- matrixStats::rowMeans2(ypred * (1 - ypred))
-  .bayes_R2_model(ypred, var_res)
+.var_res_bernoulli <- function(ypred, ...) {
+  matrixStats::rowMeans2(ypred * (1 - ypred))
 }
 

--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -3,6 +3,11 @@
 #' @aliases bayes_R2
 #'
 #' @inheritParams predict.brmsfit
+#' @param method Character string specifying how R2 is computed. Either
+#'   `"model"` to use the model-based variances, or `"residual"` to
+#'   use the residual-based variances. If `NULL` (the default), the
+#'   model-based R2 is computed where possible, falling back to residual-based
+#'   R2 for families without current support of model-based variances.
 #' @param ... Further arguments passed to
 #'   \code{\link[brms:posterior_epred.brmsfit]{posterior_epred}},
 #'   which is used in the computation of the R-squared values.
@@ -46,12 +51,15 @@
 #' @importFrom rstantools bayes_R2
 #' @export bayes_R2
 #' @export
-bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
+bayes_R2.brmsfit <- function(object, resp = NULL, method = NULL, summary = TRUE,
                              robust = FALSE, probs = c(0.025, 0.975), ...) {
   contains_draws(object)
   object <- restructure(object)
   resp <- validate_resp(resp, object)
   summary <- as_one_logical(summary)
+  if (!is.null(method)) {
+    rlang::arg_match(method, values = c("model", "residual"))
+  }
   # check for precomputed values
   R2 <- get_criterion(object, "bayes_R2")
   has_stored <- is.matrix(R2)
@@ -83,7 +91,8 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
   args_ypred <- list(object, sort = TRUE, ...)
   R2 <- named_list(paste0("R2", resp))
   warned_families <- character(0)
-
+  supported_model_variances <- c("gaussian", "bernoulli")
+  
   for (i in seq_along(R2)) {
     # assumes expectations of different responses to be independent
     args_ypred$resp <- resp[i]
@@ -92,30 +101,28 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
       ypred <- ordinal_probs_continuous(ypred)
     }
     family_name <- family(object, resp = resp[i])$family
-    if (family_name %in% "gaussian") {
-      args_sigma <- args_ypred
-      args_sigma$dpar <- "sigma"
-      sigma <- do_call(posterior_epred, args_sigma)
-      # use mean of heteroscedastic sigma as approximate 
-      # (see Tjur (2009) for discussion)
-      var_res <- matrixStats::rowMeans2(sigma)^2
-      R2[[i]] <- .bayes_R2_model(ypred, var_res)
-    } else if (family_name %in% "bernoulli") {
-      var_res <- matrixStats::rowMeans2(ypred * (1 - ypred))
-      R2[[i]] <- .bayes_R2_model(ypred, var_res)
+    
+    if (!is.null(method) && method == "residual") {
+      R2[[i]] <- .residual_r2(i, object, resp, ypred)
     } else {
-      if (!family_name %in% warned_families) {
-        warning2(
-          "No model-based residual variance is currently implemented for ",
-          "family '", family_name, "'\nin 'bayes_R2'. ",
-          "Falling back to residual-based R2 computation."
-        )
-        warned_families <- c(warned_families, family_name)
+      if (family_name == "gaussian") {
+        R2[[i]] <- .gaussian_r2(ypred, posterior_epred, args_ypred)
+      } else if (family_name == "bernoulli") {
+        R2[[i]] <- .bernoulli_r2(ypred)
+      } else if (!family_name %in% supported_model_variances) {
+        if (!family_name %in% warned_families) {
+          warning2(
+            "No model-based residual variance is currently implemented for ",
+            "family '", family_name, "'\nin 'bayes_R2'. ",
+            "Falling back to residual-based R2 computation."
+          )
+          warned_families <- c(warned_families, family_name)
+        }
+        R2[[i]] <- .residual_r2(i, object, resp, ypred)
       }
-      y <- do_call(get_y, c(list(object, warn = TRUE, resp = resp[i]), list(...)))
-      R2[[i]] <- .bayes_R2_res(y, ypred)
     }
   }
+
   R2 <- do_call(cbind, R2)
   colnames(R2) <- paste0("R2", resp)
   if (summary) {
@@ -137,3 +144,26 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
   var_ypred <- matrixStats::rowVars(ypred)
   as.matrix(var_ypred / (var_ypred + var_res))
 }
+
+.residual_r2 <- function(i, object, resp, ypred, ...) {
+  y <- do_call(get_y, c(list(object, warn = TRUE, resp = resp[i]), list(...)))
+  .bayes_R2_res(y, ypred)
+}
+
+# ------------------- family specific model-based R2 functions -----------------
+
+.gaussian_r2 <- function(ypred, posterior_epred, args_ypred) {
+  args_sigma <- args_ypred
+  args_sigma$dpar <- "sigma"
+  sigma <- do_call(posterior_epred, args_sigma)
+  # use mean of heteroscedastic sigma as approximate 
+  # (see Tjur (2009) for discussion)
+  var_res <- matrixStats::rowMeans2(sigma)^2
+  .bayes_R2_model(ypred, var_res)
+}
+
+.bernoulli_r2 <- function(ypred) {
+  var_res <- matrixStats::rowMeans2(ypred * (1 - ypred))
+  .bayes_R2_model(ypred, var_res)
+}
+

--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -15,6 +15,10 @@
 #'
 #' @details For an introduction to the approach, see Gelman et al. (2019)
 #'  and \url{https://github.com/jgabry/bayes_R2/}.
+#'  For Gaussian and Bernoulli models, \code{bayes_R2} uses model-based
+#'  residual variances as proposed in Gelman et al. (2019), with Bernoulli
+#'  models using Tjur's pseudo-variance. For other families, \code{bayes_R2}
+#'  warns and falls back to residual-based variances.
 #'
 #' @references Andrew Gelman, Ben Goodrich, Jonah Gabry & Aki Vehtari. (2019).
 #'   R-squared for Bayesian regression models, \emph{The American Statistician},
@@ -70,18 +74,38 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
       "'bayes_R2' which is likely invalid for ordinal families."
     )
   }
-  args_y <- list(object, warn = TRUE, ...)
   args_ypred <- list(object, sort = TRUE, ...)
   R2 <- named_list(paste0("R2", resp))
+  warned_families <- character(0)
   for (i in seq_along(R2)) {
     # assumes expectations of different responses to be independent
-    args_ypred$resp <- args_y$resp <- resp[i]
-    y <- do_call(get_y, args_y)
+    args_ypred$resp <- resp[i]
     ypred <- do_call(posterior_epred, args_ypred)
     if (is_ordinal(family(object, resp = resp[i]))) {
       ypred <- ordinal_probs_continuous(ypred)
     }
-    R2[[i]] <- .bayes_R2(y, ypred)
+    family_name <- family(object, resp = resp[i])$family
+    if (family_name %in% "gaussian") {
+      args_sigma <- args_ypred
+      args_sigma$dpar <- "sigma"
+      sigma <- do_call(posterior_epred, args_sigma)
+      var_res <- .bayes_R2_var_res_gaussian(sigma)
+      R2[[i]] <- .bayes_R2_model(ypred, var_res)
+    } else if (family_name %in% "bernoulli") {
+      var_res <- .bayes_R2_var_res_bernoulli(ypred)
+      R2[[i]] <- .bayes_R2_model(ypred, var_res)
+    } else {
+      if (!family_name %in% warned_families) {
+        warning2(
+          "No model-based residual variance is currently implemented for ",
+          "family '", family_name, "' in 'bayes_R2'. Falling back ",
+          "to residual-based R2 computation."
+        )
+        warned_families <- c(warned_families, family_name)
+      }
+      y <- do_call(get_y, c(list(object, warn = TRUE, resp = resp[i]), list(...)))
+      R2[[i]] <- .bayes_R2_res(y, ypred)
+    }
   }
   R2 <- do_call(cbind, R2)
   colnames(R2) <- paste0("R2", resp)
@@ -93,9 +117,23 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
 
 # internal function of bayes_R2.brmsfit
 # see https://github.com/jgabry/bayes_R2/blob/master/bayes_R2.pdf
-.bayes_R2 <- function(y, ypred, ...) {
+.bayes_R2_res <- function(y, ypred, ...) {
   e <- -1 * sweep(ypred, 2, y)
   var_ypred <- matrixStats::rowVars(ypred)
   var_e <- matrixStats::rowVars(e)
   as.matrix(var_ypred / (var_ypred + var_e))
+}
+
+.bayes_R2_model <- function(ypred, var_res, ...) {
+  var_ypred <- matrixStats::rowVars(ypred)
+  as.matrix(var_ypred / (var_ypred + var_res))
+}
+
+.bayes_R2_var_res_gaussian <- function(sigma, ...) {
+  sigma <- as.matrix(sigma)
+  matrixStats::rowMeans2(sigma^2)
+}
+
+.bayes_R2_var_res_bernoulli <- function(ypred, ...) {
+  matrixStats::rowMeans2(ypred * (1 - ypred))
 }

--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -15,15 +15,21 @@
 #'
 #' @details For an introduction to the approach, see Gelman et al. (2019)
 #'  and \url{https://github.com/jgabry/bayes_R2/}.
-#'  For Gaussian (homoscedastic sigma) and Bernoulli models, \code{bayes_R2} 
-#'  uses model-based residual variances as proposed in Gelman et al. (2019), 
-#'  with Bernoulli models using Tjur's pseudo-variance. For other families, 
+#'  For Gaussian and Bernoulli models, \code{bayes_R2} uses model-based residual
+#'  variances as proposed in Gelman et al. (2019), with Bernoulli models using 
+#'  Tjur's pseudo-variance. For Gaussian models with heteroscedastic
+#'  sigma, the mean residual variance is used as an approximation (see Tjur 
+#'  (2009) for discussion on this approximation). For other families, 
 #'  \code{bayes_R2} warns and falls back to residual-based variances.
 #'
 #' @references Andrew Gelman, Ben Goodrich, Jonah Gabry & Aki Vehtari. (2019).
 #'   R-squared for Bayesian regression models, \emph{The American Statistician},
 #'   73(3):307-309. \code{10.1080/00031305.2018.1549100} (Preprint available at
 #'   \url{https://acris.aalto.fi/ws/portalfiles/portal/34206843/bayes_R2_v3.pdf})
+#' 
+#'   Tue Tjur. (2009). Coefficient of determination in logistic regression 
+#'   models - A new proposal: The coefficient of discrimination, \emph{The 
+#'   American Statistician}, 63:366-372. \code{10.1198/tast.2009.08210}
 #'
 #' @examples
 #' \dontrun{
@@ -77,9 +83,7 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
   args_ypred <- list(object, sort = TRUE, ...)
   R2 <- named_list(paste0("R2", resp))
   warned_families <- character(0)
-  
-  fallback_msg <- "Falling back to residual-based R2 computation."
-  
+
   for (i in seq_along(R2)) {
     # assumes expectations of different responses to be independent
     args_ypred$resp <- resp[i]
@@ -92,20 +96,10 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
       args_sigma <- args_ypred
       args_sigma$dpar <- "sigma"
       sigma <- do_call(posterior_epred, args_sigma)
-      is_heteroscedastic <- any(
-        matrixStats::rowVars(sigma) > .Machine$double.eps * matrixStats::rowMeans2(sigma)^2
-      )
-      if (is_heteroscedastic) {
-        warning2(
-          "Detected heteroscedastic sigma. The model-based Bayes R\u00b2 is ",
-          "not yet implemented\nfor the heteroscedastic case. ", fallback_msg
-        )
-        y <- do_call(get_y, c(list(object, warn = TRUE, resp = resp[i]), list(...)))
-        R2[[i]] <- .bayes_R2_res(y, ypred)
-      } else {
-        var_res <- matrixStats::rowMeans2(sigma)^2
-        R2[[i]] <- .bayes_R2_model(ypred, var_res)
-      }
+      # use mean of heteroscedastic sigma as approximate 
+      # (see Tjur (2009) for discussion)
+      var_res <- matrixStats::rowMeans2(sigma)^2
+      R2[[i]] <- .bayes_R2_model(ypred, var_res)
     } else if (family_name %in% "bernoulli") {
       var_res <- matrixStats::rowMeans2(ypred * (1 - ypred))
       R2[[i]] <- .bayes_R2_model(ypred, var_res)
@@ -113,7 +107,8 @@ bayes_R2.brmsfit <- function(object, resp = NULL, summary = TRUE,
       if (!family_name %in% warned_families) {
         warning2(
           "No model-based residual variance is currently implemented for ",
-          "family '", family_name, "'\nin 'bayes_R2'. ", fallback_msg
+          "family '", family_name, "'\nin 'bayes_R2'. ",
+          "Falling back to residual-based R2 computation."
         )
         warned_families <- c(warned_families, family_name)
       }

--- a/man/bayes_R2.brmsfit.Rd
+++ b/man/bayes_R2.brmsfit.Rd
@@ -49,10 +49,10 @@ Compute a Bayesian version of R-squared for regression models
 \details{
 For an introduction to the approach, see Gelman et al. (2019)
  and \url{https://github.com/jgabry/bayes_R2/}.
- For Gaussian and Bernoulli models, \code{bayes_R2} uses model-based
- residual variances as proposed in Gelman et al. (2019), with Bernoulli
- models using Tjur's pseudo-variance. For other families, \code{bayes_R2}
- warns and falls back to residual-based variances.
+ For Gaussian (homoscedastic sigma) and Bernoulli models, \code{bayes_R2} 
+ uses model-based residual variances as proposed in Gelman et al. (2019), 
+ with Bernoulli models using Tjur's pseudo-variance. For other families, 
+ \code{bayes_R2} warns and falls back to residual-based variances.
 }
 \examples{
 \dontrun{

--- a/man/bayes_R2.brmsfit.Rd
+++ b/man/bayes_R2.brmsfit.Rd
@@ -49,6 +49,10 @@ Compute a Bayesian version of R-squared for regression models
 \details{
 For an introduction to the approach, see Gelman et al. (2019)
  and \url{https://github.com/jgabry/bayes_R2/}.
+ For Gaussian and Bernoulli models, \code{bayes_R2} uses model-based
+ residual variances as proposed in Gelman et al. (2019), with Bernoulli
+ models using Tjur's pseudo-variance. For other families, \code{bayes_R2}
+ warns and falls back to residual-based variances.
 }
 \examples{
 \dontrun{

--- a/man/bayes_R2.brmsfit.Rd
+++ b/man/bayes_R2.brmsfit.Rd
@@ -23,7 +23,7 @@ are performed only for the specified response variables.}
 
 \item{method}{Character string specifying how R2 is computed. Either
 `"model"` to use the model-based variances, or `"residual"` to
-use the residual-based variances. If `NULL` (the default), the
+use the residual-based variances. If `NULL` (default), the
 model-based R2 is computed where possible, falling back to residual-based
 R2 for families without current support of model-based variances.}
 

--- a/man/bayes_R2.brmsfit.Rd
+++ b/man/bayes_R2.brmsfit.Rd
@@ -8,6 +8,7 @@
 \method{bayes_R2}{brmsfit}(
   object,
   resp = NULL,
+  method = NULL,
   summary = TRUE,
   robust = FALSE,
   probs = c(0.025, 0.975),
@@ -19,6 +20,12 @@
 
 \item{resp}{Optional names of response variables. If specified, predictions
 are performed only for the specified response variables.}
+
+\item{method}{Character string specifying how R2 is computed. Either
+`"model"` to use the model-based variances, or `"residual"` to
+use the residual-based variances. If `NULL` (the default), the
+model-based R2 is computed where possible, falling back to residual-based
+R2 for families without current support of model-based variances.}
 
 \item{summary}{Should summary statistics be returned
 instead of the raw values? Default is \code{TRUE}.}

--- a/man/bayes_R2.brmsfit.Rd
+++ b/man/bayes_R2.brmsfit.Rd
@@ -49,9 +49,11 @@ Compute a Bayesian version of R-squared for regression models
 \details{
 For an introduction to the approach, see Gelman et al. (2019)
  and \url{https://github.com/jgabry/bayes_R2/}.
- For Gaussian (homoscedastic sigma) and Bernoulli models, \code{bayes_R2} 
- uses model-based residual variances as proposed in Gelman et al. (2019), 
- with Bernoulli models using Tjur's pseudo-variance. For other families, 
+ For Gaussian and Bernoulli models, \code{bayes_R2} uses model-based residual
+ variances as proposed in Gelman et al. (2019), with Bernoulli models using 
+ Tjur's pseudo-variance. For Gaussian models with heteroscedastic
+ sigma, the mean residual variance is used as an approximation (see Tjur 
+ (2009) for discussion on this approximation). For other families, 
  \code{bayes_R2} warns and falls back to residual-based variances.
 }
 \examples{
@@ -71,4 +73,8 @@ Andrew Gelman, Ben Goodrich, Jonah Gabry & Aki Vehtari. (2019).
   R-squared for Bayesian regression models, \emph{The American Statistician},
   73(3):307-309. \code{10.1080/00031305.2018.1549100} (Preprint available at
   \url{https://acris.aalto.fi/ws/portalfiles/portal/34206843/bayes_R2_v3.pdf})
+
+  Tue Tjur. (2009). Coefficient of determination in logistic regression 
+  models - A new proposal: The coefficient of discrimination, \emph{The 
+  American Statistician}, 63:366-372. \code{10.1198/tast.2009.08210}
 }

--- a/man/brms-package.Rd
+++ b/man/brms-package.Rd
@@ -105,6 +105,7 @@ Other contributors:
   \item Wellington J. Silva [contributor]
   \item Luiz Carvalho [contributor]
   \item Sermet Pekin [contributor]
+  \item Florence Bockting [contributor]
 }
 
 }

--- a/tests/local/tests.models-5.R
+++ b/tests/local/tests.models-5.R
@@ -1,5 +1,63 @@
 source("setup_tests_local.R")
 
+old_bayes_R2 <- function(fit) {
+  y <- brms:::get_y(fit, warn = TRUE)
+  ypred <- posterior_epred(fit, sort = TRUE)
+  e <- -1 * sweep(ypred, 2, y)
+  var_ypred <- matrixStats::rowVars(ypred)
+  var_e <- matrixStats::rowVars(e)
+  var_ypred / (var_ypred + var_e)
+}
+
+test_that("bayes_R2 prior-only draws match model-based formula", {
+  set.seed(2801)
+  dat <- data.frame(
+    x = rnorm(40),
+    y = rnorm(40)
+  )
+  fit <- brm(
+    y ~ x, data = dat, family = gaussian(),
+    prior = c(
+      prior(normal(0, 0.5), class = b),
+      prior(normal(0, 0.5), class = Intercept),
+      prior(exponential(1), class = sigma)
+    ),
+    sample_prior = "only",
+    chains = 1, iter = 600, warmup = 200,
+    seed = 2802, refresh = 0
+  )
+  ypred <- posterior_epred(fit, sort = TRUE)
+  sigma <- posterior_epred(fit, dpar = "sigma", sort = TRUE)
+  var_mupred <- matrixStats::rowVars(ypred)
+  var_res <- matrixStats::rowMeans2(sigma^2)
+  expected <- var_mupred / (var_mupred + var_res)
+  expect_equal(bayes_R2(fit, summary = FALSE)[, 1], expected)
+})
+
+test_that("bayes_R2 posterior difference shrinks with larger n", {
+  make_fit <- function(n, seed) {
+    set.seed(seed)
+    dat <- data.frame(x = rnorm(n))
+    dat$y <- 1 + 1.5 * dat$x + rnorm(n, sd = 1)
+    brm(
+      y ~ x, data = dat, family = gaussian(),
+      chains = 1, iter = 700, warmup = 300,
+      seed = seed, refresh = 0
+    )
+  }
+  fit_small <- make_fit(8, 2803)
+  fit_large <- make_fit(250, 2804)
+
+  model_small <- bayes_R2(fit_small, summary = FALSE)[, 1]
+  model_large <- bayes_R2(fit_large, summary = FALSE)[, 1]
+  residual_small <- old_bayes_R2(fit_small)
+  residual_large <- old_bayes_R2(fit_large)
+
+  diff_small <- abs(stats::median(model_small) - stats::median(residual_small))
+  diff_large <- abs(stats::median(model_large) - stats::median(residual_large))
+  expect_gt(diff_small, diff_large)
+})
+
 test_that("global shrinkage priors work correctly", suppressWarnings({
   set.seed(2563)
   dat <- epilepsy

--- a/tests/testthat/tests.brmsfit-methods.R
+++ b/tests/testthat/tests.brmsfit-methods.R
@@ -118,6 +118,9 @@ test_that("bayes_R2 has reasonable ouputs", {
     R2 <- bayes_R2(fit1, summary = FALSE),
     "No model-based residual variance is currently implemented"
   )
+  expect_no_warning(
+    R2 <- bayes_R2(fit1, method = "residual", summary = FALSE)
+  )
   expect_equal(dim(R2), c(ndraws(fit1), 1))
   fit1 <- SW(add_criterion(fit1, "bayes_R2"))
   R2 <- SW(bayes_R2(fit2, newdata = model.frame(fit2)[1:5, ], re_formula = NA))

--- a/tests/testthat/tests.brmsfit-methods.R
+++ b/tests/testthat/tests.brmsfit-methods.R
@@ -114,12 +114,15 @@ test_that("autocor has reasonable ouputs", {
 })
 
 test_that("bayes_R2 has reasonable ouputs", {
-  fit1 <- add_criterion(fit1, "bayes_R2")
-  R2 <- bayes_R2(fit1, summary = FALSE)
+  expect_warning(
+    R2 <- bayes_R2(fit1, summary = FALSE),
+    "No model-based residual variance is currently implemented"
+  )
   expect_equal(dim(R2), c(ndraws(fit1), 1))
-  R2 <- bayes_R2(fit2, newdata = model.frame(fit2)[1:5, ], re_formula = NA)
+  fit1 <- SW(add_criterion(fit1, "bayes_R2"))
+  R2 <- SW(bayes_R2(fit2, newdata = model.frame(fit2)[1:5, ], re_formula = NA))
   expect_equal(dim(R2), c(1, 4))
-  R2 <- bayes_R2(fit6)
+  R2 <- SW(bayes_R2(fit6))
   expect_equal(dim(R2), c(2, 4))
 })
 


### PR DESCRIPTION
## Description
This PR refers to [Issue#1815](https://github.com/paul-buerkner/brms/issues/1815).
Update `bayes_R2()` to use model-based residual variance for supported families (Gaussian and Bernoulli), while preserving fallback behavior (i.e., residual-based R2) for unsupported families.

Note, changes in this PR might be **breaking** as the output of the plot might change. However, the change in computation is rather considered as a "bug" and this PR as a **fix**.  For safety reasons I run a reverse dependency check for this PR which indicated no issues with dependent packages.

## Changes
- Refactored `bayes_R2.brmsfit()` to compute R2 via model-based residual variance for:
  - Gaussian models (`E[sigma^2]` per draw)
  - Bernoulli models (Tjur pseudo-variance: `E[pi * (1 - pi)]` per draw)
- Added explicit fallback to residual-based computation for other families.
- Added a warning when fallback is used, emitted once per family.
- Split internals into helper functions for clarity:
  - `.bayes_R2_res()`
  - `.bayes_R2_model()`
  - `.bayes_R2_var_res_gaussian()`
  - `.bayes_R2_var_res_bernoulli()`

## TODO
- [x] update function documentation
- [x] update tests
- [x] add release note in `NEWS.md` 
- [x] run reverse dependency check