### PR TITLE
Fix grouped-thresholds support for custom ordinal families

### DIFF
--- a/R/families.R
+++ b/R/families.R
@@ -1236,7 +1236,9 @@ custom_family <- function(name, dpars = "mu", links = "identity",
   }
   class(out) <- c("customfamily", "brmsfamily", "family")
   if (is_ordinal(out)) {
-    threshold <- match.arg(threshold)
+    threshold <- match.arg(
+      threshold, c("flexible", "equidistant", "sum_to_zero")
+    )
     out$threshold <- threshold
   }
   out

--- a/R/stan-likelihood.R
+++ b/R/stan-likelihood.R
@@ -970,9 +970,23 @@ stan_log_lik_custom <- function(bterms, threads = NULL, ...) {
   p <- stan_log_lik_dpars(bterms, reqn = !no_loop)
   mix <- get_mix_id(bterms)
   dpars <- paste0(family$dpars, mix)
+  lpdf <- family$name
   if (is_ordinal(family)) {
     prefix <- paste0(resp, if (nzchar(mix)) paste0("_mu", mix))
-    p$thres <- paste0("Intercept", prefix)
+    if (has_thres_groups(bterms)) {
+      if (no_loop) {
+        stop2("Custom ordinal families with grouped thresholds must be ",
+              "evaluated in a loop. Set 'loop = TRUE' in 'custom_family'.")
+      }
+      str_add(lpdf) <- "_merged"
+      p$thres <- paste0("merged_Intercept", prefix)
+      p$Jthres <- stan_log_lik_advars(bterms, "Jthres", reqn = TRUE, ...)$Jthres
+    } else {
+      p$thres <- paste0("Intercept", prefix)
+    }
+    if (has_sum_to_zero_thres(bterms)) {
+      str_add(p$thres) <- "_stz"
+    }
   }
   # insert the response name into the 'vars' strings
   # addition terms contain the response in their variable name
@@ -988,7 +1002,7 @@ stan_log_lik_custom <- function(bterms, threads = NULL, ...) {
     grepl("^((vint)|(vreal))[[:digit:]]+$", var_names)
   var_resps <- ifelse(is_var_adterms, resp, "")
   vars <- paste0(var_names, var_resps, var_indices)
-  sdist(family$name, p[dpars], p$thres, vars, vec = no_loop)
+  sdist(lpdf, p[dpars], p$thres, p$Jthres, vars, vec = no_loop)
 }
 
 # ordinal log-probability density functions in Stan language

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -2434,6 +2434,49 @@ test_that("custom families are handled correctly", {
   expect_match2(scode,
     "target += beta_binomial2_vec_lpmf(Y | mu, tau, vint1, vreal1);"
   )
+
+  # check grouped thresholds with custom families
+  custom_thres_family <- custom_family(
+    "custom_thres_family",
+    dpar = c("mu", "disc"),
+    links = c("identity", "log"),
+    type = "int",
+    specials = "ordinal",
+    threshold = "flexible"
+  )
+  stan_funs <- "
+    real custom_thres_family_merged_lpmf(int y, real mu, real disc, vector thres, array[] int j) {
+      return y;
+    }
+  "
+  stanvars <- stanvar(scode = stan_funs, block = "functions")
+  dat <- data.frame(
+    response = rep(1:3, times = 2),
+    gr = rep(factor(1:3), each = 2)
+  )
+  scode <- stancode(
+    response | thres(gr = gr) ~ 1,
+    data = dat,
+    family = custom_thres_family,
+    stanvar = stanvars,
+  )
+  expect_match2(
+    scode,
+    "target += custom_thres_family_merged_lpmf(Y[n] | mu[n], disc, merged_Intercept, Jthres[n]);"
+  )
+  # check sum-to-zero grouped thresholds
+  custom_thres_family_stz <- custom_thres_family
+  custom_thres_family_stz$threshold <- "sum_to_zero"
+  scode <- stancode(
+    response | thres(gr = gr) ~ 1,
+    data = dat,
+    family = custom_thres_family_stz,
+    stanvar = stanvars,
+  )
+  expect_match2(
+    scode,
+    "target += custom_thres_family_merged_lpmf(Y[n] | mu[n], disc, merged_Intercept_stz, Jthres[n]);"
+  )
 })
 
 test_that("likelihood of distributional beta models is correct", {
@@ -2674,6 +2717,8 @@ test_that("Un-normalized Stan code is correct", {
   expect_match2(scode, "target += beta_binomial2_lpmf(Y[n] | mu[n], tau, vint1[n], vreal1[n]);")
   expect_match2(scode, "gamma_lupdf(tau | 0.1, 0.1);")
 })
+
+
 
 # the new array syntax is now used throughout brms
 # test_that("Canonicalizing Stan code is correct", {


### PR DESCRIPTION
This PR fixes an error when a custom ordinal family is used with `thres(gr = ...)`, where the generated Stan code doesn't pass the `merged_Intercept` to the log PMF. This extends the fix in #1843                            
                                                                
Reprex
```r
library(brms)
 
dat <- data.frame(
  response = sample(1:5, 100, replace = TRUE),
  thres = factor(sample(1:4, 100, replace = TRUE))
)

custom_thres_family <- custom_family(
  "custom_thres_family",
  dpar = c("mu", "disc"),
  links = c("identity", "log"),
  type = "int",
  specials = "ordinal",
  threshold = "flexible"
)
                                                                                                                                           
fun_block <- "                                                                                                                             
  real acat_logit_lpmf(int y, real mu, real disc, vector thres) {                                                                        
    int nthres = num_elements(thres);                                                                                                      
    vector[nthres + 1] p = append_row(0, cumulative_sum(disc * (mu - thres)));                                                             
    return p[y] - log_sum_exp(p);           
  }                                                                                                                                        
  real custom_thres_family_merged_lpmf(                                                                        
      int y, real mu, real disc, vector thres, array[] int j) {                                                                            
    return acat_logit_lpmf(y | mu, disc, thres[j[1]:j[2]]);                                                                                
  }                                                                                                                                        
"   

make_stancode(
  bf(
    response | thres(gr = thres) ~ 1
  ),
  family = custom_thres_family,
  stanvar = stanvar(scode = fun_block, block = "functions"),
  data = dat
)

```
Which leads to this incorrect line
```bash
   -------------------------------------------------
    59:      vector[N] mu = rep_vector(0.0, N);
    60:      for (n in 1:N) {
    61:        target += custom_thres_family_lpmf(Y[n] | mu[n], disc, Intercept);
                                                                      ^
    62:      }
    63:    }
   -------------------------------------------------

Identifier 'Intercept' not in scope. Did you mean 'Intercept_1'?
```

After the patch we get the correct Stan code
```stan
target += custom_thres_family_merged_lpmf(Y[n] | mu[n], disc, merged_Intercept, Jthres[n]);
```


PR also includes a small fix so that `threshold = c("equidistant", "sum_to_zero")` is picked up in custom families.

Changes shouldn't cause any regressions and all tests pass.