### PR TITLE
Fix for loo 2.10

### DIFF
--- a/tests/testthat/tests.brmsfit-methods.R
+++ b/tests/testthat/tests.brmsfit-methods.R
@@ -474,7 +474,7 @@ test_that("loo has reasonable outputs", {
   loo6_2 <- SW(loo(fit6, cores = 1, newdata = fit6$data))
   expect_true(is.numeric(loo6_2$estimates))
   loo_compare <- loo_compare(loo6_1, loo6_2)
-  expect_range(loo_compare[2, 1], -1, 1)
+  expect_range(loo_compare$elpd_diff[2], -1, 1)
 })
 
 test_that("loo_subsample has reasonable outputs", {


### PR DESCRIPTION
This PR was made with assistance from Codex.

loo_compare() now returns a data.frame, a test was failing because it was indexing using matrix syntax. This PR makes a small fix to adjust this. 

There is another test failure because of a mistake I made in `loo` (see stan-dev/loo#381), which will be fixed soon.