### PR TITLE
Fix threading with custom ordinal families and grouped thresholds

### DIFF
--- a/R/stan-likelihood.R
+++ b/R/stan-likelihood.R
@@ -980,7 +980,9 @@ stan_log_lik_custom <- function(bterms, threads = NULL, ...) {
       }
       str_add(lpdf) <- "_merged"
       p$thres <- paste0("merged_Intercept", prefix)
-      p$Jthres <- stan_log_lik_advars(bterms, "Jthres", reqn = TRUE, ...)$Jthres
+      p$Jthres <- stan_log_lik_advars(
+        bterms, "Jthres", reqn = TRUE, threads = threads, ...
+      )$Jthres
     } else {
       p$thres <- paste0("Intercept", prefix)
     }

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -2477,6 +2477,18 @@ test_that("custom families are handled correctly", {
     scode,
     "target += custom_thres_family_merged_lpmf(Y[n] | mu[n], disc, merged_Intercept_stz, Jthres[n]);"
   )
+  # threaded variants: Jthres must be indexed with the global nn,
+  scode <- stancode(
+    response | thres(gr = gr) ~ 1,
+    data = dat,
+    family = custom_thres_family,
+    stanvar = stanvars,
+    threads = threading(2)
+  )
+  expect_match2(
+    scode,
+    "ptarget += custom_thres_family_merged_lpmf(Y[nn] | mu[n], disc, merged_Intercept, Jthres[nn]);"
+  )
 })
 
 test_that("likelihood of distributional beta models is correct", {


### PR DESCRIPTION
My previous PR #1883 didn't pass `threads` to `stan_log_lik_advars`, which means the wrong index is used for `Jthres` inside `partial_log_lik_lpmf` when threading is enabled for custom ordinal families with grouped thresholds. 

Before this PR:
```stan
 for (n in 1:N) {
      int nn = n + start - 1;
      ptarget += custom_thres_family_merged_lpmf(Y[nn] | mu[n], disc, merged_Intercept, Jthres[n]);
 }
```

After the fix `Jthres` gets the correct `nn` indexing
```stan
for (n in 1:N) {
      int nn = n + start - 1;
      ptarget += custom_thres_family_merged_lpmf(Y[nn] | mu[n], disc, merged_Intercept, Jthres[nn]);
 }
```

