### PR TITLE
Stabilised and debugged inverse Gaussian CDF and CCDF

### DIFF
--- a/inst/chunks/fun_inv_gaussian.stan
+++ b/inst/chunks/fun_inv_gaussian.stan
@@ -33,8 +33,8 @@
    *   log(P(Y <= y))
    */
    real inv_gaussian_lcdf(real y, real mu, real shape) {
-     return log(Phi(sqrt(shape) / sqrt(y) * (y / mu - 1)) +
-              exp(2 * shape / mu) * Phi(-sqrt(shape) / sqrt(y) * (y / mu + 1)));
+     return log_sum_exp(std_normal_lcdf((sqrt(shape) / sqrt(y)) * (y / mu - 1)),
+              (2 * shape / mu) + std_normal_lcdf(-(sqrt(shape) / sqrt(y)) * (y / mu + 1)));
    }
   /* inverse Gaussian log-CCDF for a single quantile
    * Args:
@@ -45,6 +45,5 @@
    *   log(P(Y > y))
    */
    real inv_gaussian_lccdf(real y, real mu, real shape) {
-     return log1m(Phi(sqrt(shape) / sqrt(y) * (y / mu - 1)) -
-              exp(2 * shape / mu) * Phi(-sqrt(shape) / sqrt(y) * (y / mu + 1)));
+     return log1m_exp(inv_gaussian_lcdf(y | mu, shape));
    }


### PR DESCRIPTION
I am embarrassed to admit that I am (somehow) not a regular **brms** user, and so I have not tested this pull request. As requested, however, here is a version of the inverse Gaussian CDF that has been more stable for me in other contexts. I hope it is helpful even if it isn't yet thoroughly checked.

My implementation elsewhere uses a different parametrisation in order to align with conventions for the generalised inverse Gaussian, and that might also have an effect on stability. Nonetheless, the small changes I've made to this file certainly call more stable variants of the underlying Stan math functions, use some composed functions to do more work on the log scale, and fix a sign error in the CCDF.