### PR TITLE
Fixed website issue

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -59,6 +59,10 @@ jobs:
               run_dont_run = TRUE,
               new_process = TRUE
             )
+            # overwrite references/index.html so it points to all functions instead of addition terms page
+            pkgdown::build_reference_index(
+              override = list(destination = "docs")
+            )
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -60,6 +60,7 @@ jobs:
               new_process = TRUE
             )
             # overwrite references/index.html so it points to all functions instead of addition terms page
+            unlink("docs/reference/index.html")
             pkgdown::build_reference_index(
               override = list(destination = "docs")
             )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -114,4 +114,4 @@ SystemRequirements: pngquant
 VignetteBuilder:
     knitr,
     R.rsp
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -663,58 +663,70 @@ import(ggplot2)
 import(methods)
 import(parallel)
 import(stats)
-importFrom(bayesplot,log_posterior)
-importFrom(bayesplot,neff_ratio)
-importFrom(bayesplot,nuts_params)
-importFrom(bayesplot,pp_check)
-importFrom(bayesplot,theme_default)
-importFrom(bridgesampling,bayes_factor)
-importFrom(bridgesampling,bridge_sampler)
-importFrom(bridgesampling,post_prob)
+importFrom(bayesplot,
+  log_posterior,
+  neff_ratio,
+  nuts_params,
+  pp_check,
+  theme_default
+)
+importFrom(bridgesampling,
+  bayes_factor,
+  bridge_sampler,
+  post_prob
+)
 importFrom(coda,as.mcmc)
 importFrom(grDevices,devAskNewPage)
 importFrom(graphics,plot)
-importFrom(loo,.compute_point_estimate)
-importFrom(loo,.ndraws)
-importFrom(loo,.thin_draws)
-importFrom(loo,is.loo)
-importFrom(loo,kfold)
-importFrom(loo,loo)
-importFrom(loo,loo_compare)
-importFrom(loo,loo_model_weights)
-importFrom(loo,loo_moment_match)
-importFrom(loo,loo_subsample)
-importFrom(loo,psis)
-importFrom(loo,waic)
-importFrom(nlme,VarCorr)
-importFrom(nlme,fixef)
-importFrom(nlme,ranef)
-importFrom(posterior,as_draws)
-importFrom(posterior,as_draws_array)
-importFrom(posterior,as_draws_df)
-importFrom(posterior,as_draws_list)
-importFrom(posterior,as_draws_matrix)
-importFrom(posterior,as_draws_rvars)
-importFrom(posterior,nchains)
-importFrom(posterior,ndraws)
-importFrom(posterior,niterations)
-importFrom(posterior,nvariables)
-importFrom(posterior,rhat)
-importFrom(posterior,subset_draws)
-importFrom(posterior,summarize_draws)
-importFrom(posterior,variables)
+importFrom(loo,
+  .compute_point_estimate,
+  .ndraws,
+  .thin_draws,
+  is.loo,
+  kfold,
+  loo,
+  loo_compare,
+  loo_model_weights,
+  loo_moment_match,
+  loo_subsample,
+  psis,
+  waic
+)
+importFrom(nlme,
+  VarCorr,
+  fixef,
+  ranef
+)
+importFrom(posterior,
+  as_draws,
+  as_draws_array,
+  as_draws_df,
+  as_draws_list,
+  as_draws_matrix,
+  as_draws_rvars,
+  nchains,
+  ndraws,
+  niterations,
+  nvariables,
+  rhat,
+  subset_draws,
+  summarize_draws,
+  variables
+)
 importFrom(rlang,.data)
-importFrom(rstantools,bayes_R2)
-importFrom(rstantools,log_lik)
-importFrom(rstantools,loo_R2)
-importFrom(rstantools,loo_linpred)
-importFrom(rstantools,loo_predict)
-importFrom(rstantools,loo_predictive_interval)
-importFrom(rstantools,nsamples)
-importFrom(rstantools,posterior_epred)
-importFrom(rstantools,posterior_interval)
-importFrom(rstantools,posterior_linpred)
-importFrom(rstantools,posterior_predict)
-importFrom(rstantools,predictive_error)
-importFrom(rstantools,predictive_interval)
-importFrom(rstantools,prior_summary)
+importFrom(rstantools,
+  bayes_R2,
+  log_lik,
+  loo_R2,
+  loo_linpred,
+  loo_predict,
+  loo_predictive_interval,
+  nsamples,
+  posterior_epred,
+  posterior_interval,
+  posterior_linpred,
+  posterior_predict,
+  predictive_error,
+  predictive_interval,
+  prior_summary
+)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -41,7 +41,6 @@ articles:
     desc: >
        These vignettes demonstrate how to use various features of the **brms** package.
     contents:
-      - brms_customfamilies
       - brms_distreg
       - brms_families
       - brms_missings


### PR DESCRIPTION
This PR rebuilds the reference index after the full site is built to create the correct reference index link again. However, this fix isn't super thorough and doesn't fix the sitemap, for example. [This pkgdown PR](https://github.com/r-lib/pkgdown/pull/3016) should fix everything properly.

Due to an upstream bug in pkgdown, if a function defines an alias of `index` (see [here](https://github.com/paul-buerkner/brms/blob/5b0357af9ff54206ea1b325d2cfbe3680502bd3e/R/formula-ad.R#L11)) then the actual reference "index" file (for example, https://mc-stan.org/loo/reference/index.html) will be overwritten and point to just that one function. Removing the alias would be easiest solution but also removes `?index`. 

This PR also removes a _pkgdown reference to a deleted vignette. See [this comment](https://github.com/paul-buerkner/brms/pull/1910#issuecomment-5304588868) for an inventory of other places where this old vignette is mentioned.

Closes #1908.