### PR TITLE
Fix @aliases placement in posterior.R roxygen documentation

### DIFF
--- a/R/posterior.R
+++ b/R/posterior.R
@@ -1,8 +1,8 @@
 #' Index \code{brmsfit} objects
 #'
-#' @aliases variables nvariables niterations nchains ndraws
-#'
 #' Index variables, iterations, chains, and draws.
+#'
+#' @aliases variables nvariables niterations nchains ndraws
 #'
 #' @param x A \code{brmsfit} object or another \R object for which
 #' the methods are defined.

--- a/man/draws-index-brms.Rd
+++ b/man/draws-index-brms.Rd
@@ -7,12 +7,6 @@
 \alias{niterations}
 \alias{nchains}
 \alias{ndraws}
-\alias{Index}
-\alias{variables,}
-\alias{iterations,}
-\alias{chains,}
-\alias{and}
-\alias{draws.}
 \alias{variables.brmsfit}
 \alias{nvariables.brmsfit}
 \alias{niterations.brmsfit}
@@ -37,5 +31,5 @@ the methods are defined.}
 \item{...}{Arguments passed to individual methods (if applicable).}
 }
 \description{
-Index \code{brmsfit} objects
+Index variables, iterations, chains, and draws.
 }


### PR DESCRIPTION
While working on #1920 and rebuilding the documentation, I noticed an error in posterior.R. This was caused by the `@aliases` line being before what should probably be the description. The error said `@aliases` was three lines instead of one, and the description "Index variables, iterations..." was not rendered. I just moved `@aliases` after the description line and rebuilt the .Rd