### PR TITLE
Implement group level mixtures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ### New Features
 
+* Compute `mixture` models over the levels of a grouping variable (e.g.
+participants) rather than over individual observations via the new `gr`
+argument of `mixture`, so that whole groups are assigned to the same mixture
+component. (#1659)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,14 +8,11 @@ correlations, which failed with an error, for example, when using
 
 ### New Features
 
-* Compute `mixture` models over the levels of a grouping variable (e.g.
-participants) rather than over individual observations via the new `gr`
-argument of `mixture`, so that whole groups are assigned to the same mixture
-component. Cross-validation for these models is performed with the group as the
-unit (leave-one-group-out), including `kfold`, `reloo`, `loo_moment_match`, and
-`loo_subsample`. Multivariate models are supported if all responses are grouped
-mixtures over the same grouping variable with `rescor = FALSE`; the group then
-remains the pointwise unit jointly across responses. (#1659)
+* Compute `mixture` models over the levels of a grouping variable rather than
+over individual observations via the new `gr` argument of `mixture`, so that
+whole groups are assigned to the same mixture component. Cross-validation is
+then performed with the group as the pointwise unit (leave-one-group-out).
+(#1659)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # brms 2.23
 
+### Bug Fixes
+
+* Fix pointwise `log_lik` evaluation in multivariate models without residual
+correlations, which failed with an error, for example, when using
+`loo_subsample`.
+
 ### New Features
 
 * Compute `mixture` models over the levels of a grouping variable (e.g.
@@ -7,7 +13,9 @@ participants) rather than over individual observations via the new `gr`
 argument of `mixture`, so that whole groups are assigned to the same mixture
 component. Cross-validation for these models is performed with the group as the
 unit (leave-one-group-out), including `kfold`, `reloo`, `loo_moment_match`, and
-`loo_subsample`. (#1659)
+`loo_subsample`. Multivariate models are supported if all responses are grouped
+mixtures over the same grouping variable with `rescor = FALSE`; the group then
+remains the pointwise unit jointly across responses. (#1659)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,9 @@
 * Compute `mixture` models over the levels of a grouping variable (e.g.
 participants) rather than over individual observations via the new `gr`
 argument of `mixture`, so that whole groups are assigned to the same mixture
-component. (#1659)
+component. Cross-validation for these models is performed with the group as the
+unit (leave-one-group-out), including `kfold`, `reloo`, `loo_moment_match`, and
+`loo_subsample`. (#1659)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel

--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -1449,9 +1449,9 @@ validate_formula.mvbrmsformula <- function(
   # symmetric case: every response is a grouped mixture over the same
   # grouping variable, without residual correlations ('rescor' is already
   # excluded for mixture families via 'allow_rescor' above). This guarantees
-  # a single well-defined pointwise unit for posterior inference — the group,
+  # a single well-defined pointwise unit for posterior inference: the group,
   # whose joint log-likelihood is the sum of the per-response per-group
-  # contributions — on which 'log_lik', 'loo', and the leave-one-group-out
+  # contributions, on which 'log_lik', 'loo', and the leave-one-group-out
   # refinements ('reloo', 'kfold', 'loo_moment_match', 'loo_subsample')
   # rely. Mixing grouped-mixture responses with per-observation responses
   # (or with different grouping variables) leaves no common pointwise unit,

--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -1445,30 +1445,20 @@ validate_formula.mvbrmsformula <- function(
             "in multivariate gaussian or student models.")
     }
   }
-  # In multivariate models, group-level mixtures are only supported in the
-  # symmetric case: every response is a grouped mixture over the same
-  # grouping variable, without residual correlations ('rescor' is already
-  # excluded for mixture families via 'allow_rescor' above). This guarantees
-  # a single well-defined pointwise unit for posterior inference: the group,
-  # whose joint log-likelihood is the sum of the per-response per-group
-  # contributions, on which 'log_lik', 'loo', and the leave-one-group-out
-  # refinements ('reloo', 'kfold', 'loo_moment_match', 'loo_subsample')
-  # rely. Mixing grouped-mixture responses with per-observation responses
-  # (or with different grouping variables) leaves no common pointwise unit,
-  # so these models remain unsupported until that is resolved.
+  # multivariate group-level mixtures require all responses to be grouped
+  # mixtures over the same variable so that the group remains the pointwise
+  # unit of 'log_lik'
   has_grmix <- ulapply(formula$forms, function(f) has_mix_groups(f$family))
   if (any(has_grmix)) {
     if (!all(has_grmix)) {
       stop2("Group-level mixtures (via 'gr' in mixture()) are not yet ",
-            "supported in multivariate models unless all responses are ",
-            "grouped mixtures, as the pointwise unit of the likelihood ",
-            "required for 'log_lik' and 'loo' would be undefined otherwise.")
+            "supported in multivariate models unless all responses ",
+            "are grouped mixtures.")
     }
     grvars <- ulapply(formula$forms, function(f) get_mix_var(f$family))
     if (length(unique(grvars)) > 1L) {
       stop2("Group-level mixtures in multivariate models require the same ",
-            "'gr' variable for all responses, so that leave-one-group-out ",
-            "methods ('loo', 'kfold', 'reloo') have a well-defined unit.")
+            "'gr' variable for all responses.")
     }
   }
   # handle default of correlations between 'me' terms

--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -1422,10 +1422,6 @@ validate_formula.mvbrmsformula <- function(
   if (length(formula$forms) < 2L) {
     stop2("Multivariate models require at least two responses.")
   }
-  if (any(ulapply(formula$forms, function(f) has_mix_groups(f$family)))) {
-    stop2("Group-level mixtures (via 'gr' in mixture()) are not yet ",
-          "supported in multivariate models.")
-  }
   allow_rescor <- allow_rescor(formula)
   if (is.null(formula$rescor)) {
     # with 'mi' terms we usually don't want rescor to be estimated
@@ -1447,6 +1443,32 @@ validate_formula.mvbrmsformula <- function(
     if (!allow_rescor) {
       stop2("Currently, estimating 'rescor' is only possible ",
             "in multivariate gaussian or student models.")
+    }
+  }
+  # In multivariate models, group-level mixtures are only supported in the
+  # symmetric case: every response is a grouped mixture over the same
+  # grouping variable, without residual correlations ('rescor' is already
+  # excluded for mixture families via 'allow_rescor' above). This guarantees
+  # a single well-defined pointwise unit for posterior inference — the group,
+  # whose joint log-likelihood is the sum of the per-response per-group
+  # contributions — on which 'log_lik', 'loo', and the leave-one-group-out
+  # refinements ('reloo', 'kfold', 'loo_moment_match', 'loo_subsample')
+  # rely. Mixing grouped-mixture responses with per-observation responses
+  # (or with different grouping variables) leaves no common pointwise unit,
+  # so these models remain unsupported until that is resolved.
+  has_grmix <- ulapply(formula$forms, function(f) has_mix_groups(f$family))
+  if (any(has_grmix)) {
+    if (!all(has_grmix)) {
+      stop2("Group-level mixtures (via 'gr' in mixture()) are not yet ",
+            "supported in multivariate models unless all responses are ",
+            "grouped mixtures, as the pointwise unit of the likelihood ",
+            "required for 'log_lik' and 'loo' would be undefined otherwise.")
+    }
+    grvars <- ulapply(formula$forms, function(f) get_mix_var(f$family))
+    if (length(unique(grvars)) > 1L) {
+      stop2("Group-level mixtures in multivariate models require the same ",
+            "'gr' variable for all responses, so that leave-one-group-out ",
+            "methods ('loo', 'kfold', 'reloo') have a well-defined unit.")
     }
   }
   # handle default of correlations between 'me' terms

--- a/R/brmsformula.R
+++ b/R/brmsformula.R
@@ -1350,7 +1350,7 @@ validate_formula.brmsformula <- function(
   if (is.mixfamily(out$family)) {
     # every mixture family needs to know about additional response information
     for (i in seq_along(out$family$mix)) {
-      for (term in c("cats", "thres", "bhaz")) {
+      for (term in c("cats", "thres", "bhaz", "mixgr_var")) {
         out$family$mix[[i]][[term]] <- out$family[[term]]
       }
     }
@@ -1421,6 +1421,10 @@ validate_formula.mvbrmsformula <- function(
   }
   if (length(formula$forms) < 2L) {
     stop2("Multivariate models require at least two responses.")
+  }
+  if (any(ulapply(formula$forms, function(f) has_mix_groups(f$family)))) {
+    stop2("Group-level mixtures (via 'gr' in mixture()) are not yet ",
+          "supported in multivariate models.")
   }
   allow_rescor <- allow_rescor(formula)
   if (is.null(formula$rescor)) {

--- a/R/brmsterms.R
+++ b/R/brmsterms.R
@@ -202,8 +202,7 @@ brmsterms.brmsformula <- function(formula, check_response = TRUE,
   # make a formula containing all required variables
   y$unused <- attr(x$formula, "unused")
   lhsvars <- if (resp_rhs_all) all_vars(y$respform)
-  # grouping variable of a group-level mixture is specified on the family
-  # rather than in the formula, hence add it explicitly to the used variables
+  # the mixture grouping variable is specified via the family, not the formula
   mixvars <- if (has_mix_groups(family)) str2formula(get_mix_var(family))
   y$allvars <- allvars_formula(
     lhsvars, advars, mixvars, lapply(y$dpars, get_allvars),

--- a/R/brmsterms.R
+++ b/R/brmsterms.R
@@ -202,8 +202,11 @@ brmsterms.brmsformula <- function(formula, check_response = TRUE,
   # make a formula containing all required variables
   y$unused <- attr(x$formula, "unused")
   lhsvars <- if (resp_rhs_all) all_vars(y$respform)
+  # grouping variable of a group-level mixture is specified on the family
+  # rather than in the formula, hence add it explicitly to the used variables
+  mixvars <- if (has_mix_groups(family)) str2formula(get_mix_var(family))
   y$allvars <- allvars_formula(
-    lhsvars, advars, lapply(y$dpars, get_allvars),
+    lhsvars, advars, mixvars, lapply(y$dpars, get_allvars),
     lapply(y$nlpars, get_allvars), y$time$allvars,
     get_unused_arg_vars(y),
     .env = environment(formula)

--- a/R/data-helpers.R
+++ b/R/data-helpers.R
@@ -485,7 +485,10 @@ validate_newdata <- function(
   do_check <- union(get_pred_vars(bterms), get_int_vars(bterms))
   # do not check variables from the 'unused' argument #1238
   unused_arg_vars <- get_unused_arg_vars(bterms)
-  dont_check <- unique(c(group_vars, cens_vars, unused_arg_vars))
+  # the grouping variable of a group-level mixture defines group indices
+  # only within the data at hand, so new levels are allowed
+  mixgr_vars <- get_mix_var(object$family)
+  dont_check <- unique(c(group_vars, cens_vars, unused_arg_vars, mixgr_vars))
   dont_check <- setdiff(dont_check, do_check)
   dont_check <- names(mf) %in% dont_check
   is_factor <- ulapply(mf, is.factor)

--- a/R/data-helpers.R
+++ b/R/data-helpers.R
@@ -485,8 +485,7 @@ validate_newdata <- function(
   do_check <- union(get_pred_vars(bterms), get_int_vars(bterms))
   # do not check variables from the 'unused' argument #1238
   unused_arg_vars <- get_unused_arg_vars(bterms)
-  # the grouping variable of a group-level mixture defines group indices
-  # only within the data at hand, so new levels are allowed
+  # new levels of the mixture grouping variable are allowed
   mixgr_vars <- get_mix_var(object$family)
   dont_check <- unique(c(group_vars, cens_vars, unused_arg_vars, mixgr_vars))
   dont_check <- setdiff(dont_check, do_check)

--- a/R/data-response.R
+++ b/R/data-response.R
@@ -434,6 +434,37 @@ data_response.brmsframe <- function(x, data, check_response = TRUE,
     }
     c(out) <- vint
   }
+  if (has_mix_groups(x$family)) {
+    # group-level (over-group) mixture: the whole group belongs to one component
+    if (has_ad_terms(x, c("cens", "trunc", "weights"))) {
+      stop2("Group-level mixtures (via 'gr' in mixture()) are not supported ",
+            "in combination with 'cens', 'trunc', or 'weights'.")
+    }
+    # group indices are defined by the data at hand; they only relate
+    # observations within one data set to each other, so new data may
+    # contain a subset of the original groups or even new groups
+    grmix <- factor(eval2(get_mix_var(x$family), data))
+    Jmix <- as.integer(grmix)
+    out$Ngrmix <- nlevels(grmix)
+    out$Jmix <- as.array(Jmix)
+    # predicted mixing proportions must be constant within each group
+    pred_theta <- any(dpar_class(names(x$dpars)) %in% "theta")
+    if (pred_theta) {
+      theta_dpars <- names(x$dpars)[dpar_class(names(x$dpars)) %in% "theta"]
+      theta_vars <- unique(ulapply(x$dpars[theta_dpars], function(p)
+        all_vars(p$allvars)))
+      for (v in theta_vars) {
+        vals <- eval2(v, data)
+        n_unique <- tapply(vals, Jmix, function(z) length(unique(z)))
+        if (any(n_unique > 1L)) {
+          stop2("Predicted mixing proportions ('theta') must be constant ",
+                "within each group defined by 'gr' in mixture().")
+        }
+      }
+      # one representative observation per group to read theta from
+      out$Jmixrep <- as.array(match(seq_len(out$Ngrmix), Jmix))
+    }
+  }
   if (length(out)) {
     resp <- usc(combine_prefix(x))
     out <- setNames(out, paste0(names(out), resp))

--- a/R/data-response.R
+++ b/R/data-response.R
@@ -435,14 +435,12 @@ data_response.brmsframe <- function(x, data, check_response = TRUE,
     c(out) <- vint
   }
   if (has_mix_groups(x$family)) {
-    # group-level (over-group) mixture: the whole group belongs to one component
+    # group-level mixture: the whole group belongs to one component
     if (has_ad_terms(x, c("cens", "trunc", "weights"))) {
       stop2("Group-level mixtures (via 'gr' in mixture()) are not supported ",
             "in combination with 'cens', 'trunc', or 'weights'.")
     }
-    # group indices are defined by the data at hand; they only relate
-    # observations within one data set to each other, so new data may
-    # contain a subset of the original groups or even new groups
+    # group indices are defined by the data at hand
     grmix <- mixgr_factor(x$family, data)
     Jmix <- as.integer(grmix)
     out$Ngrmix <- nlevels(grmix)

--- a/R/data-response.R
+++ b/R/data-response.R
@@ -443,7 +443,7 @@ data_response.brmsframe <- function(x, data, check_response = TRUE,
     # group indices are defined by the data at hand; they only relate
     # observations within one data set to each other, so new data may
     # contain a subset of the original groups or even new groups
-    grmix <- factor(eval2(get_mix_var(x$family), data))
+    grmix <- mixgr_factor(x$family, data)
     Jmix <- as.integer(grmix)
     out$Ngrmix <- nlevels(grmix)
     out$Jmix <- as.array(Jmix)

--- a/R/families.R
+++ b/R/families.R
@@ -891,6 +891,14 @@ acat <- function(link = "logit", link_disc = "log",
 #'   models. As the resulting model is only weakly identified, informative
 #'   priors on the \code{theta} parameters are strongly recommended (see the
 #'   examples in \code{\link{brmsformula}}).
+#' @param gr Optional name (as a character string) of a grouping variable in the
+#'   data. If specified, the mixture is computed over the levels of that variable
+#'   rather than over individual observations, that is, all observations that
+#'   belong to the same group are assumed to stem from the same (unknown) mixture
+#'   component. This is useful, for example, when entire participants (rather than
+#'   single trials) are thought to belong to different latent classes. By default
+#'   (\code{NULL}), the mixture is computed at the observation level as usual.
+#'   See Details for restrictions of group-level mixtures.
 #'
 #' @return An object of class \code{mixfamily}.
 #'
@@ -912,6 +920,23 @@ acat <- function(link = "logit", link_disc = "log",
 #' population-level intercepts via \code{\link{set_prior}} to improve
 #' posterior inference. In addition, it is sometimes necessary to set \code{init = 0}
 #' in the call to \code{\link{brm}} to allow chains to initialize properly.
+#'
+#' By default, the mixture is computed at the level of individual observations,
+#' that is, each observation may stem from a different mixture component. Via
+#' argument \code{gr}, the mixture can instead be computed over the levels of a
+#' grouping variable so that all observations within a group share the same
+#' (unknown) component. This yields a different likelihood in which the mixing
+#' is marginalized once per group rather than once per observation. Group-level
+#' mixtures currently require the mixing proportions to be either estimated,
+#' fixed, or predicted by covariates that are constant within each group. They
+#' are not supported in combination with within-chain threading, censoring,
+#' truncation, observation weights, or multivariate models. For group-level
+#' mixtures, \code{log_lik}, \code{loo}, and \code{waic} are computed per group
+#' (i.e. leave-one-group-out cross-validation), while \code{kfold} and the
+#' refinements \code{reloo}, \code{loo_moment_match}, and \code{loo_subsample}
+#' are not available. When predicting from new data, the groups are defined by the
+#' grouping variable within that data set and need not match the groups of the
+#' original data.
 #'
 #' For more details on the specification of mixture
 #' models, see \code{\link{brmsformula}}.
@@ -969,10 +994,17 @@ acat <- function(link = "logit", link_disc = "log",
 #'
 #' ## compare model fit
 #' loo(fit1, fit2, fit3, fit4)
+#'
+#' ## group-level mixture: whole groups belong to the same component
+#' dat$g <- rep(1:60, each = 5)
+#' fit6 <- brm(bf(y ~ 1), dat, family = mixture(gaussian, gaussian, gr = "g"),
+#'             prior = prior, init = 0, chains = 2)
+#' summary(fit6)
 #' }
 #'
 #' @export
-mixture <- function(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL) {
+mixture <- function(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL,
+                    gr = NULL) {
   dots <- c(list(...), flist)
   if (length(nmix) == 1L) {
     nmix <- rep(nmix, length(dots))
@@ -984,12 +1016,19 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL) {
   if (!is.null(refcat) && !isNA(refcat)) {
     stop2("For mixture models, 'refcat' can only be NULL or NA.")
   }
+  # optional grouping variable for group-level (over-group) mixtures
+  if (!is.null(gr) && !isNA(gr)) {
+    gr <- as_one_character(gr)
+  } else {
+    gr <- NULL
+  }
   dots <- dots[rep(seq_along(dots), nmix)]
   family <- list(
     family = "mixture",
     link = "identity",
     mix = lapply(dots, validate_family),
-    refcat = refcat
+    refcat = refcat,
+    mixgr_var = gr
   )
   class(family) <- c("mixfamily", "brmsfamily", "family")
   # validity checks
@@ -1851,6 +1890,16 @@ no_nu <- function(bterms) {
 # get mixture index if specified
 get_mix_id <- function(family) {
   family_info(family, "mix") %||% ""
+}
+
+# get the grouping variable name of a group-level (over-group) mixture
+get_mix_var <- function(family) {
+  if (is.list(family)) family[["mixgr_var"]] else NULL
+}
+
+# is the mixture computed over a grouping variable rather than observations?
+has_mix_groups <- function(family) {
+  length(get_mix_var(family)) > 0L
 }
 
 # does the family-link combination have a built-in Stan function?

--- a/R/families.R
+++ b/R/families.R
@@ -930,7 +930,14 @@ acat <- function(link = "logit", link_disc = "log",
 #' mixtures currently require the mixing proportions to be either estimated,
 #' fixed, or predicted by covariates that are constant within each group. They
 #' are not supported in combination with within-chain threading, censoring,
-#' truncation, observation weights, or multivariate models. For group-level
+#' truncation, or observation weights. In multivariate models, group-level
+#' mixtures are supported only if every response is a grouped mixture over the
+#' same grouping variable and \code{rescor = FALSE}: each response then
+#' contributes its own independent per-group mixture, and the joint
+#' log-likelihood of a group is the sum of the per-response terms. Other
+#' multivariate combinations are not supported, as they would leave the
+#' pointwise unit of the likelihood — and thus \code{log_lik}, \code{loo}, and
+#' related methods — undefined. For group-level
 #' mixtures, cross-validation is performed with the group as the unit
 #' (leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
 #' value per group, and \code{kfold} (folding over whole groups) as well as the
@@ -1894,8 +1901,16 @@ get_mix_id <- function(family) {
 }
 
 # get the grouping variable name of a group-level (over-group) mixture
+# multivariate models store one family per response; formula validation
+# enforces a single shared grouping variable across all responses
 get_mix_var <- function(family) {
-  if (is.list(family)) family[["mixgr_var"]] else NULL
+  if (is.family(family)) {
+    return(family[["mixgr_var"]])
+  }
+  if (is.list(family)) {
+    return(unique(ulapply(family, get_mix_var)))
+  }
+  NULL
 }
 
 # is the mixture computed over a grouping variable rather than observations?

--- a/R/families.R
+++ b/R/families.R
@@ -931,12 +931,13 @@ acat <- function(link = "logit", link_disc = "log",
 #' fixed, or predicted by covariates that are constant within each group. They
 #' are not supported in combination with within-chain threading, censoring,
 #' truncation, observation weights, or multivariate models. For group-level
-#' mixtures, \code{log_lik}, \code{loo}, and \code{waic} are computed per group
-#' (i.e. leave-one-group-out cross-validation), while \code{kfold} and the
+#' mixtures, cross-validation is performed with the group as the unit
+#' (leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
+#' value per group, and \code{kfold} (folding over whole groups) as well as the
 #' refinements \code{reloo}, \code{loo_moment_match}, and \code{loo_subsample}
-#' are not available. When predicting from new data, the groups are defined by the
-#' grouping variable within that data set and need not match the groups of the
-#' original data.
+#' operate on these per-group terms. When predicting from new data, the groups are
+#' defined by the grouping variable within that data set and need not match the
+#' groups of the original data.
 #'
 #' For more details on the specification of mixture
 #' models, see \code{\link{brmsformula}}.
@@ -1900,6 +1901,24 @@ get_mix_var <- function(family) {
 # is the mixture computed over a grouping variable rather than observations?
 has_mix_groups <- function(family) {
   length(get_mix_var(family)) > 0L
+}
+
+# grouping factor of a group-level (over-group) mixture; its level order
+# defines the group indices and hence the per-group columns of 'log_lik'
+mixgr_factor <- function(family, data) {
+  factor(eval2(get_mix_var(family), data))
+}
+
+# row indices of each group in a group-level (over-group) mixture,
+# in the order of the per-group columns of 'log_lik'
+# @param x a 'brmsfit' with a group-level mixture family
+# @param newdata data defining the groups (defaults to the model frame)
+mixgr_row_ids <- function(x, newdata = NULL) {
+  stopifnot(is.brmsfit(x), has_mix_groups(x$family))
+  if (is.null(newdata)) {
+    newdata <- model.frame(x)
+  }
+  unname(split(seq_rows(newdata), mixgr_factor(x$family, newdata)))
 }
 
 # does the family-link combination have a built-in Stan function?

--- a/R/families.R
+++ b/R/families.R
@@ -936,8 +936,8 @@ acat <- function(link = "logit", link_disc = "log",
 #' contributes its own independent per-group mixture, and the joint
 #' log-likelihood of a group is the sum of the per-response terms. Other
 #' multivariate combinations are not supported, as they would leave the
-#' pointwise unit of the likelihood — and thus \code{log_lik}, \code{loo}, and
-#' related methods — undefined. For group-level
+#' pointwise unit of the likelihood, and thus \code{log_lik}, \code{loo}, and
+#' related methods, undefined. For group-level
 #' mixtures, cross-validation is performed with the group as the unit
 #' (leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
 #' value per group, and \code{kfold} (folding over whole groups) as well as the

--- a/R/families.R
+++ b/R/families.R
@@ -891,14 +891,12 @@ acat <- function(link = "logit", link_disc = "log",
 #'   models. As the resulting model is only weakly identified, informative
 #'   priors on the \code{theta} parameters are strongly recommended (see the
 #'   examples in \code{\link{brmsformula}}).
-#' @param gr Optional name (as a character string) of a grouping variable in the
-#'   data. If specified, the mixture is computed over the levels of that variable
-#'   rather than over individual observations, that is, all observations that
-#'   belong to the same group are assumed to stem from the same (unknown) mixture
-#'   component. This is useful, for example, when entire participants (rather than
-#'   single trials) are thought to belong to different latent classes. By default
-#'   (\code{NULL}), the mixture is computed at the observation level as usual.
-#'   See Details for restrictions of group-level mixtures.
+#' @param gr Optional name of a grouping variable in the data. If specified,
+#'   the mixture is computed over the levels of that variable rather than over
+#'   individual observations, that is, all observations within a group are
+#'   assumed to stem from the same mixture component. By default (\code{NULL}),
+#'   the mixture is computed at the observation level. See Details for
+#'   restrictions of group-level mixtures.
 #'
 #' @return An object of class \code{mixfamily}.
 #'
@@ -921,30 +919,20 @@ acat <- function(link = "logit", link_disc = "log",
 #' posterior inference. In addition, it is sometimes necessary to set \code{init = 0}
 #' in the call to \code{\link{brm}} to allow chains to initialize properly.
 #'
-#' By default, the mixture is computed at the level of individual observations,
-#' that is, each observation may stem from a different mixture component. Via
-#' argument \code{gr}, the mixture can instead be computed over the levels of a
-#' grouping variable so that all observations within a group share the same
-#' (unknown) component. This yields a different likelihood in which the mixing
-#' is marginalized once per group rather than once per observation. Group-level
-#' mixtures currently require the mixing proportions to be either estimated,
-#' fixed, or predicted by covariates that are constant within each group. They
-#' are not supported in combination with within-chain threading, censoring,
-#' truncation, or observation weights. In multivariate models, group-level
-#' mixtures are supported only if every response is a grouped mixture over the
-#' same grouping variable and \code{rescor = FALSE}: each response then
-#' contributes its own independent per-group mixture, and the joint
-#' log-likelihood of a group is the sum of the per-response terms. Other
-#' multivariate combinations are not supported, as they would leave the
-#' pointwise unit of the likelihood, and thus \code{log_lik}, \code{loo}, and
-#' related methods, undefined. For group-level
-#' mixtures, cross-validation is performed with the group as the unit
-#' (leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
-#' value per group, and \code{kfold} (folding over whole groups) as well as the
-#' refinements \code{reloo}, \code{loo_moment_match}, and \code{loo_subsample}
-#' operate on these per-group terms. When predicting from new data, the groups are
-#' defined by the grouping variable within that data set and need not match the
-#' groups of the original data.
+#' Via argument \code{gr}, the mixture can be computed over the levels of a
+#' grouping variable instead of over individual observations, so that all
+#' observations within a group share the same (unknown) component. The mixture
+#' is then marginalized once per group rather than once per observation.
+#' Group-level mixtures require the mixing proportions to be constant within
+#' each group and do not support within-chain threading, censoring, truncation,
+#' or observation weights. In multivariate models, they are supported only if
+#' all responses are grouped mixtures over the same grouping variable (with
+#' \code{rescor = FALSE}). Cross-validation is performed with the group as the
+#' pointwise unit (leave-one-group-out): \code{log_lik}, \code{loo}, and
+#' \code{waic} return one value per group, and \code{kfold}, \code{reloo},
+#' \code{loo_moment_match}, and \code{loo_subsample} operate on these per-group
+#' terms. When predicting from new data, the groups are defined by the grouping
+#' variable within that data set and need not match the original groups.
 #'
 #' For more details on the specification of mixture
 #' models, see \code{\link{brmsformula}}.
@@ -1024,7 +1012,7 @@ mixture <- function(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL,
   if (!is.null(refcat) && !isNA(refcat)) {
     stop2("For mixture models, 'refcat' can only be NULL or NA.")
   }
-  # optional grouping variable for group-level (over-group) mixtures
+  # optional grouping variable for group-level mixtures
   if (!is.null(gr) && !isNA(gr)) {
     gr <- as_one_character(gr)
   } else {
@@ -1900,9 +1888,7 @@ get_mix_id <- function(family) {
   family_info(family, "mix") %||% ""
 }
 
-# get the grouping variable name of a group-level (over-group) mixture
-# multivariate models store one family per response; formula validation
-# enforces a single shared grouping variable across all responses
+# get the grouping variable name of a group-level mixture
 get_mix_var <- function(family) {
   if (is.family(family)) {
     return(family[["mixgr_var"]])
@@ -1918,13 +1904,13 @@ has_mix_groups <- function(family) {
   length(get_mix_var(family)) > 0L
 }
 
-# grouping factor of a group-level (over-group) mixture; its level order
-# defines the group indices and hence the per-group columns of 'log_lik'
+# grouping factor of a group-level mixture; its level order defines
+# the group indices and hence the per-group columns of 'log_lik'
 mixgr_factor <- function(family, data) {
   factor(eval2(get_mix_var(family), data))
 }
 
-# row indices of each group in a group-level (over-group) mixture,
+# row indices of each group in a group-level mixture,
 # in the order of the per-group columns of 'log_lik'
 # @param x a 'brmsfit' with a group-level mixture family
 # @param newdata data defining the groups (defaults to the model frame)

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -199,13 +199,11 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
     # group-level mixtures use whole groups as the pointwise unit
     if (!is.null(group)) {
       stop2("Argument 'group' is not supported for group-level mixture ",
-            "models; folds are formed over the mixture grouping variable ",
-            "('gr' in mixture()) automatically.")
+            "models; folds are always formed over the mixture groups.")
     }
     if (!isFALSE(joint)) {
       stop2("Argument 'joint' is not supported for group-level mixture ",
-            "models; log likelihoods are always evaluated jointly per ",
-            "group defined by 'gr' in mixture().")
+            "models; log likelihoods are always joint per group.")
     }
     return(.kfold_grouped(
       x, K = K, Ksub = Ksub, folds = folds, save_fits = save_fits,
@@ -400,9 +398,8 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
   )
 }
 
-# K-fold cross-validation for group-level (over-group) mixtures, where the
-# pointwise unit is a whole group: folds are formed over groups and
-# 'log_lik' returns one column per group
+# K-fold cross-validation for group-level mixtures: folds are formed
+# over groups and 'log_lik' returns one column per group
 # @inheritParams .kfold
 .kfold_grouped <- function(x, K, Ksub, folds, save_fits, newdata, newdata2,
                            resp, model_name, recompile = NULL,

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -150,6 +150,12 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
                           group = NULL, joint = FALSE, compare = TRUE,
                           resp = NULL, model_names = NULL, save_fits = FALSE,
                           recompile = NULL, future_args = list()) {
+  if (has_mix_groups(x$family)) {
+    # the fold and observation bookkeeping assumes one log_lik column per
+    # observation, while group-level mixtures return one column per group
+    stop2("'kfold' is not supported for group-level mixture ",
+          "models (specified via 'gr' in mixture()).")
+  }
   args <- split_dots(x, ..., model_names = model_names)
   if (!"use_stored" %in% names(args)) {
     further_arg_names <- c(

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -90,6 +90,13 @@
 #'   \link[loo:kfold-helpers]{kfold-helpers} page).
 #'   }
 #'
+#'   For group-level mixture models (argument \code{gr} of
+#'   \code{\link{mixture}}), the pointwise unit of the likelihood is the
+#'   mixture group rather than the observation: folds are always formed over
+#'   whole groups, arguments \code{group} and \code{joint} are not supported,
+#'   \code{folds = "loo"} performs exact leave-one-group-out cross-validation,
+#'   and a numeric \code{folds} vector must be constant within each group.
+#'
 #'   When running \code{kfold} on a \code{brmsfit} created with the
 #'   \pkg{cmdstanr} backend in a different \R session, several recompilations
 #'   will be triggered because by default, \pkg{cmdstanr} writes the model
@@ -194,6 +201,11 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
       stop2("Argument 'group' is not supported for group-level mixture ",
             "models; folds are formed over the mixture grouping variable ",
             "('gr' in mixture()) automatically.")
+    }
+    if (!isFALSE(joint)) {
+      stop2("Argument 'joint' is not supported for group-level mixture ",
+            "models; log likelihoods are always evaluated jointly per ",
+            "group defined by 'gr' in mixture().")
     }
     return(.kfold_grouped(
       x, K = K, Ksub = Ksub, folds = folds, save_fits = save_fits,
@@ -404,8 +416,8 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
   if (is.null(folds)) {
     fold_type <- "random"
     gfolds <- loo::kfold_split_random(K, ngroups)
-  } else if (is.character(folds) && length(folds) == 1L) {
-    fold_type <- match.arg(folds, "loo")
+  } else if (identical(folds, "loo")) {
+    fold_type <- "loo"
     gfolds <- seq_len(ngroups)
     K <- ngroups
     message("Setting 'K' to the number of groups (", K, ")")

--- a/R/kfold.R
+++ b/R/kfold.R
@@ -150,12 +150,6 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
                           group = NULL, joint = FALSE, compare = TRUE,
                           resp = NULL, model_names = NULL, save_fits = FALSE,
                           recompile = NULL, future_args = list()) {
-  if (has_mix_groups(x$family)) {
-    # the fold and observation bookkeeping assumes one log_lik column per
-    # observation, while group-level mixtures return one column per group
-    stop2("'kfold' is not supported for group-level mixture ",
-          "models (specified via 'gr' in mixture()).")
-  }
   args <- split_dots(x, ..., model_names = model_names)
   if (!"use_stored" %in% names(args)) {
     further_arg_names <- c(
@@ -194,6 +188,20 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
     newdata2 <- validate_data2(newdata2, bterms)
   }
   N <- nrow(newdata)
+  if (has_mix_groups(x$family)) {
+    # group-level mixtures use whole groups as the pointwise unit
+    if (!is.null(group)) {
+      stop2("Argument 'group' is not supported for group-level mixture ",
+            "models; folds are formed over the mixture grouping variable ",
+            "('gr' in mixture()) automatically.")
+    }
+    return(.kfold_grouped(
+      x, K = K, Ksub = Ksub, folds = folds, save_fits = save_fits,
+      newdata = newdata, newdata2 = newdata2, resp = resp,
+      model_name = model_name, recompile = recompile,
+      future_args = future_args, ...
+    ))
+  }
   joint <- validate_joint(joint)
   # validate argument 'group'
   gvar <- NULL
@@ -241,26 +249,7 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
     K <- max(folds)
     message("Setting 'K' to the number of folds (", K, ")")
   }
-  # validate argument 'Ksub'
-  if (is.null(Ksub)) {
-    Ksub <- seq_len(K)
-  } else {
-    # see issue #441 for reasons to check for arrays
-    is_array_Ksub <- is.array(Ksub)
-    Ksub <- as.integer(Ksub)
-    if (length(Ksub) == 0L) {
-      stop2("'Ksub' must be a positive integer or a non-empty integer vector.")
-    }
-    if (any(Ksub <= 0 | Ksub > K)) {
-      stop2("'Ksub' must contain positive integers not larger than 'K'.")
-    }
-    if (length(Ksub) == 1L && !is_array_Ksub) {
-      Ksub <- sample(seq_len(K), Ksub)
-    } else {
-      Ksub <- unique(Ksub)
-    }
-    Ksub <- sort(Ksub)
-  }
+  Ksub <- validate_kfold_ksub(Ksub, K)
 
   # ensure that the model can be run in the current R session
   x <- recompile_model(x, recompile = recompile)
@@ -331,7 +320,6 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
   future_args$future.seed <- TRUE
   res <- do_call("future_lapply", future_args, pkg = "future.apply")
 
-  diagnostics <- vector("list")
   lppds <- pred_obs_list <- vector("list", length(Ksub))
   if (save_fits) {
     fits <- array(list(), dim = c(length(Ksub), 3))
@@ -346,12 +334,6 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
   }
 
   lppds <- do_call(cbind, lppds)
-
-  diagnostics$pareto_k <- apply(lppds, 2, posterior::pareto_khat,
-                                are_log_weights = TRUE)
-  diagnostics$n_eff <- apply(exp(lppds), 2, posterior::ess_mean)
-  diagnostics$r_eff <- diagnostics$n_eff / nrow(lppds)
-
   elpds <- apply(lppds, 2, log_mean_exp)
   pred_obs <- unlist(pred_obs_list)
   if (joint == "obs") {
@@ -396,8 +378,152 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
     ll_full <- do_call(cbind, ll_full_marg)
   }
   lpds <- apply(ll_full, 2, log_mean_exp)
-  ps <- lpds - elpds
 
+  .kfold_finalize(
+    lppds, elpds, lpds,
+    atts = nlist(K, Ksub, group, folds, fold_type, joint),
+    model_name = model_name, unit = "observations",
+    fits = if (save_fits) fits, data = if (save_fits) newdata,
+    data2 = if (save_fits) newdata2
+  )
+}
+
+# K-fold cross-validation for group-level (over-group) mixtures, where the
+# pointwise unit is a whole group: folds are formed over groups and
+# 'log_lik' returns one column per group
+# @inheritParams .kfold
+.kfold_grouped <- function(x, K, Ksub, folds, save_fits, newdata, newdata2,
+                           resp, model_name, recompile = NULL,
+                           future_args = list(), ...) {
+  N <- nrow(newdata)
+  grmix <- mixgr_factor(x$family, newdata)
+  Jrow <- as.integer(grmix)  # group index per observation
+  ngroups <- nlevels(grmix)
+
+  # assign whole groups (not observations) to folds
+  if (is.null(folds)) {
+    fold_type <- "random"
+    gfolds <- loo::kfold_split_random(K, ngroups)
+  } else if (is.character(folds) && length(folds) == 1L) {
+    fold_type <- match.arg(folds, "loo")
+    gfolds <- seq_len(ngroups)
+    K <- ngroups
+    message("Setting 'K' to the number of groups (", K, ")")
+  } else if (is.numeric(folds)) {
+    # per-observation fold ids, required to be constant within each group
+    if (length(folds) != N) {
+      stop2("If 'folds' is a vector, it must be of length N.")
+    }
+    if (any(tapply(folds, Jrow, function(z) length(unique(z))) > 1L)) {
+      stop2("For group-level mixtures, 'folds' must be constant within each ",
+            "group defined by 'gr' in mixture().")
+    }
+    gfolds <- as.numeric(factor(folds[match(seq_len(ngroups), Jrow)]))
+    fold_type <- "custom"
+    K <- max(gfolds)
+    message("Setting 'K' to the number of folds (", K, ")")
+  } else {
+    stop2("Unsupported 'folds' for group-level mixture models. Use the ",
+          "default, folds = 'loo', or a numeric vector constant within groups.")
+  }
+  ofolds <- gfolds[Jrow]  # fold id per observation
+
+  Ksub <- validate_kfold_ksub(Ksub, K)
+
+  # ensure that the model can be run in the current R session
+  x <- recompile_model(x, recompile = recompile)
+
+  # split dots for use in log_lik and update
+  dots <- list(...)
+  ll_arg_names <- arg_names("log_lik")
+  ll_args <- dots[intersect(names(dots), ll_arg_names)]
+  ll_args$allow_new_levels <- TRUE
+  ll_args$sample_new_levels <-
+    first_not_null(ll_args$sample_new_levels, "gaussian")
+  ll_args$resp <- resp
+  ll_args$combine <- TRUE
+  up_args <- dots[setdiff(names(dots), ll_arg_names)]
+  up_args$object <- x
+  up_args$refresh <- 0
+
+  .kfold_grouped_k <- function(k) {
+    message("Fitting model ", k, " out of ", K)
+    omitted <- which(ofolds == k)
+    # held-out groups in ascending order, matching log_lik column order
+    groups_k <- sort(unique(Jrow[omitted]))
+    up_args$newdata <- newdata[-omitted, , drop = FALSE]
+    up_args$data2 <- subset_data2(newdata2, -omitted)
+    fit <- SW(do_call(update, up_args))
+    ll_args$object <- fit
+    ll_args$newdata <- newdata[omitted, , drop = FALSE]
+    ll_args$newdata2 <- subset_data2(newdata2, omitted)
+    lppds <- do_call(log_lik, ll_args)
+    out <- nlist(lppds, groups = groups_k, omitted, predicted = omitted)
+    if (save_fits) {
+      out$fit <- fit
+    }
+    return(out)
+  }
+
+  future_args$X <- Ksub
+  future_args$FUN <- .kfold_grouped_k
+  future_args$future.seed <- TRUE
+  res <- do_call("future_lapply", future_args, pkg = "future.apply")
+
+  if (save_fits) {
+    fits <- array(list(), dim = c(length(Ksub), 3))
+    dimnames(fits) <- list(NULL, c("fit", "omitted", "predicted"))
+    for (i in seq_along(Ksub)) {
+      fits[i, ] <- res[[i]][c("fit", "omitted", "predicted")]
+    }
+  }
+
+  # collect per-group columns across folds and order them by group index
+  lppds <- do_call(cbind, lapply(res, "[[", "lppds"))
+  groups <- unlist(lapply(res, "[[", "groups"))
+  lppds <- lppds[, order(groups), drop = FALSE]
+  elpds <- apply(lppds, 2, log_mean_exp)
+
+  # in-sample log-lik of the predicted groups from the full posterior
+  ll_args$object <- x
+  ll_args$newdata <- newdata
+  ll_args$newdata2 <- newdata2
+  if (length(Ksub) < K) {
+    # subsetting by ascending row index preserves the per-group column order
+    rows <- which(Jrow %in% groups)
+    ll_args$newdata <- newdata[rows, , drop = FALSE]
+    ll_args$newdata2 <- subset_data2(newdata2, rows)
+  }
+  ll_full <- do_call(log_lik, ll_args)
+  lpds <- apply(ll_full, 2, log_mean_exp)
+
+  .kfold_finalize(
+    lppds, elpds, lpds,
+    atts = nlist(
+      K, Ksub, group = get_mix_var(x$family), folds = ofolds,
+      fold_type, joint = "group"
+    ),
+    model_name = model_name, unit = "groups",
+    fits = if (save_fits) fits, data = if (save_fits) newdata,
+    data2 = if (save_fits) newdata2
+  )
+}
+
+# assemble and classify a 'kfold' object from pointwise log-likelihoods
+# @param lppds matrix of held-out log-likelihood draws, one column per
+#   pointwise unit (an observation or, for group-level mixtures, a group)
+# @param elpds,lpds pointwise held-out and in-sample log scores
+# @param atts attributes to store in the returned object
+# @param unit name of the pointwise unit ("observations" or "groups")
+# @param fits,data,data2 stored only if 'fits' is non-NULL (save_fits = TRUE)
+.kfold_finalize <- function(lppds, elpds, lpds, atts, model_name, unit,
+                            fits = NULL, data = NULL, data2 = NULL) {
+  diagnostics <- list()
+  diagnostics$pareto_k <- apply(lppds, 2, posterior::pareto_khat,
+                                are_log_weights = TRUE)
+  diagnostics$n_eff <- apply(exp(lppds), 2, posterior::ess_mean)
+  diagnostics$r_eff <- diagnostics$n_eff / nrow(lppds)
+  ps <- lpds - elpds
   # put everything together in a loo object
   pointwise <- cbind(elpd_kfold = elpds, p_kfold = ps, kfoldic = -2 * elpds)
   est <- colSums(pointwise)
@@ -405,19 +531,18 @@ kfold.brmsfit <- function(x, ..., K = 10, Ksub = NULL, folds = NULL,
   estimates <- cbind(Estimate = est, SE = se_est)
   rownames(estimates) <- colnames(pointwise)
   out <- nlist(estimates, pointwise, diagnostics)
-  k_threshold <- min(posterior::ps_khat_threshold(nrow(lppds)), 0.7)
-  atts <- nlist(K, Ksub, group, folds, fold_type, joint, k_threshold)
+  atts$k_threshold <- min(posterior::ps_khat_threshold(nrow(lppds)), 0.7)
   attributes(out)[names(atts)] <- atts
-  if (save_fits) {
+  if (!is.null(fits)) {
     out$fits <- fits
-    out$data <- newdata
-    out$data2 <- newdata2
+    out$data <- data
+    out$data2 <- data2
   }
-  if (length(loo::pareto_k_ids(out, threshold = k_threshold)) > 0) {
+  n_high_k <- length(loo::pareto_k_ids(out, threshold = atts$k_threshold))
+  if (n_high_k > 0) {
     warning2(
-      "Found ", length(loo::pareto_k_ids(out, threshold = k_threshold)),
-      " observations with a pareto_k > ", k_threshold,
-      " in model '", model_name, "'."
+      "Found ", n_high_k, " ", unit, " with a pareto_k > ",
+      atts$k_threshold, " in model '", model_name, "'."
     )
   }
   structure(out, dims = dim(lppds), class = c("kfold", "loo"))
@@ -503,6 +628,31 @@ kfold_predict <- function(x, method = "posterior_predict", resp = NULL, ...) {
     )
   }
   nlist(y, yrep)
+}
+
+# validate argument 'Ksub' of kfold
+# @param K number of folds
+validate_kfold_ksub <- function(Ksub, K) {
+  if (is.null(Ksub)) {
+    Ksub <- seq_len(K)
+  } else {
+    # see issue #441 for reasons to check for arrays
+    is_array_Ksub <- is.array(Ksub)
+    Ksub <- as.integer(Ksub)
+    if (length(Ksub) == 0L) {
+      stop2("'Ksub' must be a positive integer or a non-empty integer vector.")
+    }
+    if (any(Ksub <= 0 | Ksub > K)) {
+      stop2("'Ksub' must contain positive integers not larger than 'K'.")
+    }
+    if (length(Ksub) == 1L && !is_array_Ksub) {
+      Ksub <- sample(seq_len(K), Ksub)
+    } else {
+      Ksub <- unique(Ksub)
+    }
+    Ksub <- sort(Ksub)
+  }
+  Ksub
 }
 
 # validate argument 'joint' in kfold

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -126,8 +126,7 @@ log_lik.brmsprep <- function(object, cores = NULL, ...) {
     object$dpars[[dp]] <- get_dpar(object, dpar = dp)
   }
   if (!is.null(object$mixgr)) {
-    # group-level (over-group) mixture: the likelihood factorizes over groups
-    # rather than observations, hence return one column per group
+    # group-level mixture: one log_lik column per group
     return(log_lik_mixture_grouped(object))
   }
   N <- choose_N(object)
@@ -139,9 +138,7 @@ log_lik.brmsprep <- function(object, cores = NULL, ...) {
   reorder_obs(out, old_order, sort = sort)
 }
 
-# number of groups of a group-level mixture, or NULL if the model has none;
-# in multivariate models, all responses share the same grouping variable
-# (enforced during formula validation), so the number of groups is unique
+# number of groups of a group-level mixture, or NULL if the model has none
 mixgr_ngroups <- function(prep) {
   if (is.mvbrmsprep(prep)) {
     prep <- prep$resps[[1]]
@@ -1041,9 +1038,8 @@ mixture_group_ps <- function(prep) {
   ps
 }
 
-# log-likelihood of a group-level (over-group) mixture model
-# the mixture is marginalized once per group, hence one column per group is
-# returned, enabling leave-one-group-out cross-validation via loo/waic
+# log-likelihood of a group-level mixture model
+# the mixture is marginalized once per group, hence one column per group
 # @return a draws x ngroups matrix
 log_lik_mixture_grouped <- function(prep) {
   ps <- mixture_group_ps(prep)
@@ -1056,7 +1052,6 @@ log_lik_mixture_grouped <- function(prep) {
 }
 
 # log-likelihood of a single group of a group-level mixture model
-# used for pointwise evaluation in loo and waic
 # @param g index of the group for which to compute log-lik values
 # @return a vector of length prep$ndraws
 log_lik_mixture_grouped_i <- function(g, prep) {

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -64,7 +64,7 @@ log_lik.brmsfit <- function(object, newdata = NULL, re_formula = NULL,
     stopifnot(combine)
     log_lik <- log_lik_pointwise
     # for group-level mixtures, the likelihood is pointwise per group
-    N <- if (!is.null(prep$mixgr)) prep$mixgr$ngroups else choose_N(prep)
+    N <- mixgr_ngroups(prep) %||% choose_N(prep)
     # names need to be 'data' and 'draws' as per ?loo::loo.function
     attr(log_lik, "data") <- data.frame(i = seq_len(N))
     attr(log_lik, "draws") <- prep
@@ -139,13 +139,23 @@ log_lik.brmsprep <- function(object, cores = NULL, ...) {
   reorder_obs(out, old_order, sort = sort)
 }
 
+# number of groups of a group-level mixture, or NULL if the model has none;
+# in multivariate models, all responses share the same grouping variable
+# (enforced during formula validation), so the number of groups is unique
+mixgr_ngroups <- function(prep) {
+  if (is.mvbrmsprep(prep)) {
+    prep <- prep$resps[[1]]
+  }
+  prep$mixgr$ngroups
+}
+
 # evaluate log_lik in a pointwise manner
 # cannot be an S3 method since 'data_i' must be the first argument
 # names must be 'data_i' and 'draws' as per ?loo::loo.function
 log_lik_pointwise <- function(data_i, draws, ...) {
   i <- data_i$i
   if (is.mvbrmsprep(draws) && !length(draws$mvpars$rescor)) {
-    out <- lapply(draws$resps, log_lik_pointwise, i = i)
+    out <- lapply(draws$resps, function(resp) log_lik_pointwise(data_i, resp, ...))
     out <- Reduce("+", out)
   } else if (!is.null(draws$mixgr)) {
     # group-level mixture: 'i' indexes groups rather than observations

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -63,8 +63,10 @@ log_lik.brmsfit <- function(object, newdata = NULL, re_formula = NULL,
   if (pointwise) {
     stopifnot(combine)
     log_lik <- log_lik_pointwise
+    # for group-level mixtures, the likelihood is pointwise per group
+    N <- if (!is.null(prep$mixgr)) prep$mixgr$ngroups else choose_N(prep)
     # names need to be 'data' and 'draws' as per ?loo::loo.function
-    attr(log_lik, "data") <- data.frame(i = seq_len(choose_N(prep)))
+    attr(log_lik, "data") <- data.frame(i = seq_len(N))
     attr(log_lik, "draws") <- prep
   } else {
     log_lik <- log_lik(prep, combine = combine, cores = cores)
@@ -123,6 +125,11 @@ log_lik.brmsprep <- function(object, cores = NULL, ...) {
   for (dp in names(object$dpars)) {
     object$dpars[[dp]] <- get_dpar(object, dpar = dp)
   }
+  if (!is.null(object$mixgr)) {
+    # group-level (over-group) mixture: the likelihood factorizes over groups
+    # rather than observations, hence return one column per group
+    return(log_lik_mixture_grouped(object))
+  }
   N <- choose_N(object)
   out <- plapply(seq_len(N), log_lik_fun, .cores = cores, prep = object)
   out <- do_call(cbind, out)
@@ -140,6 +147,9 @@ log_lik_pointwise <- function(data_i, draws, ...) {
   if (is.mvbrmsprep(draws) && !length(draws$mvpars$rescor)) {
     out <- lapply(draws$resps, log_lik_pointwise, i = i)
     out <- Reduce("+", out)
+  } else if (!is.null(draws$mixgr)) {
+    # group-level mixture: 'i' indexes groups rather than observations
+    out <- log_lik_mixture_grouped_i(i, draws)
   } else {
     log_lik_fun <- paste0("log_lik_", draws$family$fun)
     log_lik_fun <- get(log_lik_fun, asNamespace("brms"))
@@ -994,6 +1004,63 @@ log_lik_mixture <- function(i, prep) {
     out <- log(rowSums(out))
   }
   log_lik_weight(out, i = i, prep = prep)
+}
+
+# per-group, per-component log-weights of a group-level mixture
+# computes log(theta_k^g) + sum_{i in group g} log f_k(y_i)
+# @return a draws x ngroups x components array
+mixture_group_ps <- function(prep) {
+  families <- family_names(prep$family)
+  J <- prep$mixgr$J
+  ngroups <- prep$mixgr$ngroups
+  ndraws <- prep$ndraws
+  nmix <- length(families)
+  # accumulate each component's per-observation log density within its group
+  ps <- array(0, dim = c(ndraws, ngroups, nmix))
+  for (k in seq_len(nmix)) {
+    log_lik_fun <- get(paste0("log_lik_", families[k]), asNamespace("brms"))
+    tmp_prep <- pseudo_prep_for_mixture(prep, k)
+    for (i in seq_len(prep$nobs)) {
+      ps[, J[i], k] <- ps[, J[i], k] + log_lik_fun(i, tmp_prep)
+    }
+  }
+  # add the (group-constant) log mixing weights
+  for (g in seq_len(ngroups)) {
+    ps[, g, ] <- ps[, g, ] + log(get_theta(prep, i = prep$mixgr$rep[g]))
+  }
+  ps
+}
+
+# log-likelihood of a group-level (over-group) mixture model
+# the mixture is marginalized once per group, hence one column per group is
+# returned, enabling leave-one-group-out cross-validation via loo/waic
+# @return a draws x ngroups matrix
+log_lik_mixture_grouped <- function(prep) {
+  ps <- mixture_group_ps(prep)
+  ngroups <- dim(ps)[2]
+  out <- matrix(NA_real_, nrow = dim(ps)[1], ncol = ngroups)
+  for (g in seq_len(ngroups)) {
+    out[, g] <- log_sum_exp_rows(ps[, g, , drop = FALSE])
+  }
+  out
+}
+
+# log-likelihood of a single group of a group-level mixture model
+# used for pointwise evaluation in loo and waic
+# @param g index of the group for which to compute log-lik values
+# @return a vector of length prep$ndraws
+log_lik_mixture_grouped_i <- function(g, prep) {
+  families <- family_names(prep$family)
+  obs <- which(prep$mixgr$J == g)
+  ps <- log(get_theta(prep, i = prep$mixgr$rep[g]))
+  for (k in seq_along(families)) {
+    log_lik_fun <- get(paste0("log_lik_", families[k]), asNamespace("brms"))
+    tmp_prep <- pseudo_prep_for_mixture(prep, k)
+    for (i in obs) {
+      ps[, k] <- ps[, k] + log_lik_fun(i, tmp_prep)
+    }
+  }
+  log_sum_exp_rows(ps)
 }
 
 # ----------- log_lik helper-functions -----------

--- a/R/loo_moment_match.R
+++ b/R/loo_moment_match.R
@@ -61,6 +61,10 @@ loo_moment_match.brmsfit <- function(x, loo = NULL, k_threshold = 0.7,
                                      newdata = NULL, resp = NULL, check = TRUE,
                                      recompile = FALSE, ...) {
   stopifnot(is.brmsfit(x))
+  if (has_mix_groups(x$family)) {
+    stop2("'loo_moment_match' is not supported for group-level mixture ",
+          "models (specified via 'gr' in mixture()).")
+  }
   loo <- loo %||% x$criteria[["loo"]]
   if (is.null(loo)) {
     stop2("No 'loo' object was provided and none is stored within the model.")

--- a/R/loo_moment_match.R
+++ b/R/loo_moment_match.R
@@ -61,10 +61,6 @@ loo_moment_match.brmsfit <- function(x, loo = NULL, k_threshold = 0.7,
                                      newdata = NULL, resp = NULL, check = TRUE,
                                      recompile = FALSE, ...) {
   stopifnot(is.brmsfit(x))
-  if (has_mix_groups(x$family)) {
-    stop2("'loo_moment_match' is not supported for group-level mixture ",
-          "models (specified via 'gr' in mixture()).")
-  }
   loo <- loo %||% x$criteria[["loo"]]
   if (is.null(loo)) {
     stop2("No 'loo' object was provided and none is stored within the model.")
@@ -117,8 +113,13 @@ loo_moment_match.loo <- function(x, fit, ...) {
   loo_moment_match(fit, loo = x, ...)
 }
 
-# compute a vector of log-likelihood values for the ith observation
+# compute a vector of log-likelihood values for the ith pointwise unit
+# (a single observation, or a whole group for group-level mixtures)
 .log_lik_i <- function(x, i, newdata, ...) {
+  if (has_mix_groups(x$family)) {
+    # 'i' indexes a mixture group; predict all of its observations jointly
+    i <- mixgr_row_ids(x, newdata)[[i]]
+  }
   as.vector(log_lik(x, newdata = newdata[i, , drop = FALSE], ...))
 }
 

--- a/R/loo_moment_match.R
+++ b/R/loo_moment_match.R
@@ -114,7 +114,6 @@ loo_moment_match.loo <- function(x, fit, ...) {
 }
 
 # compute a vector of log-likelihood values for the ith pointwise unit
-# (a single observation, or a whole group for group-level mixtures)
 .log_lik_i <- function(x, i, newdata, ...) {
   if (has_mix_groups(x$family)) {
     # 'i' indexes a mixture group; predict all of its observations jointly

--- a/R/loo_subsample.R
+++ b/R/loo_subsample.R
@@ -28,6 +28,10 @@
 #' @export
 loo_subsample.brmsfit <- function(x, ..., compare = TRUE, resp = NULL,
                                   model_names = NULL) {
+  if (has_mix_groups(x$family)) {
+    stop2("'loo_subsample' is not supported for group-level mixture ",
+          "models (specified via 'gr' in mixture()).")
+  }
   args <- split_dots(x, ..., model_names = model_names)
   c(args) <- nlist(
     criterion = "loo_subsample", compare, resp,

--- a/R/loo_subsample.R
+++ b/R/loo_subsample.R
@@ -28,10 +28,7 @@
 #' @export
 loo_subsample.brmsfit <- function(x, ..., compare = TRUE, resp = NULL,
                                   model_names = NULL) {
-  if (has_mix_groups(x$family)) {
-    stop2("'loo_subsample' is not supported for group-level mixture ",
-          "models (specified via 'gr' in mixture()).")
-  }
+  # group-level mixtures need no special handling: pointwise log_lik is per group
   args <- split_dots(x, ..., model_names = model_names)
   c(args) <- nlist(
     criterion = "loo_subsample", compare, resp,

--- a/R/numeric-helpers.R
+++ b/R/numeric-helpers.R
@@ -156,6 +156,12 @@ log_sum_exp <- function(x, y) {
   max + log(exp(x - max) + exp(y - max))
 }
 
+# stable row-wise log(sum(exp(x))) of a matrix
+# (or of an array slice coercible to a matrix)
+log_sum_exp_rows <- function(x) {
+  matrixStats::rowLogSumExps(matrix(x, nrow = dim(x)[1]))
+}
+
 log_mean_exp <- function(x) {
   max_x <- max(x)
   max_x + log(sum(exp(x - max_x))) - log(length(x))

--- a/R/numeric-helpers.R
+++ b/R/numeric-helpers.R
@@ -156,8 +156,7 @@ log_sum_exp <- function(x, y) {
   max + log(exp(x - max) + exp(y - max))
 }
 
-# stable row-wise log(sum(exp(x))) of a matrix
-# (or of an array slice coercible to a matrix)
+# stable row-wise log(sum(exp(x)))
 log_sum_exp_rows <- function(x) {
   matrixStats::rowLogSumExps(matrix(x, nrow = dim(x)[1]))
 }

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -209,6 +209,12 @@ posterior_predict.brmsprep <- function(object, transform = NULL, sort = FALSE,
   }
   pp_fun <- paste0("posterior_predict_", object$family$fun)
   pp_fun <- get(pp_fun, asNamespace("brms"))
+  if (!is.null(object$mixgr)) {
+    # sample one mixture component per group (shared across its observations)
+    # before dispatching, so the assignment is consistent across observations
+    # (also under parallel execution)
+    object$mixgr$ids <- sample_mixture_group_ids(object)
+  }
   N <- choose_N(object)
   out <- plapply(seq_len(N), pp_fun, .cores = cores, prep = object,
     output = output, p = p, ...)
@@ -1120,8 +1126,14 @@ posterior_predict_custom <- function(i, prep, output = "random",
 posterior_predict_mixture <- function(i, prep, output = "random", ...) {
   validate_pp_output_support("mixture", output)
   families <- family_names(prep$family)
-  theta <- get_theta(prep, i = i)
-  smix <- sample_mixture_ids(theta)
+  if (!is.null(prep$mixgr)) {
+    # group-level mixture: reuse the component sampled for this observation's
+    # group (precomputed in posterior_predict.brmsprep)
+    smix <- prep$mixgr$ids[, prep$mixgr$J[i]]
+  } else {
+    theta <- get_theta(prep, i = i)
+    smix <- sample_mixture_ids(theta)
+  }
   out <- rep(NA, prep$ndraws)
   for (j in seq_along(families)) {
     draw_ids <- which(smix == j)
@@ -1252,6 +1264,20 @@ sample_mixture_ids <- function(theta) {
   ulapply(seq_rows(theta), function(s)
     sample(mix_comp, 1, prob = theta[s, ])
   )
+}
+
+# sample one mixture component id per group for group-level mixtures
+# the mixing proportions are constant within a group, hence sampling is based
+# on the group's representative observation
+# @param prep a 'brmsprep' object carrying a 'mixgr' list
+# @return a draws x ngroups matrix of sampled component ids
+sample_mixture_group_ids <- function(prep) {
+  ngroups <- prep$mixgr$ngroups
+  ids <- matrix(NA_integer_, nrow = prep$ndraws, ncol = ngroups)
+  for (g in seq_len(ngroups)) {
+    ids[, g] <- sample_mixture_ids(get_theta(prep, i = prep$mixgr$rep[g]))
+  }
+  ids
 }
 
 # extract the first valid predicted value per Stan sample per observation

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -210,9 +210,7 @@ posterior_predict.brmsprep <- function(object, transform = NULL, sort = FALSE,
   pp_fun <- paste0("posterior_predict_", object$family$fun)
   pp_fun <- get(pp_fun, asNamespace("brms"))
   if (!is.null(object$mixgr)) {
-    # sample one mixture component per group (shared across its observations)
-    # before dispatching, so the assignment is consistent across observations
-    # (also under parallel execution)
+    # sample one mixture component per group, shared across its observations
     object$mixgr$ids <- sample_mixture_group_ids(object)
   }
   N <- choose_N(object)
@@ -1127,8 +1125,7 @@ posterior_predict_mixture <- function(i, prep, output = "random", ...) {
   validate_pp_output_support("mixture", output)
   families <- family_names(prep$family)
   if (!is.null(prep$mixgr)) {
-    # group-level mixture: reuse the component sampled for this observation's
-    # group (precomputed in posterior_predict.brmsprep)
+    # reuse the component sampled for this observation's group
     smix <- prep$mixgr$ids[, prep$mixgr$J[i]]
   } else {
     theta <- get_theta(prep, i = i)
@@ -1267,9 +1264,6 @@ sample_mixture_ids <- function(theta) {
 }
 
 # sample one mixture component id per group for group-level mixtures
-# the mixing proportions are constant within a group, hence sampling is based
-# on the group's representative observation
-# @param prep a 'brmsprep' object carrying a 'mixgr' list
 # @return a draws x ngroups matrix of sampled component ids
 sample_mixture_group_ids <- function(prep) {
   ngroups <- prep$mixgr$ngroups

--- a/R/pp_mixture.R
+++ b/R/pp_mixture.R
@@ -29,6 +29,10 @@
 #' \deqn{P(Y_n) = \sum_{k=1,...,K} P(Y_n | K_n = k) P(K_n = k)}
 #' is a normalizing constant.
 #'
+#' For group-level mixtures (argument \code{gr} of \code{\link{mixture}}),
+#' component memberships are defined per group rather than per observation,
+#' so the dimension N of the returned array corresponds to the groups.
+#'
 #' @examples
 #' \dontrun{
 #' ## simulate some data
@@ -87,11 +91,23 @@ pp_mixture.brmsfit <- function(x, newdata = NULL, re_formula = NULL,
   for (dp in names(prep$dpars)) {
     prep$dpars[[dp]] <- get_dpar(prep, dpar = dp)
   }
-  N <- choose_N(prep)
-  out <- lapply(seq_len(N), log_lik_mixture, prep = prep)
-  out <- abind(out, along = 3)
-  out <- aperm(out, c(1, 3, 2))
-  old_order <- prep$old_order
+  if (!is.null(prep$mixgr)) {
+    # group-level mixture: component responsibilities are defined per group
+    ps <- mixture_group_ps(prep)
+    ngroups <- dim(ps)[2]
+    out <- ps
+    for (g in seq_len(ngroups)) {
+      norm <- log_sum_exp_rows(ps[, g, , drop = FALSE])
+      out[, g, ] <- ps[, g, ] - norm
+    }
+    old_order <- NULL
+  } else {
+    N <- choose_N(prep)
+    out <- lapply(seq_len(N), log_lik_mixture, prep = prep)
+    out <- abind(out, along = 3)
+    out <- aperm(out, c(1, 3, 2))
+    old_order <- prep$old_order
+  }
   sort <- isTRUE(ncol(out) != length(old_order))
   out <- reorder_obs(out, old_order, sort = sort)
   if (!log) {

--- a/R/pp_mixture.R
+++ b/R/pp_mixture.R
@@ -92,7 +92,7 @@ pp_mixture.brmsfit <- function(x, newdata = NULL, re_formula = NULL,
     prep$dpars[[dp]] <- get_dpar(prep, dpar = dp)
   }
   if (!is.null(prep$mixgr)) {
-    # group-level mixture: component responsibilities are defined per group
+    # group-level mixture: responsibilities are defined per group
     ps <- mixture_group_ps(prep)
     ngroups <- dim(ps)[2]
     out <- ps

--- a/R/prepare_predictions.R
+++ b/R/prepare_predictions.R
@@ -154,13 +154,12 @@ prepare_predictions.brmsframe <- function(x, draws, sdata, ...) {
       }
     }
     if (has_mix_groups(x$family)) {
-      # group-level (over-group) mixture: the whole group shares one component
+      # group-level mixture: the whole group shares one component
       J <- as.integer(sdata[[paste0("Jmix", resp)]])
       out$mixgr <- list(
         J = J,
         ngroups = as.integer(sdata[[paste0("Ngrmix", resp)]]),
-        # one representative observation per group to read theta from
-        # (mixing proportions are validated to be constant within groups)
+        # representative observation per group to read theta from
         rep = match(seq_len(sdata[[paste0("Ngrmix", resp)]]), J)
       )
     }

--- a/R/prepare_predictions.R
+++ b/R/prepare_predictions.R
@@ -153,6 +153,17 @@ prepare_predictions.brmsframe <- function(x, draws, sdata, ...) {
         out$dpars$theta <- data2draws(out$dpars$theta, dim = dim)
       }
     }
+    if (has_mix_groups(x$family)) {
+      # group-level (over-group) mixture: the whole group shares one component
+      J <- as.integer(sdata[[paste0("Jmix", resp)]])
+      out$mixgr <- list(
+        J = J,
+        ngroups = as.integer(sdata[[paste0("Ngrmix", resp)]]),
+        # one representative observation per group to read theta from
+        # (mixing proportions are validated to be constant within groups)
+        rep = match(seq_len(sdata[[paste0("Ngrmix", resp)]]), J)
+      )
+    }
   }
   if (is_ordinal(x$family)) {
     # it is better to handle ordinal thresholds outside the

--- a/R/reloo.R
+++ b/R/reloo.R
@@ -65,6 +65,10 @@ reloo.brmsfit <- function(x, loo = NULL, k_threshold = 0.7, newdata = NULL,
                           resp = NULL, check = TRUE, recompile = NULL,
                           future_args = list(), ...) {
   stopifnot(is.brmsfit(x), is.list(future_args))
+  if (has_mix_groups(x$family)) {
+    stop2("'reloo' is not supported for group-level mixture models ",
+          "(specified via 'gr' in mixture()).")
+  }
   if (is.brmsfit_multiple(x)) {
     warn_brmsfit_multiple(x)
     class(x) <- "brmsfit"

--- a/R/reloo.R
+++ b/R/reloo.R
@@ -65,10 +65,6 @@ reloo.brmsfit <- function(x, loo = NULL, k_threshold = 0.7, newdata = NULL,
                           resp = NULL, check = TRUE, recompile = NULL,
                           future_args = list(), ...) {
   stopifnot(is.brmsfit(x), is.list(future_args))
-  if (has_mix_groups(x$family)) {
-    stop2("'reloo' is not supported for group-level mixture models ",
-          "(specified via 'gr' in mixture()).")
-  }
   if (is.brmsfit_multiple(x)) {
     warn_brmsfit_multiple(x)
     class(x) <- "brmsfit"
@@ -85,8 +81,17 @@ reloo.brmsfit <- function(x, loo = NULL, k_threshold = 0.7, newdata = NULL,
     mf <- as.data.frame(newdata)
   }
   mf <- rm_attr(mf, c("terms", "brmsframe"))
-  if (NROW(mf) != NROW(loo$pointwise)) {
-    stop2("Number of observations in 'loo' and 'x' do not match.")
+  # for group-level mixtures, 'reloo' is leave-one-group-out
+  grouped <- has_mix_groups(x$family)
+  if (grouped) {
+    grmix_rows <- mixgr_row_ids(x, mf)
+    nunits <- length(grmix_rows)
+  } else {
+    nunits <- NROW(mf)
+  }
+  if (nunits != NROW(loo$pointwise)) {
+    stop2("Number of ", if (grouped) "groups" else "observations",
+          " in 'loo' and 'x' do not match.")
   }
   check <- as_one_logical(check)
   if (check) {
@@ -134,9 +139,9 @@ reloo.brmsfit <- function(x, loo = NULL, k_threshold = 0.7, newdata = NULL,
   .reloo <- function(j) {
     message(
       "\nFitting model ", j, " out of ", J,
-      " (leaving out observation ", obs[j], ")"
+      " (leaving out ", if (grouped) "group " else "observation ", obs[j], ")"
     )
-    omitted <- obs[j]
+    omitted <- if (grouped) grmix_rows[[obs[j]]] else obs[j]
     mf_omitted <- mf[-omitted, , drop = FALSE]
     up_args$newdata <- mf_omitted
     up_args$data2 <- subset_data2(x$data2, -omitted)
@@ -160,12 +165,22 @@ reloo.brmsfit <- function(x, loo = NULL, k_threshold = 0.7, newdata = NULL,
   # most of the following code is taken from rstanarm:::reloo
   # compute elpd_{loo,j} for each of the held out observations
   elpd_loo <- ulapply(lls, log_mean_exp)
-  # compute \hat{lpd}_j for each of the held out observations (using log-lik
+  # compute \hat{lpd}_j for each of the held out units (using log-lik
   # matrix from full posterior, not the leave-one-out posteriors)
-  mf_obs <- mf[obs, , drop = FALSE]
-  data2_obs <- subset_data2(x$data2, obs)
-  ll_x <- log_lik(x, newdata = mf_obs, newdata2 = data2_obs)
-  hat_lpd <- apply(ll_x, 2, log_mean_exp)
+  if (grouped) {
+    # one column per group; compute group by group to keep alignment with 'obs'
+    hat_lpd <- ulapply(obs, function(g) {
+      rows <- grmix_rows[[g]]
+      ll_g <- log_lik(x, newdata = mf[rows, , drop = FALSE],
+                      newdata2 = subset_data2(x$data2, rows))
+      log_mean_exp(as.vector(ll_g))
+    })
+  } else {
+    mf_obs <- mf[obs, , drop = FALSE]
+    data2_obs <- subset_data2(x$data2, obs)
+    ll_x <- log_lik(x, newdata = mf_obs, newdata2 = data2_obs)
+    hat_lpd <- apply(ll_x, 2, log_mean_exp)
+  }
   # compute effective number of parameters
   p_loo <- hat_lpd - elpd_loo
   # replace parts of the loo object with these computed quantities

--- a/R/stan-likelihood.R
+++ b/R/stan-likelihood.R
@@ -64,8 +64,7 @@ stan_log_lik_mixfamily <- function(bterms, threads, ...) {
   stopifnot(is.brmsterms(bterms), is.mixfamily(bterms$family))
   grouped <- has_mix_groups(bterms$family)
   if (grouped && use_threading(threads)) {
-    stop2("Threading is not supported for group-level mixture models ",
-          "specified via 'gr' in mixture().")
+    stop2("Threading is not supported for group-level mixture models.")
   }
   dp_ids <- dpar_id(names(bterms$dpars))
   fdp_ids <- dpar_id(names(bterms$fdpars))
@@ -101,9 +100,8 @@ stan_log_lik_mixfamily <- function(bterms, threads, ...) {
   out
 }
 
-# Stan code for a group-level (over-group) mixture likelihood
-# accumulates each component's log density per group, then marginalizes
-# the mixture once per group via log_sum_exp
+# Stan code for a group-level mixture likelihood: accumulate each component's
+# log density per group, then marginalize the mixture once per group
 # @param ll character vector of per-component accumulation statements
 # @param resp optional response prefix
 # @param pred_mix_prob are mixing proportions predicted (per group)?
@@ -235,10 +233,8 @@ stan_log_lik_mix <- function(ll, bterms, pred_mix_prob, threads,
   Y <- stan_log_lik_Y_name(bterms)
   n <- stan_nn(threads)
   if (has_mix_groups(bterms$family)) {
-    # group-level (over-group) mixture: accumulate this component's log
-    # density into a per-group vector; the mixing weight is added later,
-    # once per group. Always use the normalized lpdf/lpmf because
-    # normalization constants do not factor out of the group-level log_sum_exp.
+    # always use the normalized lpdf: normalization constants do not
+    # cancel from the group-level log_sum_exp
     lpdf <- stan_log_lik_lpdf_name(bterms, normalize = TRUE)
     return(glue(
       "Lmix{resp}[Jmix{resp}{n}, {mix}] += ",

--- a/R/stan-likelihood.R
+++ b/R/stan-likelihood.R
@@ -62,6 +62,11 @@ stan_log_lik_family <- function(bterms, threads, ...) {
 # Stan code for the log likelihood of a mixture family
 stan_log_lik_mixfamily <- function(bterms, threads, ...) {
   stopifnot(is.brmsterms(bterms), is.mixfamily(bterms$family))
+  grouped <- has_mix_groups(bterms$family)
+  if (grouped && use_threading(threads)) {
+    stop2("Threading is not supported for group-level mixture models ",
+          "specified via 'gr' in mixture().")
+  }
   dp_ids <- dpar_id(names(bterms$dpars))
   fdp_ids <- dpar_id(names(bterms$fdpars))
   pred_mix_prob <- any(dpar_class(names(bterms$dpars)) %in% "theta")
@@ -76,6 +81,9 @@ stan_log_lik_mixfamily <- function(bterms, threads, ...) {
     )
   }
   resp <- usc(bterms$resp)
+  if (grouped) {
+    return(stan_log_lik_mixfamily_grouped(ll, resp, pred_mix_prob))
+  }
   n <- stan_nn(threads)
   has_weights <- has_ad_terms(bterms, "weights")
   weights <- str_if(has_weights, glue("weights{resp}{n} * "))
@@ -88,6 +96,42 @@ stan_log_lik_mixfamily <- function(bterms, threads, ...) {
   str_add(out) <- collapse("    ", ll)
   str_add(out) <- glue(
     "  {tp()}{weights}log_sum_exp(ps);\n",
+    "  }}\n"
+  )
+  out
+}
+
+# Stan code for a group-level (over-group) mixture likelihood
+# accumulates each component's log density per group, then marginalizes
+# the mixture once per group via log_sum_exp
+# @param ll character vector of per-component accumulation statements
+# @param resp optional response prefix
+# @param pred_mix_prob are mixing proportions predicted (per group)?
+stan_log_lik_mixfamily_grouped <- function(ll, resp, pred_mix_prob) {
+  nmix <- length(ll)
+  k <- seq_len(nmix)
+  theta <- str_if(pred_mix_prob,
+    glue("theta{k}{resp}[Jmixrep{resp}[j]]"),
+    glue("log(theta{k}{resp})")
+  )
+  ps <- glue("ps[{k}] = {theta} + Lmix{resp}[j, {k}];\n")
+  out <- glue(
+    "  // likelihood of the group-level mixture model\n",
+    "  {{\n",
+    "    matrix[Ngrmix{resp}, {nmix}] Lmix{resp}",
+    " = rep_matrix(0.0, Ngrmix{resp}, {nmix});\n",
+    "    for (n in 1:N{resp}) {{\n"
+  )
+  str_add(out) <- collapse("      ", ll)
+  str_add(out) <- glue(
+    "    }}\n",
+    "    for (j in 1:Ngrmix{resp}) {{\n",
+    "      array[{nmix}] real ps;\n"
+  )
+  str_add(out) <- collapse("      ", ps)
+  str_add(out) <- glue(
+    "    {tp()}log_sum_exp(ps);\n",
+    "    }}\n",
     "  }}\n"
   )
   out
@@ -188,14 +232,25 @@ stan_log_lik_mix <- function(ll, bterms, pred_mix_prob, threads,
   stopifnot(is.sdist(ll))
   resp <- usc(bterms$resp)
   mix <- get_mix_id(bterms)
+  Y <- stan_log_lik_Y_name(bterms)
+  n <- stan_nn(threads)
+  if (has_mix_groups(bterms$family)) {
+    # group-level (over-group) mixture: accumulate this component's log
+    # density into a per-group vector; the mixing weight is added later,
+    # once per group. Always use the normalized lpdf/lpmf because
+    # normalization constants do not factor out of the group-level log_sum_exp.
+    lpdf <- stan_log_lik_lpdf_name(bterms, normalize = TRUE)
+    return(glue(
+      "Lmix{resp}[Jmix{resp}{n}, {mix}] += ",
+      "{ll$dist}_{lpdf}({Y}{resp}{n}{ll$shift} | {ll$args});\n"
+    ))
+  }
   theta <- str_if(pred_mix_prob,
     glue("theta{mix}{resp}[n]"),
     glue("log(theta{mix}{resp})")
   )
   tr <- stan_log_lik_trunc(ll, bterms, threads = threads)
   lpdf <- stan_log_lik_lpdf_name(bterms, normalize, dist = ll$dist)
-  Y <- stan_log_lik_Y_name(bterms)
-  n <- stan_nn(threads)
   if (is.formula(bterms$adforms$cens)) {
     # mostly copied over from stan_log_lik_cens
     # no vectorized version available for mixture models

--- a/R/stan-response.R
+++ b/R/stan-response.R
@@ -103,6 +103,22 @@ stan_response <- function(bframe, threads, normalize, ...) {
       str_add(out$pll_args) <- glue(", data int nthres{resp}")
     }
   }
+  if (has_mix_groups(family)) {
+    # group-level (over-group) mixture indexing; threading is disabled for
+    # these models, so no partial-log-likelihood arguments are required
+    str_add(out$data) <- glue(
+      "  int<lower=1> Ngrmix{resp};  // number of mixture groups\n",
+      "  array[N{resp}] int<lower=1> Jmix{resp};",
+      "  // mixture group per observation\n"
+    )
+    pred_mix_prob <- any(dpar_class(names(bframe$dpars)) %in% "theta")
+    if (pred_mix_prob) {
+      str_add(out$data) <- glue(
+        "  // representative observation per mixture group\n",
+        "  array[Ngrmix{resp}] int<lower=1> Jmixrep{resp};\n"
+      )
+    }
+  }
   if (is.formula(bframe$adforms$se)) {
     str_add(out$data) <- glue(
       "  vector<lower=0>[N{resp}] se{resp};  // known sampling error\n"

--- a/R/stan-response.R
+++ b/R/stan-response.R
@@ -104,8 +104,7 @@ stan_response <- function(bframe, threads, normalize, ...) {
     }
   }
   if (has_mix_groups(family)) {
-    # group-level (over-group) mixture indexing; threading is disabled for
-    # these models, so no partial-log-likelihood arguments are required
+    # group-level mixture indexing (threading is disabled for these models)
     str_add(out$data) <- glue(
       "  int<lower=1> Ngrmix{resp};  // number of mixture groups\n",
       "  array[N{resp}] int<lower=1> Jmix{resp};",

--- a/man/kfold.brmsfit.Rd
+++ b/man/kfold.brmsfit.Rd
@@ -133,6 +133,13 @@ The \code{kfold} function performs exact \eqn{K}-fold
   \link[loo:kfold-helpers]{kfold-helpers} page).
   }
 
+  For group-level mixture models (argument \code{gr} of
+  \code{\link{mixture}}), the pointwise unit of the likelihood is the
+  mixture group rather than the observation: folds are always formed over
+  whole groups, arguments \code{group} and \code{joint} are not supported,
+  \code{folds = "loo"} performs exact leave-one-group-out cross-validation,
+  and a numeric \code{folds} vector must be constant within each group.
+
   When running \code{kfold} on a \code{brmsfit} created with the
   \pkg{cmdstanr} backend in a different \R session, several recompilations
   will be triggered because by default, \pkg{cmdstanr} writes the model

--- a/man/mixture.Rd
+++ b/man/mixture.Rd
@@ -88,8 +88,8 @@ same grouping variable and \code{rescor = FALSE}: each response then
 contributes its own independent per-group mixture, and the joint
 log-likelihood of a group is the sum of the per-response terms. Other
 multivariate combinations are not supported, as they would leave the
-pointwise unit of the likelihood — and thus \code{log_lik}, \code{loo}, and
-related methods — undefined. For group-level
+pointwise unit of the likelihood, and thus \code{log_lik}, \code{loo}, and
+related methods, undefined. For group-level
 mixtures, cross-validation is performed with the group as the unit
 (leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
 value per group, and \code{kfold} (folding over whole groups) as well as the

--- a/man/mixture.Rd
+++ b/man/mixture.Rd
@@ -83,12 +83,13 @@ mixtures currently require the mixing proportions to be either estimated,
 fixed, or predicted by covariates that are constant within each group. They
 are not supported in combination with within-chain threading, censoring,
 truncation, observation weights, or multivariate models. For group-level
-mixtures, \code{log_lik}, \code{loo}, and \code{waic} are computed per group
-(i.e. leave-one-group-out cross-validation), while \code{kfold} and the
+mixtures, cross-validation is performed with the group as the unit
+(leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
+value per group, and \code{kfold} (folding over whole groups) as well as the
 refinements \code{reloo}, \code{loo_moment_match}, and \code{loo_subsample}
-are not available. When predicting from new data, the groups are defined by the
-grouping variable within that data set and need not match the groups of the
-original data.
+operate on these per-group terms. When predicting from new data, the groups are
+defined by the grouping variable within that data set and need not match the
+groups of the original data.
 
 For more details on the specification of mixture
 models, see \code{\link{brmsformula}}.

--- a/man/mixture.Rd
+++ b/man/mixture.Rd
@@ -82,7 +82,14 @@ is marginalized once per group rather than once per observation. Group-level
 mixtures currently require the mixing proportions to be either estimated,
 fixed, or predicted by covariates that are constant within each group. They
 are not supported in combination with within-chain threading, censoring,
-truncation, observation weights, or multivariate models. For group-level
+truncation, or observation weights. In multivariate models, group-level
+mixtures are supported only if every response is a grouped mixture over the
+same grouping variable and \code{rescor = FALSE}: each response then
+contributes its own independent per-group mixture, and the joint
+log-likelihood of a group is the sum of the per-response terms. Other
+multivariate combinations are not supported, as they would leave the
+pointwise unit of the likelihood — and thus \code{log_lik}, \code{loo}, and
+related methods — undefined. For group-level
 mixtures, cross-validation is performed with the group as the unit
 (leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
 value per group, and \code{kfold} (folding over whole groups) as well as the

--- a/man/mixture.Rd
+++ b/man/mixture.Rd
@@ -4,7 +4,7 @@
 \alias{mixture}
 \title{Finite Mixture Families in \pkg{brms}}
 \usage{
-mixture(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL)
+mixture(..., flist = NULL, nmix = 1, order = NULL, refcat = NULL, gr = NULL)
 }
 \arguments{
 \item{...}{One or more objects providing a description of the
@@ -39,6 +39,15 @@ This is analogous to \code{refcat = NA} in \code{\link{categorical}}
 models. As the resulting model is only weakly identified, informative
 priors on the \code{theta} parameters are strongly recommended (see the
 examples in \code{\link{brmsformula}}).}
+
+\item{gr}{Optional name (as a character string) of a grouping variable in the
+data. If specified, the mixture is computed over the levels of that variable
+rather than over individual observations, that is, all observations that
+belong to the same group are assumed to stem from the same (unknown) mixture
+component. This is useful, for example, when entire participants (rather than
+single trials) are thought to belong to different latent classes. By default
+(\code{NULL}), the mixture is computed at the observation level as usual.
+See Details for restrictions of group-level mixtures.}
 }
 \value{
 An object of class \code{mixfamily}.
@@ -63,6 +72,23 @@ For most mixture models, you may want to specify priors on the
 population-level intercepts via \code{\link{set_prior}} to improve
 posterior inference. In addition, it is sometimes necessary to set \code{init = 0}
 in the call to \code{\link{brm}} to allow chains to initialize properly.
+
+By default, the mixture is computed at the level of individual observations,
+that is, each observation may stem from a different mixture component. Via
+argument \code{gr}, the mixture can instead be computed over the levels of a
+grouping variable so that all observations within a group share the same
+(unknown) component. This yields a different likelihood in which the mixing
+is marginalized once per group rather than once per observation. Group-level
+mixtures currently require the mixing proportions to be either estimated,
+fixed, or predicted by covariates that are constant within each group. They
+are not supported in combination with within-chain threading, censoring,
+truncation, observation weights, or multivariate models. For group-level
+mixtures, \code{log_lik}, \code{loo}, and \code{waic} are computed per group
+(i.e. leave-one-group-out cross-validation), while \code{kfold} and the
+refinements \code{reloo}, \code{loo_moment_match}, and \code{loo_subsample}
+are not available. When predicting from new data, the groups are defined by the
+grouping variable within that data set and need not match the groups of the
+original data.
 
 For more details on the specification of mixture
 models, see \code{\link{brmsformula}}.
@@ -120,6 +146,12 @@ pp_check(fit5)
 
 ## compare model fit
 loo(fit1, fit2, fit3, fit4)
+
+## group-level mixture: whole groups belong to the same component
+dat$g <- rep(1:60, each = 5)
+fit6 <- brm(bf(y ~ 1), dat, family = mixture(gaussian, gaussian, gr = "g"),
+            prior = prior, init = 0, chains = 2)
+summary(fit6)
 }
 
 }

--- a/man/mixture.Rd
+++ b/man/mixture.Rd
@@ -40,14 +40,12 @@ models. As the resulting model is only weakly identified, informative
 priors on the \code{theta} parameters are strongly recommended (see the
 examples in \code{\link{brmsformula}}).}
 
-\item{gr}{Optional name (as a character string) of a grouping variable in the
-data. If specified, the mixture is computed over the levels of that variable
-rather than over individual observations, that is, all observations that
-belong to the same group are assumed to stem from the same (unknown) mixture
-component. This is useful, for example, when entire participants (rather than
-single trials) are thought to belong to different latent classes. By default
-(\code{NULL}), the mixture is computed at the observation level as usual.
-See Details for restrictions of group-level mixtures.}
+\item{gr}{Optional name of a grouping variable in the data. If specified,
+the mixture is computed over the levels of that variable rather than over
+individual observations, that is, all observations within a group are
+assumed to stem from the same mixture component. By default (\code{NULL}),
+the mixture is computed at the observation level. See Details for
+restrictions of group-level mixtures.}
 }
 \value{
 An object of class \code{mixfamily}.
@@ -73,30 +71,20 @@ population-level intercepts via \code{\link{set_prior}} to improve
 posterior inference. In addition, it is sometimes necessary to set \code{init = 0}
 in the call to \code{\link{brm}} to allow chains to initialize properly.
 
-By default, the mixture is computed at the level of individual observations,
-that is, each observation may stem from a different mixture component. Via
-argument \code{gr}, the mixture can instead be computed over the levels of a
-grouping variable so that all observations within a group share the same
-(unknown) component. This yields a different likelihood in which the mixing
-is marginalized once per group rather than once per observation. Group-level
-mixtures currently require the mixing proportions to be either estimated,
-fixed, or predicted by covariates that are constant within each group. They
-are not supported in combination with within-chain threading, censoring,
-truncation, or observation weights. In multivariate models, group-level
-mixtures are supported only if every response is a grouped mixture over the
-same grouping variable and \code{rescor = FALSE}: each response then
-contributes its own independent per-group mixture, and the joint
-log-likelihood of a group is the sum of the per-response terms. Other
-multivariate combinations are not supported, as they would leave the
-pointwise unit of the likelihood, and thus \code{log_lik}, \code{loo}, and
-related methods, undefined. For group-level
-mixtures, cross-validation is performed with the group as the unit
-(leave-one-group-out): \code{log_lik}, \code{loo}, and \code{waic} return one
-value per group, and \code{kfold} (folding over whole groups) as well as the
-refinements \code{reloo}, \code{loo_moment_match}, and \code{loo_subsample}
-operate on these per-group terms. When predicting from new data, the groups are
-defined by the grouping variable within that data set and need not match the
-groups of the original data.
+Via argument \code{gr}, the mixture can be computed over the levels of a
+grouping variable instead of over individual observations, so that all
+observations within a group share the same (unknown) component. The mixture
+is then marginalized once per group rather than once per observation.
+Group-level mixtures require the mixing proportions to be constant within
+each group and do not support within-chain threading, censoring, truncation,
+or observation weights. In multivariate models, they are supported only if
+all responses are grouped mixtures over the same grouping variable (with
+\code{rescor = FALSE}). Cross-validation is performed with the group as the
+pointwise unit (leave-one-group-out): \code{log_lik}, \code{loo}, and
+\code{waic} return one value per group, and \code{kfold}, \code{reloo},
+\code{loo_moment_match}, and \code{loo_subsample} operate on these per-group
+terms. When predicting from new data, the groups are defined by the grouping
+variable within that data set and need not match the original groups.
 
 For more details on the specification of mixture
 models, see \code{\link{brmsformula}}.

--- a/man/pp_mixture.brmsfit.Rd
+++ b/man/pp_mixture.brmsfit.Rd
@@ -87,6 +87,10 @@ the (posterior) mixing probability of component k
 (i.e. parameter \code{theta<k>}), and
 \deqn{P(Y_n) = \sum_{k=1,...,K} P(Y_n | K_n = k) P(K_n = k)}
 is a normalizing constant.
+
+For group-level mixtures (argument \code{gr} of \code{\link{mixture}}),
+component memberships are defined per group rather than per observation,
+so the dimension N of the returned array corresponds to the groups.
 }
 \examples{
 \dontrun{

--- a/tests/local/tests.models-3.R
+++ b/tests/local/tests.models-3.R
@@ -223,6 +223,52 @@ test_that("Mixture models work correctly", suppressWarnings({
   # expect_equal(dim(pp_mixture(fit3)), c(nobs(fit3), 4, 3))
 }))
 
+test_that("group-level mixture models work correctly", suppressWarnings({
+  set.seed(1234)
+  ng <- 40
+  npg <- 6
+  comp <- rbinom(ng, 1, 0.4)
+  dat <- do.call(rbind, lapply(seq_len(ng), function(g) {
+    data.frame(g = factor(g), y = rnorm(npg, c(0, 6)[comp[g] + 1], 1))
+  }))
+  fit <- brm(
+    bf(y ~ 1), data = dat,
+    family = mixture(gaussian, gaussian, gr = "g"),
+    prior = c(prior(normal(0, 5), Intercept, dpar = mu1),
+              prior(normal(6, 5), Intercept, dpar = mu2)),
+    chains = 2, init = 0, refresh = 0, seed = 1234
+  )
+  print(fit)
+  # the mixing proportions and component means are recovered
+  ps <- posterior_summary(fit, variable = c("b_mu1_Intercept", "b_mu2_Intercept"))
+  expect_range(ps["b_mu1_Intercept", "Estimate"], -1, 1)
+  expect_range(ps["b_mu2_Intercept", "Estimate"], 5, 7)
+  # predictions are per observation, but log_lik / loo are per group
+  expect_equal(dim(posterior_predict(fit)), c(ndraws(fit), nobs(fit)))
+  expect_equal(dim(posterior_epred(fit)), c(ndraws(fit), nobs(fit)))
+  expect_equal(ncol(log_lik(fit)), ng)
+  expect_equal(nrow(loo(fit)$pointwise), ng)
+  # pointwise evaluation is also computed per group
+  expect_equal(
+    loo(fit, pointwise = TRUE)$pointwise[, "elpd_loo"],
+    loo(fit)$pointwise[, "elpd_loo"]
+  )
+  expect_equal(dim(pp_mixture(fit)), c(ng, 4, 2))
+  # kfold and loo refinements are not available for group-level mixtures
+  expect_error(kfold(fit), "not supported for group-level")
+  expect_error(reloo(fit, loo(fit)), "not supported for group-level")
+  expect_error(loo_subsample(fit), "not supported for group-level")
+  # newdata may contain a subset of the original groups or new groups
+  nd <- dat[dat$g %in% c("1", "2"), ]
+  nd$g <- factor(rep(c("1", "new"), each = npg))
+  expect_equal(ncol(log_lik(fit, newdata = nd)), 2)
+  expect_equal(
+    dim(posterior_predict(fit, newdata = nd)),
+    c(ndraws(fit), nrow(nd))
+  )
+  expect_equal(dim(pp_mixture(fit, newdata = nd)), c(2, 4, 2))
+}))
+
 test_that("Gaussian processes work correctly", suppressWarnings({
   ## Basic GPs
   set.seed(1112)

--- a/tests/local/tests.models-3.R
+++ b/tests/local/tests.models-3.R
@@ -236,7 +236,8 @@ test_that("group-level mixture models work correctly", suppressWarnings({
     family = mixture(gaussian, gaussian, gr = "g"),
     prior = c(prior(normal(0, 5), Intercept, dpar = mu1),
               prior(normal(6, 5), Intercept, dpar = mu2)),
-    chains = 2, init = 0, refresh = 0, seed = 1234
+    chains = 2, init = 0, refresh = 0, seed = 1234,
+    save_pars = save_pars(all = TRUE)  # required for loo_moment_match
   )
   print(fit)
   # the mixing proportions and component means are recovered
@@ -254,10 +255,33 @@ test_that("group-level mixture models work correctly", suppressWarnings({
     loo(fit)$pointwise[, "elpd_loo"]
   )
   expect_equal(dim(pp_mixture(fit)), c(ng, 4, 2))
-  # kfold and loo refinements are not available for group-level mixtures
-  expect_error(kfold(fit), "not supported for group-level")
-  expect_error(reloo(fit, loo(fit)), "not supported for group-level")
-  expect_error(loo_subsample(fit), "not supported for group-level")
+  # kfold and the loo refinements operate per group (leave-one-group-out)
+  loo1 <- loo(fit)
+  # exact leave-one-group-out kfold tracks PSIS-loo
+  kf <- kfold(fit, folds = "loo", chains = 1, refresh = 0)
+  expect_equal(nrow(kf$pointwise), ng)
+  expect_equal(
+    kf$estimates["elpd_kfold", "Estimate"],
+    loo1$estimates["elpd_loo", "Estimate"], tolerance = 2
+  )
+  # K-fold over groups keeps whole groups within a fold
+  kf5 <- kfold(fit, K = 5, chains = 1, refresh = 0, save_fits = TRUE)
+  expect_equal(nrow(kf5$pointwise), ng)
+  # predictions from the saved fits are per observation
+  kfp <- kfold_predict(kf5)
+  expect_equal(length(kfp$y), nobs(fit))
+  # a single integer 'Ksub' selects that many random folds
+  kf2 <- kfold(fit, K = 5, Ksub = 2, chains = 1, refresh = 0)
+  expect_lt(nrow(kf2$pointwise), ng)
+  # reloo refits problematic groups and preserves the per-group unit
+  rl <- reloo(fit, loo1, k_threshold = 0.5, chains = 1, refresh = 0)
+  expect_equal(nrow(rl$pointwise), ng)
+  expect_true(all(is.finite(rl$pointwise[, "elpd_loo"])))
+  # subsampling and moment matching operate on the per-group pointwise term
+  expect_equal(nrow(loo_subsample(fit, observations = 20)$pointwise), 20)
+  expect_s3_class(loo_moment_match(fit, loo1, k_threshold = 0.5), "loo")
+  # 'group' is redundant with the mixture grouping and is rejected
+  expect_error(kfold(fit, group = "g"), "not supported for group-level")
   # newdata may contain a subset of the original groups or new groups
   nd <- dat[dat$g %in% c("1", "2"), ]
   nd$g <- factor(rep(c("1", "new"), each = npg))

--- a/tests/local/tests.models-3.R
+++ b/tests/local/tests.models-3.R
@@ -282,6 +282,10 @@ test_that("group-level mixture models work correctly", suppressWarnings({
   expect_s3_class(loo_moment_match(fit, loo1, k_threshold = 0.5), "loo")
   # 'group' is redundant with the mixture grouping and is rejected
   expect_error(kfold(fit, group = "g"), "not supported for group-level")
+  # 'joint' has no meaning when the group is the pointwise unit
+  expect_error(kfold(fit, joint = "obs"), "not supported for group-level")
+  # only the default, folds = 'loo', or group-constant numeric folds work
+  expect_error(kfold(fit, folds = "stratified"), "Unsupported 'folds'")
   # newdata may contain a subset of the original groups or new groups
   nd <- dat[dat$g %in% c("1", "2"), ]
   nd$g <- factor(rep(c("1", "new"), each = npg))

--- a/tests/testthat/tests.families.R
+++ b/tests/testthat/tests.families.R
@@ -105,6 +105,12 @@ test_that("mixture returns expected results and errors", {
   expect_null(mixture(gaussian, gaussian)$refcat)
   expect_error(mixture(gaussian, gaussian, refcat = 1),
                "'refcat' can only be NULL or NA")
+  # group-level mixtures store the grouping variable name on the family
+  expect_null(mixture(gaussian, gaussian)$mixgr_var)
+  expect_false(brms:::has_mix_groups(mixture(gaussian, gaussian)))
+  mix_gr <- mixture(gaussian, gaussian, gr = "ID")
+  expect_equal(mix_gr$mixgr_var, "ID")
+  expect_true(brms:::has_mix_groups(mix_gr))
 })
 
 test_that("response interval is defined correctly", {

--- a/tests/testthat/tests.families.R
+++ b/tests/testthat/tests.families.R
@@ -111,6 +111,11 @@ test_that("mixture returns expected results and errors", {
   mix_gr <- mixture(gaussian, gaussian, gr = "ID")
   expect_equal(mix_gr$mixgr_var, "ID")
   expect_true(brms:::has_mix_groups(mix_gr))
+  # the grouping factor defines the group indices and log_lik column order
+  dat <- data.frame(ID = c("b", "a", "b", "c"))
+  gr <- brms:::mixgr_factor(mix_gr, dat)
+  expect_equal(levels(gr), c("a", "b", "c"))
+  expect_equal(as.integer(gr), c(2L, 1L, 2L, 3L))
 })
 
 test_that("response interval is defined correctly", {

--- a/tests/testthat/tests.misc.R
+++ b/tests/testthat/tests.misc.R
@@ -84,3 +84,16 @@ test_that("lsp works correctly", {
     c("inv_logit", "inv_logit_scaled")
   )
 })
+
+test_that("validate_kfold_ksub works correctly", {
+  expect_equal(validate_kfold_ksub(NULL, 5), 1:5)
+  # a single integer selects that many random folds
+  expect_length(validate_kfold_ksub(3, 10), 3L)
+  # arrays are taken as fold indices, not a number of folds (#441)
+  expect_equal(validate_kfold_ksub(array(2), 10), 2L)
+  expect_equal(validate_kfold_ksub(c(4, 2, 2), 5), c(2L, 4L))
+  expect_error(validate_kfold_ksub(integer(0), 5),
+               "non-empty integer vector")
+  expect_error(validate_kfold_ksub(7, 5),
+               "not larger than 'K'")
+})

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -1927,6 +1927,25 @@ test_that("Stan code of group-level mixture model is correct", {
   )
   expect_match2(scode, "Lmix[Jmix[n], 1] += poisson_log_lpmf(Y[n] | mu1[n]);")
 
+  # the normalized lpdf is required even with normalize = FALSE, because
+  # normalization constants do not cancel from the group-level log_sum_exp
+  scode <- stancode(
+    bf(y ~ x), data,
+    family = mixture(gaussian, gaussian, gr = "g"),
+    normalize = FALSE
+  )
+  expect_match2(scode, "Lmix[Jmix[n], 1] += normal_lpdf(Y[n] | mu1[n], sigma1);")
+  expect_match2(scode, "Lmix[Jmix[n], 2] += normal_lpdf(Y[n] | mu2[n], sigma2);")
+
+  # 'gr' composes with 'refcat = NA': all proportions predicted, per group
+  scode <- stancode(
+    bf(y ~ x, theta1 ~ gc, theta2 ~ gc), data,
+    family = mixture(gaussian, gaussian, gr = "g", refcat = NA)
+  )
+  expect_match2(scode, "theta1 += Intercept_theta1 + Xc_theta1 * b_theta1;")
+  expect_match2(scode, "theta2 += Intercept_theta2 + Xc_theta2 * b_theta2;")
+  expect_match2(scode, "ps[1] = theta1[Jmixrep[j]] + Lmix[j, 1];")
+
   # predicted proportions varying within group are not allowed
   expect_error(
     standata(bf(y ~ x, theta1 ~ x), data,

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -1945,12 +1945,33 @@ test_that("Stan code of group-level mixture model is correct", {
              family = mixture(gaussian, gaussian, gr = "g")),
     "not supported in combination with"
   )
-  # group-level mixtures are not yet supported in multivariate models
+  # multivariate: only symmetric grouped mixtures on the same 'gr' are allowed
   expect_error(
     stancode(bf(y ~ x) + bf(x ~ 1, family = gaussian()), data,
              family = mixture(gaussian, gaussian, gr = "g")),
     "not yet supported in multivariate models"
   )
+  data$y2 <- rnorm(nrow(data))
+  data$g2 <- data$g
+  mixfam <- mixture(gaussian, gaussian, gr = "g")
+  expect_error(
+    stancode(bf(y ~ x, family = mixfam) +
+               bf(y2 ~ x, family = mixture(gaussian, gaussian, gr = "g2")) +
+               set_rescor(FALSE), data),
+    "require the same 'gr' variable"
+  )
+  expect_error(
+    stancode(bf(y ~ x, family = mixfam) + bf(y2 ~ x, family = mixfam) +
+               set_rescor(TRUE), data),
+    "only possible in multivariate gaussian or student models"
+  )
+  scode <- stancode(
+    bf(y ~ x, family = mixfam) + bf(y2 ~ x, family = mixfam) +
+      set_rescor(FALSE), data
+  )
+  expect_match2(scode, "matrix[Ngrmix_y, 2] Lmix_y = rep_matrix(0.0, Ngrmix_y, 2);")
+  expect_match2(scode, "matrix[Ngrmix_y2, 2] Lmix_y2 = rep_matrix(0.0, Ngrmix_y2, 2);")
+  expect_match2(scode, "ps[1] = log(theta1_y2) + Lmix_y2[j, 1];")
 })
 
 test_that("sparse matrix multiplication is applied correctly", {

--- a/tests/testthat/tests.stancode.R
+++ b/tests/testthat/tests.stancode.R
@@ -1856,7 +1856,7 @@ test_that("Stan code of mixture model is correct", {
              data = data, family = fam_na),
     "all mixing proportions must be predicted"
   )
-  
+
   fam <- mixture(cumulative, sratio)
   scode <- stancode(y ~ x, data, family = fam)
   expect_match2(scode, "ordered_logistic_lpmf(Y[n] | mu1[n], Intercept_mu1);")
@@ -1891,6 +1891,66 @@ test_that("Stan code of mixture model is correct", {
   scode <- stancode(bform, data = data, prior = bprior)
   expect_match2(scode, "mu1[n] = (nlp_eta[n] ^ 2);")
   expect_match2(scode, "mu2[n] = (log(nlp_eta[n]) + nlp_a[n]);")
+})
+
+test_that("Stan code of group-level mixture model is correct", {
+  data <- data.frame(y = 1:10, x = rnorm(10), g = rep(1:5, each = 2))
+
+  # estimated (joint) mixing proportions
+  scode <- stancode(
+    bf(y ~ x, sigma2 ~ x), data,
+    family = mixture(gaussian, gaussian, gr = "g")
+  )
+  expect_match2(scode, "int<lower=1> Ngrmix;  // number of mixture groups")
+  expect_match2(scode, "array[N] int<lower=1> Jmix;")
+  expect_match2(scode, "matrix[Ngrmix, 2] Lmix = rep_matrix(0.0, Ngrmix, 2);")
+  expect_match2(scode, "Lmix[Jmix[n], 1] += normal_lpdf(Y[n] | mu1[n], sigma1);")
+  expect_match2(scode, "Lmix[Jmix[n], 2] += normal_lpdf(Y[n] | mu2[n], sigma2[n]);")
+  expect_match2(scode, "for (j in 1:Ngrmix) {")
+  expect_match2(scode, "ps[1] = log(theta1) + Lmix[j, 1];")
+  expect_match2(scode, "ps[2] = log(theta2) + Lmix[j, 2];")
+  expect_match2(scode, "target += log_sum_exp(ps);")
+
+  # predicted mixing proportions that are constant within each group
+  data$gc <- factor(rep(c("a", "b"), each = 5))
+  scode <- stancode(
+    bf(y ~ x, theta1 ~ gc), data,
+    family = mixture(gaussian, gaussian, gr = "g")
+  )
+  expect_match2(scode, "array[Ngrmix] int<lower=1> Jmixrep;")
+  expect_match2(scode, "ps[1] = theta1[Jmixrep[j]] + Lmix[j, 1];")
+
+  # discrete component families use the normalized lpmf
+  scode <- stancode(
+    bf(y ~ x), data,
+    family = mixture(poisson, poisson, gr = "g")
+  )
+  expect_match2(scode, "Lmix[Jmix[n], 1] += poisson_log_lpmf(Y[n] | mu1[n]);")
+
+  # predicted proportions varying within group are not allowed
+  expect_error(
+    standata(bf(y ~ x, theta1 ~ x), data,
+             family = mixture(gaussian, gaussian, gr = "g")),
+    "must be constant within each group"
+  )
+  # threading is not supported for group-level mixtures
+  expect_error(
+    stancode(bf(y ~ x), data, family = mixture(gaussian, gaussian, gr = "g"),
+             threads = threading(2)),
+    "Threading is not supported"
+  )
+  # censoring/truncation/weights are not supported
+  expect_error(
+    standata(bf(y | trunc(0) ~ x), data,
+             family = mixture(gaussian, gaussian, gr = "g")),
+    "not supported in combination with"
+  )
+  # group-level mixtures are not yet supported in multivariate models
+  expect_error(
+    stancode(bf(y ~ x) + bf(x ~ 1, family = gaussian()), data,
+             family = mixture(gaussian, gaussian, gr = "g")),
+    "not yet supported in multivariate models"
+  )
 })
 
 test_that("sparse matrix multiplication is applied correctly", {

--- a/tests/testthat/tests.standata.R
+++ b/tests/testthat/tests.standata.R
@@ -772,6 +772,33 @@ test_that("standata includes data for mixture models", {
   expect_equal(sdata$theta2, 3/4)
 })
 
+test_that("standata includes data for group-level mixture models", {
+  data <- data.frame(y = rnorm(10), x = rnorm(10), g = rep(c("a", "b"), each = 5))
+  form <- bf(y ~ x, family = mixture(gaussian, gaussian, gr = "g"))
+  sdata <- standata(form, data)
+  expect_equal(sdata$Ngrmix, 2)
+  expect_equal(sdata$Jmix, as.array(rep(1:2, each = 5)))
+  # no representative index unless the mixing proportions are predicted
+  expect_null(sdata$Jmixrep)
+
+  # predicted mixing proportions constant within group -> Jmixrep is emitted
+  form <- bf(y ~ x, theta1 ~ g, family = mixture(gaussian, gaussian, gr = "g"))
+  sdata <- standata(form, data)
+  expect_equal(sdata$Jmixrep, as.array(c(1, 6)))
+
+  # integer grouping variables are supported
+  data$gi <- rep(1:2, each = 5)
+  form <- bf(y ~ x, family = mixture(gaussian, gaussian, gr = "gi"))
+  sdata <- standata(form, data)
+  expect_equal(sdata$Jmix, as.array(rep(1:2, each = 5)))
+
+  # group indices are defined by the data at hand (e.g. for newdata subsets)
+  form <- bf(y ~ x, family = mixture(gaussian, gaussian, gr = "g"))
+  sdata <- standata(form, data[data$g == "b", ])
+  expect_equal(sdata$Ngrmix, 1)
+  expect_equal(sdata$Jmix, as.array(rep(1, 5)))
+})
+
 test_that("standata includes data for Gaussian processes", {
   dat <- data.frame(y = rnorm(10), x1 = rnorm(10),
                     z = factor(c(2, 2, 2, 3, 4, rep(5, 5))))


### PR DESCRIPTION
Closes #1659.

The changes in this PR implement the feature requested in #1659: `mixture()` can compute the mixture over the levels of a grouping variable instead of over individual observations, so a whole group (e.g. a participant) is assigned to one component. The motivation, the likelihood distinction, and the Stan sketch are available in the issue and its linked note.

In two places I departed from the proposals from the issue:

- The grouping is specified in the call to `mixture()`, not in a `mix()` aterm in the `brmsformula`. The issue proposed `y | mix(gr = "ID") ~ ...`. That works, but a `mix` addition term collides with the existing `mi` term through R's `$` partial matching (`adforms$mi` resolves to a `mix` element when no `mi` is present), which would force `$mi` → `[["mi"]]` edits across ~8 unrelated files. Putting `gr` on the family avoids that and keeps the change scoped. The only thing the family route doesn't get for free is the grouping column reaching the model frame (built from formula variables), so it is added to `allvars` explicitly in `R/brmsterms.R`. Feel free to say if you would prefer the grouping specification as an `aterm` in the `brmsformula` instead.
- I used `log_sum_exp` over a `ps[]` array, instead of the `log_mix` proposed in the issue. This follows other brms code that already builds every mixture as `log_sum_exp` over per-component terms rather than `log_mix`, so the group-level path reuses that and generalizes to N components for free.

### Background on some coding choices

During implementation I noted some things that I want to shortly elaborate on. If you notice errors in my thinking, please say so, and I am happy to adapt the PR accordingly.

- The normalized `_lpdf` in the accumulator is required. Normalization constants cancel out of an observation-level `log_sum_exp` but are summed over the group before mixing here, so dropping them (`_lupdf`) would change the relative component weights. The grouped path therefore never uses the unnormalized form even when `normalize = FALSE`. 
- Predicting `theta` is restricted to group-constant predictors. A per-observation-varying mixing proportion is not meaningful when the component is shared across a group. This is validated in `standata`; when constant, the proportion is read from a representative observation per group (`Jmixrep`).
- `log_lik`/`loo` need to change unit for grouped mixtures. The likelihood for grouped mixtures doesn't factorize over observations, so `log_lik` returns one column per group and `loo`/`waic` become leave-one-group-out — the correct CV unit here. Base `loo`/`waic`/`loo_compare`/`r_eff` are column-count agnostic and handle it. The changes in the PR follow the same unit: `kfold` forms folds over whole groups, `reloo` and `loo_moment_match` refit/match per group, and `loo_subsample` works because the pointwise `log_lik` is already per group. `kfold_predict` works on saved grouped kfolds; predictions stay per observation while the elpd unit is the group.
- Bundled upstream **bugfix** (if you prefer I can add this in a separate PR). The Pointwise `log_lik` (`pointwise = TRUE`) was broken for *all* multivariate models without `rescor`, independent of this feature: `log_lik_pointwise` passed each response's prepared draws as `data_i` instead of `draws` (`lapply(draws$resps, log_lik_pointwise, i = i)`). Only `loo_subsample` exercises this path, which is presumably why it went unnoticed until now. 
- With its multivariate machinery, `brms` did already support independent per-response grouped mixtures. So, in the supported multivariate case, each response carries its *own* mixing proportion and its own per-group component assignment; responses can be coupled only through shared/correlated group-level effects (e.g. `(1 | p | ID)` across formulas). Thus, a group can be in component 1 for one response and component 2 for another: the joint per-group likelihood is the *product of per-response mixtures*, not a *mixture of products*. A single latent class driving all responses (one shared assignment) would require cross-response accumulation into one `Lmix` before a single `log_sum_exp`, cutting against the one-likelihood-block-per-response architecture; I felt that this is out of scope here. I added information to the `mixture()` docs, so they state the independent-assignment semantics explicitly.
- To achieve well-behaved posterior predictives, multivariate grouped mixtures are allowed if *all* responses are
grouped mixtures over the *same* grouping variable with `rescor = FALSE` (`rescor` is independently excluded for mixtures by `allow_rescor`). Then the group remains the pointwise unit jointly: its log-likelihood is the sum of the per-response per-group terms, and every CV method above carries over unchanged. Asymmetric models (grouped mixture + ordinary response) and mismatched `gr` variables are refused with errors that say why: they leave `log_lik`/`loo` without a common pointwise unit.

### Evaluation of the implementation

To test the behavior of the implementation, I reproduced Musfeld, Souza & Oberauer (2023, *PNAS* 120:e2218042120), a per-participant Hebb-repetition mixture (learner vs. non-learner):
- *Univariate accuracy model*: the generated Stan matches their per-subject `log_mix` accumulation, including a shared baseline across components (shared non-linear parameters) and a non-linear hinged-onset learner curve. Fitting all three visual conditions on the authors' OSF data recovers the learner proportion at **0.58–0.59** vs. the published **~0.60**, near-identical between groups (their central between-group null), with learning curves matching their Fig 3D.
- *Multivariate joint model*: their combined learning + awareness Stan model is two independent per-subject mixtures coupled by five 2×2 participant-effect correlations. A prototype fit on their data reproduces the key published result, the learning↔awareness onset correlation: **0.83 [0.63, 0.95]** vs. published **0.82 [0.63, 0.94]**, with awareness onset preceding learning onset as in the paper. (caveats: their ordered-beta awareness family was approximated with `Beta` plus endpoint compression; `zero_one_inflated_beta` is currently not allowed inside `mixture()`.)