### PR TITLE
Fix `kfold_predict()` for posterior predictions with more than 2 dimensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ Thanks to Sermet Pekin. (#1790)
 
 ### Bug Fixes
 
+* `kfold_predict()` supports now families whose predictions are not draws x 
+observations matrices (e.g. categorical models). (#1889)
 * `bayes_R2` now uses model-based residual variances for Gaussian and Bernoulli 
 models and falls back to residual-based computation for other families. This 
 change may lead to changes in plotting results. (#1815)

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -476,35 +476,26 @@ kfold_predict <- function(x, method = "posterior_predict", resp = NULL, ...) {
   all_predicted <- sort(unlist(x$fits[, "predicted"]))
   npredicted <- length(all_predicted)
   
-  y <- rep(NA, npredicted)
-  names(y) <- as.character(all_predicted)
+  y <- setNames(rep(NA, npredicted), as.character(all_predicted))
   yrep <- NULL
 
   for (k in seq_rows(x$fits)) {
     fit_k <- x$fits[[k, "fit"]]
     predicted_k <- x$fits[[k, "predicted"]]
-
-    obs <- match(predicted_k, all_predicted)
+    # indexes the obs of the current fold within the total obs
+    obs_k <- match(predicted_k, all_predicted)
     newdata <- x$data[predicted_k, , drop = FALSE]
     
-    y[obs] <- get_y(fit_k, resp, newdata = newdata, ...)
+    y[obs_k] <- get_y(fit_k, resp, newdata = newdata, ...)
     
     yrep_k <- method(
       fit_k, newdata = newdata, resp = resp,
       allow_new_levels = TRUE, summary = FALSE, ...
     )
     
-    if (is.null(yrep)) {
-      yrep_dim <- dim(yrep_k)
-      yrep_dim[2] <- npredicted
-      yrep_dimnames <- dimnames(yrep_k)
-      if (is.null(yrep_dimnames)) {
-        yrep_dimnames <- vector("list", length(yrep_dim))
-      }
-      yrep_dimnames[[2]] <- as.character(all_predicted) 
-      yrep <- array(NA, dim = yrep_dim, dimnames = yrep_dimnames)
-    }
-    yrep <- .assign_yrep(yrep, obs, yrep_k)
+    yrep <- .update_yrep(
+      yrep, obs_k, yrep_k, npredicted, all_predicted
+    )
   }
   nlist(y, yrep)
 }
@@ -524,9 +515,23 @@ validate_joint <- function(joint) {
   match.arg(joint, options)
 }
 
-# internal function
-.assign_yrep <- function(yrep, obs, value) {
-    idx <- rep(list(TRUE), length(dim(yrep)))
-    idx[[2]] <- obs
-    do.call("[<-", c(list(yrep), idx, list(value = value)))
+# internal function for initializing the yrep array and filling it with
+# predictions of each fold.
+.update_yrep <- function(yrep, obs, value, nrep, all_pred) {
+  # On first fold: 
+  if (is.null(yrep)) {
+    # initialise as NA array with same dimensions as yrep_k (returned from method)
+    d <- dim(value)
+    # expand 2nd dimension (number of observations) to cover all obs across folds
+    d[2] <- nrep
+    dn <- dimnames(value) %||% vector("list", length(d))
+    dn[[2]] <- as.character(all_pred)
+    # create array with correct dimensions and provide names for dimensions
+    yrep <- array(NA, dim = d, dimnames = dn)
   }
+  idx <- rep(list(TRUE), length(dim(yrep)))
+  idx[[2]] <- obs
+  # equivalent to: list(yrep)[idx] <- value
+  # overwrites the NA entries of yrep with values from this fold (via idx)
+  do.call("[<-", c(list(yrep), idx, list(value = value)))
+}

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -432,9 +432,12 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
 #' @inheritParams posterior_predict.brmsfit
 #'
 #' @return A \code{list} with two slots named \code{'y'} and \code{'yrep'}.
-#'   Slot \code{y} contains the vector of observed responses.
-#'   Slot \code{yrep} contains the matrix of predicted responses,
-#'   with rows being posterior draws and columns being observations.
+#'   \code{y} is a named vector of observed responses (names = row indices).
+#'   \code{yrep} is an \code{array} of predictions with the same structure as
+#'   the chosen \code{method} would return for all \eqn{N} out-of-fold
+#'   observations at once, with posterior draws on the first dimension and
+#'   observations on the second. See the documentation of the underlying
+#'   prediction function for details on additional dimensions.
 #'
 #' @seealso \code{\link{kfold}}
 #'
@@ -470,22 +473,38 @@ kfold_predict <- function(x, method = "posterior_predict", resp = NULL, ...) {
   }
   method <- get(validate_pp_method(method), mode = "function")
   resp <- validate_resp(resp, x$fits[[1, "fit"]], multiple = FALSE)
-  all_predicted <- as.character(sort(unlist(x$fits[, "predicted"])))
+  all_predicted <- sort(unlist(x$fits[, "predicted"]))
   npredicted <- length(all_predicted)
-  ndraws <- ndraws(x$fits[[1, "fit"]])
+  
   y <- rep(NA, npredicted)
-  yrep <- matrix(NA, nrow = ndraws, ncol = npredicted)
-  names(y) <- colnames(yrep) <- all_predicted
+  names(y) <- as.character(all_predicted)
+  yrep <- NULL
+
   for (k in seq_rows(x$fits)) {
     fit_k <- x$fits[[k, "fit"]]
     predicted_k <- x$fits[[k, "predicted"]]
-    obs_names <- as.character(predicted_k)
+
+    obs <- match(predicted_k, all_predicted)
     newdata <- x$data[predicted_k, , drop = FALSE]
-    y[obs_names] <- get_y(fit_k, resp, newdata = newdata, ...)
-    yrep[, obs_names] <- method(
+    
+    y[obs] <- get_y(fit_k, resp, newdata = newdata, ...)
+    
+    yrep_k <- method(
       fit_k, newdata = newdata, resp = resp,
       allow_new_levels = TRUE, summary = FALSE, ...
     )
+    
+    if (is.null(yrep)) {
+      yrep_dim <- dim(yrep_k)
+      yrep_dim[2] <- npredicted
+      yrep_dimnames <- dimnames(yrep_k)
+      if (is.null(yrep_dimnames)) {
+        yrep_dimnames <- vector("list", length(yrep_dim))
+      }
+      yrep_dimnames[[2]] <- as.character(all_predicted) 
+      yrep <- array(NA, dim = yrep_dim, dimnames = yrep_dimnames)
+    }
+    yrep <- .assign_yrep(yrep, obs, yrep_k)
   }
   nlist(y, yrep)
 }
@@ -505,3 +524,9 @@ validate_joint <- function(joint) {
   match.arg(joint, options)
 }
 
+# internal function
+.assign_yrep <- function(yrep, obs, value) {
+    idx <- rep(list(TRUE), length(dim(yrep)))
+    idx[[2]] <- obs
+    do.call("[<-", c(list(yrep), idx, list(value = value)))
+  }

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -482,11 +482,10 @@ kfold_predict <- function(x, method = "posterior_predict", resp = NULL, ...) {
   for (k in seq_rows(x$fits)) {
     fit_k <- x$fits[[k, "fit"]]
     predicted_k <- x$fits[[k, "predicted"]]
-    # indexes the obs of the current fold within the total obs
-    obs_k <- match(predicted_k, all_predicted)
+    obs_names <- as.character(predicted_k)
     newdata <- x$data[predicted_k, , drop = FALSE]
     
-    y[obs_k] <- get_y(fit_k, resp, newdata = newdata, ...)
+    y[obs_names] <- get_y(fit_k, resp, newdata = newdata, ...)
     
     yrep_k <- method(
       fit_k, newdata = newdata, resp = resp,
@@ -494,7 +493,7 @@ kfold_predict <- function(x, method = "posterior_predict", resp = NULL, ...) {
     )
     
     yrep <- .update_yrep(
-      yrep, obs_k, yrep_k, npredicted, all_predicted
+      yrep, obs_names, yrep_k, npredicted, all_predicted
     )
   }
   nlist(y, yrep)

--- a/man/kfold_predict.Rd
+++ b/man/kfold_predict.Rd
@@ -24,9 +24,12 @@ that control several aspects of data validation and prediction.}
 }
 \value{
 A \code{list} with two slots named \code{'y'} and \code{'yrep'}.
-  Slot \code{y} contains the vector of observed responses.
-  Slot \code{yrep} contains the matrix of predicted responses,
-  with rows being posterior draws and columns being observations.
+  \code{y} is a named vector of observed responses (names = row indices).
+  \code{yrep} is an \code{array} of predictions with the same structure as
+  the chosen \code{method} would return for all \eqn{N} out-of-fold
+  observations at once, with posterior draws on the first dimension and
+  observations on the second. See the documentation of the underlying
+  prediction function for details on additional dimensions.
 }
 \description{
 Compute and evaluate predictions after performing K-fold

--- a/tests/local/tests.models-1.R
+++ b/tests/local/tests.models-1.R
@@ -30,6 +30,8 @@ test_that("Poisson model from brm doc works correctly", suppressWarnings({
 
   # test kfold
   kfold1 <- kfold(fit1, save_fits = TRUE)
+  expect_equal(length(dim(kfold_predict(kfold1, method = "fitted")$yrep)), 2)
+  expect_equal(length(dim(kfold_predict(kfold1, method = "predict")$yrep)), 2)
   loo1 <- SW(loo(fit1))
   expect_range(kfold1$estimates[3, 1], 1210, 1260)
   # expected output structure
@@ -82,6 +84,9 @@ test_that("Ordinal model from brm doc works correctly", suppressWarnings({
     iter = 1000, chains = 2, refresh = 0
   )
   print(fit2)
+  kfold2 <- SM(brms::kfold(fit2, save_fits = TRUE))
+  expect_equal(length(dim(kfold_predict(kfold2, method = "fitted")$yrep)), 3)
+  expect_equal(length(dim(kfold_predict(kfold2, method = "predict")$yrep)), 2)
   expect_range(WAIC(fit2)$estimates[3, 1], 900, 950)
   suppressWarnings(ce <- conditional_effects(fit2, effect = "treat"),
                  "Predictions are treated as continuous variables")
@@ -139,6 +144,26 @@ test_that("Binomial model from brm doc works correctly", suppressWarnings({
   print(fit4)
   ce <- conditional_effects(fit4)
   expect_ggplot(plot(ce, ask = FALSE)[[1]])
+}))
+
+test_that("Categorical model works correctly with kfold_predict", suppressWarnings({
+  skip_if_not_installed("palmerpenguins")
+  data("penguins", package = "palmerpenguins")
+  penguins <- subset(penguins, complete.cases(penguins))
+
+  fit <- brm(
+    species ~ bill_length_mm + bill_depth_mm,
+    data = penguins,
+    family = categorical(),
+    chains = 2,
+    cores = 2,
+    iter = 200,
+    seed = 42
+  )
+
+  kfold1 <- brms::kfold(fit, save_fits = TRUE)
+  mupred_kfold <- kfold_predict(kfold1, method = "fitted")
+  expect_equal(length(dim(mupred_kfold$yrep)), 3)
 }))
 
 test_that("Non-linear model from brm doc works correctly", suppressWarnings({


### PR DESCRIPTION
Fixes #1889 

## Summary
+ `kfold_predict()` no longer assumes `yrep` is a draws x observations matrix; it allocates an array whose dimensions follow the chosen prediction method, with the observation axis spanning all out-of-fold rows.
+ Adds helper `.assign_yrep()` for multidimensional assignment into the observation dimension.
+ Updates `@return` documentation and extends local model tests "tests/local/tests.models-1.R".

## Problem
For families where `fitted()` / `posterior_epred()` return arrays with extra dimensions (e.g. categorical(): draws x observations x categories), `kfold_predict()` failed because it pre-allocated a matrix and used `yrep[, obs] <- ....`

## Suggested solution
+ Infer `dim(yrep)` from the first fold’s predictions and set the second dimension to the total number of predicted observations.

## Note
+ The suggested solution yields a change in the type of the output (i.e., from matrix to array)
+ might lead to breaking reverse dependencies. For example if tests like `is.matrix()` are used.