### PR TITLE
update posterior_epred_trunc to use family for custom families

### DIFF
--- a/R/posterior_epred.R
+++ b/R/posterior_epred.R
@@ -738,7 +738,10 @@ posterior_epred_trunc <- function(prep) {
   stopifnot(is_trunc(prep))
   lb <- data2draws(prep$data[["lb"]], dim_mu(prep))
   ub <- data2draws(prep$data[["ub"]], dim_mu(prep))
-  family_name <- if (prep$family$family == "custom") prep$family$name else prep$family$family
+  family_name <- str_if(
+    is.customfamily(prep$family), 
+    prep$family$name, prep$family$family
+  )
   posterior_epred_trunc_fun <-
     paste0("posterior_epred_trunc_", family_name)
   posterior_epred_trunc_fun <- try(

--- a/R/posterior_epred.R
+++ b/R/posterior_epred.R
@@ -738,15 +738,16 @@ posterior_epred_trunc <- function(prep) {
   stopifnot(is_trunc(prep))
   lb <- data2draws(prep$data[["lb"]], dim_mu(prep))
   ub <- data2draws(prep$data[["ub"]], dim_mu(prep))
+  family_name <- if (prep$family$family == "custom") prep$family$name else prep$family$family
   posterior_epred_trunc_fun <-
-    paste0("posterior_epred_trunc_", prep$family$family)
+    paste0("posterior_epred_trunc_", family_name)
   posterior_epred_trunc_fun <- try(
     get(posterior_epred_trunc_fun, asNamespace("brms")),
     silent = TRUE
   )
   if (is_try_error(posterior_epred_trunc_fun)) {
     stop2("posterior_epred values on the respone scale not yet implemented ",
-          "for truncated '", prep$family$family, "' models.")
+          "for truncated '", family_name, "' models.")
   }
   trunc_args <- nlist(prep, lb, ub)
   do_call(posterior_epred_trunc_fun, trunc_args)


### PR DESCRIPTION
Fix for issue #1885, where the truncated posterior epred looks for the wrong function when a custom family is used.

Fix involves using the `family$name` rather than `family$family` when a custom family is used.
 