### PR TITLE
Update restructure.R to recompute basis if <2.23.0 to include boundary factor (L)

### DIFF
--- a/R/restructure.R
+++ b/R/restructure.R
@@ -262,13 +262,6 @@ restructure_v2 <- function(x) {
     # that are directly passed to the Stan backends for later reuse (#1373)
     x$stan_args <- list()
   }
-  if (version < "2.19.3") {
-    # a slot was added to store parts of the Stan data computed at fitting time.
-    # storing this is strictly required only for spline models but there it is
-    # critical due to the machine-specific output of SVD (#1465)
-    bframe <- brmsframe(x$formula, data = x$data)
-    x$basis <- frame_basis(bframe, data = x$data)
-  }
   if (version < "2.21.3") {
     # the class of random effects data.frames was changed
     # in the process of introducing brmsframe objects
@@ -277,6 +270,17 @@ restructure_v2 <- function(x) {
   if (version < "2.22.11") {
     # tag column was added to the prior (#1724)
     x$prior$tag <- ""
+  }
+  if (version < "2.23.0") {
+    # a slot was added to store parts of the Stan data computed at fitting time.
+    # storing this is strictly required only for spline models but there it is
+    # critical due to the machine-specific output of SVD (#1465)
+
+    # additionally models with gp terms used not to store L but now need to in
+    # order for post-processing functions to work correctly (#1740)
+
+    bframe <- brmsframe(x$formula, data = x$data)
+    x$basis <- frame_basis(bframe, data = x$data)
   }
   x
 }


### PR DESCRIPTION
Since (#1740) v2.23.0, brmsfit objects have started storing the boundary factor (`L`) in the `basis` slot.
This resolved issues for out-of-sample predictions for newer models (#1739), but post-processing functions like `fitted` failed when applied to <v2.23.0 models that do not have the `L` stored.

This PR updates `restructure` so that it recomputes the `basis` slot. There was already code in `restructure` to do this for models <v2.19.3 so the fix is just a matter of updating the version number so that this is done for anything <v2.23.0.
 