### PR TITLE
implement `refcat = NA` for mixture families

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@ function thanks to Daniel Sabanes Bove. (#1734)
 * Add a new global option `brms.cache_folder`, which allows users to define a 
 default directory for saving and loading cached brmsfit objects.
 Thanks to Sermet Pekin. (#1790)
+* Predict all mixing proportions of a `mixture` family without a reference
+category via `refcat = NA`, analogous to `refcat = NA` in categorical models.
+Thanks to Gidon Frischkorn. (#1450)
 
 ### Bug Fixes
 

--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -530,7 +530,12 @@
 #'   one of the them has to be predicted, while the remaining one is used
 #'   as the reference category to identify the model. The so-called 'softmax'
 #'   transformation is applied on the linear predictor terms to form a
-#'   probability vector.
+#'   probability vector. Alternatively, by setting \code{refcat = NA} in
+#'   \code{\link{mixture}}, all mixing proportions can be predicted without a
+#'   reference category. In this case, the 'softmax' transformation is applied
+#'   to all linear predictor terms. As the resulting model is only weakly
+#'   identified, informative priors on the \code{theta} parameters are strongly
+#'   recommended.
 #'
 #'   For more information on mixture models, see
 #'   the documentation of \code{\link{mixture}}.

--- a/R/families.R
+++ b/R/families.R
@@ -982,7 +982,7 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL) {
           "as the number of mixture components.")
   }
   if (!is.null(refcat) && !isNA(refcat)) {
-    stop2("For mixture models, 'refcat' can only be NA.")
+    stop2("For mixture models, 'refcat' can only be NULL or NA.")
   }
   dots <- dots[rep(seq_along(dots), nmix)]
   family <- list(

--- a/R/families.R
+++ b/R/families.R
@@ -881,6 +881,16 @@ acat <- function(link = "logit", link_disc = "log",
 #'   If \code{NULL} (the default), \code{order} is set to \code{'mu'}
 #'   if all families are the same and \code{'none'} otherwise.
 #'   Other ordering constraints may be implemented in the future.
+#' @param refcat Optional reference category for the mixing proportions.
+#'   By default (\code{NULL}), when the mixing proportions are predicted,
+#'   all but one of them have to be modeled while the remaining one serves
+#'   as the reference category (its linear predictor is fixed to zero) to
+#'   identify the model. If \code{refcat = NA}, no reference category is used
+#'   and all mixing proportions are predicted via a 'softmax' transformation.
+#'   This is analogous to \code{refcat = NA} in \code{\link{categorical}}
+#'   models. As the resulting model is only weakly identified, informative
+#'   priors on the \code{theta} parameters are strongly recommended (see the
+#'   examples in \code{\link{brmsformula}}).
 #'
 #' @return An object of class \code{mixfamily}.
 #'
@@ -946,12 +956,23 @@ acat <- function(link = "logit", link_disc = "log",
 #' summary(fit4)
 #' pp_check(fit4)
 #'
+#' ## predict all mixing proportions without a reference category
+#' ## (requires informative priors on the theta parameters)
+#' mix_na <- mixture(gaussian, gaussian, refcat = NA)
+#' theta_prior <- c(prior, prior(normal(0, 1), Intercept, dpar = theta1),
+#'                   prior(normal(0, 1), Intercept, dpar = theta2))
+#' fit5 <- brm(bf(y ~ x + z, theta1 ~ x, theta2 ~ x),
+#'             dat, family = mix_na, prior = theta_prior,
+#'             init = 0, chains = 2)
+#' summary(fit5)
+#' pp_check(fit5)
+#'
 #' ## compare model fit
 #' loo(fit1, fit2, fit3, fit4)
 #' }
 #'
 #' @export
-mixture <- function(..., flist = NULL, nmix = 1, order = NULL) {
+mixture <- function(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL) {
   dots <- c(list(...), flist)
   if (length(nmix) == 1L) {
     nmix <- rep(nmix, length(dots))
@@ -960,11 +981,15 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL) {
     stop2("The length of 'nmix' should be the same ",
           "as the number of mixture components.")
   }
+  if (!is.null(refcat) && !isNA(refcat)) {
+    stop2("For mixture models, 'refcat' can only be NA.")
+  }
   dots <- dots[rep(seq_along(dots), nmix)]
   family <- list(
     family = "mixture",
     link = "identity",
-    mix = lapply(dots, validate_family)
+    mix = lapply(dots, validate_family),
+    refcat = refcat
   )
   class(family) <- c("mixfamily", "brmsfamily", "family")
   # validity checks

--- a/R/prepare_predictions.R
+++ b/R/prepare_predictions.R
@@ -138,9 +138,12 @@ prepare_predictions.brmsframe <- function(x, draws, sdata, ...) {
     if (any(ulapply(out$dpars[thetas], is.list))) {
       # theta was predicted
       missing_id <- which(ulapply(out$dpars[thetas], is.null))
-      out$dpars[[paste0("theta", missing_id)]] <- structure(
-        data2draws(0, c(ndraws, nobs)), predicted = TRUE
-      )
+      if (length(missing_id)) {
+        # a reference category exists; fill in its (zero) linear predictor
+        out$dpars[[paste0("theta", missing_id)]] <- structure(
+          data2draws(0, c(ndraws, nobs)), predicted = TRUE
+        )
+      }
     } else {
       # theta was not predicted
       out$dpars$theta <- do_call(cbind, out$dpars[thetas])

--- a/R/stan-response.R
+++ b/R/stan-response.R
@@ -504,14 +504,26 @@ stan_mixture <- function(bterms, prior, threads, normalize, ...) {
     "  real<lower=0,upper=1> theta{1:nmix}{p};  // mixing proportion\n"
   )
   if (length(theta_pred)) {
-    if (length(theta_pred) != nmix - 1) {
-      stop2("Can only predict all but one mixing proportion.")
+    if (isNA(bterms$family$refcat)) {
+      # predict all mixing proportions without a reference category
+      if (length(theta_pred) != nmix) {
+        stop2("When 'refcat = NA', all mixing proportions must be predicted.")
+      }
+      str_add(out$model_def) <- glue(
+        "  real log_sum_exp_theta{p};\n"
+      )
+    } else {
+      # predict all but one mixing proportion; the remaining one is the
+      # reference category with its linear predictor fixed to zero
+      if (length(theta_pred) != nmix - 1) {
+        stop2("Can only predict all but one mixing proportion.")
+      }
+      missing_id <- setdiff(1:nmix, dpar_id(names(theta_pred)))
+      str_add(out$model_def) <- glue(
+        "  vector[N{p}] theta{missing_id}{p} = rep_vector(0.0, N{p});\n",
+        "  real log_sum_exp_theta{p};\n"
+      )
     }
-    missing_id <- setdiff(1:nmix, dpar_id(names(theta_pred)))
-    str_add(out$model_def) <- glue(
-      "  vector[N{p}] theta{missing_id}{p} = rep_vector(0.0, N{p});\n",
-      "  real log_sum_exp_theta{p};\n"
-    )
     sum_exp_theta <- glue("exp(theta{1:nmix}{p}[n])", collapse = " + ")
     str_add(out$model_comp_mix) <- glue(
       "  for (n in 1:N{p}) {{\n",

--- a/man/brmsformula.Rd
+++ b/man/brmsformula.Rd
@@ -559,7 +559,12 @@ models for all parameters of the assumed response distribution.
   one of the them has to be predicted, while the remaining one is used
   as the reference category to identify the model. The so-called 'softmax'
   transformation is applied on the linear predictor terms to form a
-  probability vector.
+  probability vector. Alternatively, by setting \code{refcat = NA} in
+  \code{\link{mixture}}, all mixing proportions can be predicted without a
+  reference category. In this case, the 'softmax' transformation is applied
+  to all linear predictor terms. As the resulting model is only weakly
+  identified, informative priors on the \code{theta} parameters are strongly
+  recommended.
 
   For more information on mixture models, see
   the documentation of \code{\link{mixture}}.

--- a/man/mixture.Rd
+++ b/man/mixture.Rd
@@ -4,7 +4,7 @@
 \alias{mixture}
 \title{Finite Mixture Families in \pkg{brms}}
 \usage{
-mixture(..., flist = NULL, nmix = 1, order = NULL)
+mixture(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL)
 }
 \arguments{
 \item{...}{One or more objects providing a description of the
@@ -28,6 +28,17 @@ If \code{'none'} or \code{FALSE}, no ordering constraint is applied.
 If \code{NULL} (the default), \code{order} is set to \code{'mu'}
 if all families are the same and \code{'none'} otherwise.
 Other ordering constraints may be implemented in the future.}
+
+\item{refcat}{Optional reference category for the mixing proportions.
+By default (\code{NULL}), when the mixing proportions are predicted,
+all but one of them have to be modeled while the remaining one serves
+as the reference category (its linear predictor is fixed to zero) to
+identify the model. If \code{refcat = NA}, no reference category is used
+and all mixing proportions are predicted via a 'softmax' transformation.
+This is analogous to \code{refcat = NA} in \code{\link{categorical}}
+models. As the resulting model is only weakly identified, informative
+priors on the \code{theta} parameters are strongly recommended (see the
+examples in \code{\link{brmsformula}}).}
 }
 \value{
 An object of class \code{mixfamily}.
@@ -95,6 +106,17 @@ fit4 <- brm(bf(y ~ x + z, theta2 ~ x),
             init = 0, chains = 2)
 summary(fit4)
 pp_check(fit4)
+
+## predict all mixing proportions without a reference category
+## (requires informative priors on the theta parameters)
+mix_na <- mixture(gaussian, gaussian, refcat = NA)
+theta_prior <- c(prior, prior(normal(0, 1), Intercept, dpar = theta1),
+                  prior(normal(0, 1), Intercept, dpar = theta2))
+fit5 <- brm(bf(y ~ x + z, theta1 ~ x, theta2 ~ x),
+            dat, family = mix_na, prior = theta_prior,
+            init = 0, chains = 2)
+summary(fit5)
+pp_check(fit5)
 
 ## compare model fit
 loo(fit1, fit2, fit3, fit4)

--- a/tests/testthat/tests.families.R
+++ b/tests/testthat/tests.families.R
@@ -104,7 +104,7 @@ test_that("mixture returns expected results and errors", {
   expect_true(is.na(mixture(gaussian, gaussian, refcat = NA)$refcat))
   expect_null(mixture(gaussian, gaussian)$refcat)
   expect_error(mixture(gaussian, gaussian, refcat = 1),
-               "'refcat' can only be NA")
+               "'refcat' can only be NULL or NA")
 })
 
 test_that("response interval is defined correctly", {
@@ -125,3 +125,4 @@ test_that("default priors are as expected", {
 test_that("correct STAN code is used", {
     expect_equal(xbeta()$include, "fun_xbeta.stan")
 })
+

--- a/tests/testthat/tests.families.R
+++ b/tests/testthat/tests.families.R
@@ -101,6 +101,10 @@ test_that("mixture returns expected results and errors", {
                "Expecting at least 2 mixture components")
   expect_error(mixture(poisson, binomial, order = "x"),
                "Argument 'order' is invalid")
+  expect_true(is.na(mixture(gaussian, gaussian, refcat = NA)$refcat))
+  expect_null(mixture(gaussian, gaussian)$refcat)
+  expect_error(mixture(gaussian, gaussian, refcat = 1),
+               "'refcat' can only be NA")
 })
 
 test_that("response interval is defined correctly", {

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -1858,7 +1858,7 @@ test_that("Stan code of mixture model is correct", {
   )
   expect_error(
     mixture(gaussian, gaussian, refcat = 2),
-    "'refcat' can only be NA"
+    "'refcat' can only be NULL or NA"
   )
 
   fam <- mixture(cumulative, sratio)

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -1856,11 +1856,7 @@ test_that("Stan code of mixture model is correct", {
              data = data, family = fam_na),
     "all mixing proportions must be predicted"
   )
-  expect_error(
-    mixture(gaussian, gaussian, refcat = 2),
-    "'refcat' can only be NULL or NA"
-  )
-
+  
   fam <- mixture(cumulative, sratio)
   scode <- stancode(y ~ x, data, family = fam)
   expect_match2(scode, "ordered_logistic_lpmf(Y[n] | mu1[n], Intercept_mu1);")

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -1834,6 +1834,33 @@ test_that("Stan code of mixture model is correct", {
   expect_match2(scode, "theta3[n] = theta3[n] - log_sum_exp_theta;")
   expect_match2(scode, "ps[1] = theta1[n] + normal_lpdf(Y[n] | mu1[n], sigma1);")
 
+  # predict all mixing proportions without a reference category
+  fam_na <- mixture(gaussian, student, exgaussian, refcat = NA)
+  scode <- stancode(bf(y ~ x, theta1 ~ x, theta2 ~ x, theta3 ~ x),
+                         data = data, family = fam_na)
+  expect_match2(scode, "log_sum_exp_theta = log(exp(theta1[n]) + exp(theta2[n]) + exp(theta3[n]));")
+  expect_match2(scode, "theta3[n] = theta3[n] - log_sum_exp_theta;")
+  expect_match2(scode, "ps[1] = theta1[n] + normal_lpdf(Y[n] | mu1[n], sigma1);")
+  # all components are predicted; none is fixed as a reference category
+  # (the default 'theta2 = rep_vector(0.0, N);' followed by no linear predictor)
+  expect_match2(scode, "theta2 += Intercept_theta2 + Xc_theta2 * b_theta2;")
+
+  # errors when the number of predicted proportions is inconsistent
+  expect_error(
+    stancode(bf(y ~ x, theta1 ~ x, theta2 ~ x, theta3 ~ x),
+             data = data, family = fam),
+    "Can only predict all but one mixing proportion"
+  )
+  expect_error(
+    stancode(bf(y ~ x, theta1 ~ x, theta3 ~ x),
+             data = data, family = fam_na),
+    "all mixing proportions must be predicted"
+  )
+  expect_error(
+    mixture(gaussian, gaussian, refcat = 2),
+    "'refcat' can only be NA"
+  )
+
   fam <- mixture(cumulative, sratio)
   scode <- stancode(y ~ x, data, family = fam)
   expect_match2(scode, "ordered_logistic_lpmf(Y[n] | mu1[n], Intercept_mu1);")


### PR DESCRIPTION
Closes #1450.

`refcat = NA` on a `mixture()` family lets all `K` mixing proportions be predicted (`softmax` over all components, no reference), instead of the current `K - 1`. Direct analogue of `refcat = NA` in `categorical()`. Default (`refcat = NULL`) is
unchanged.

## Why this exists

In cognitive measurement models the mixing proportions decompose into shared sub-parameters (`theta1 ~ a + b + c`, `theta2 ~ a + b`, `theta3 ~ a`). Forcing one `theta` to be the reference makes this inexpressible and blocks cross-validating against implementations that fix a *different* parameter for scaling. Predicting all `K` lets the user choose which parameter carries the constraint via priors rather than having brms impose it structurally.

## Decisions in this PR

- Opt-in is a family argument, not "just supply all K formulas." All-`K` formulas currently error on purpose; silently making them valid would drop a guardrail. `refcat = NA` makes the under-identified mode a deliberate choice.

- `refcat` here is binary, not a category selector. In `categorical()`, `refcat` names *which* level is the reference. Mixtures have no named categories — in the default mode the reference is whichever `theta<ID>` formula the user omits — so the only new choice is "reference or not." Hence `refcat` accepts only `NULL` or `NA`. The name is reused for cross-family consistency; happy to rename (`softmax_all`, `no_refcat`, …) if it reads too much like a selector.

- No changes to priors/standata/`get_theta()`. They already key off `has_joint_theta()` (true whenever any `theta` is predicted), so each predicted `theta` gets ordinary priors, no Dirichlet `con_theta` is emitted, and post-processing softmaxes whatever thetas exist.

- Identifiability is documented, not enforced at runtime. A free `softmax` is shift-invariant; the default `logistic(0, 1)` intercept priors give soft identification and informative priors are recommended. No runtime warning, this matches the silent `categorical(refcat = NA)`; the caveat lives in `?mixture` and `?brmsformula`.

## Targets for review

- The stancode test asserts on the `theta2 += Intercept_theta2 + ...` accumulation line, *not* on the absence of `rep_vector(0.0, N)` — the latter is the generic predictor initializer, present for every predicted parameter, so it doesn't
  distinguish "reference" from "predicted."
- Feedback welcome on the `refcat` name and on whether a runtime identifiability message would be worth its noise.

