### PR TITLE
Use inclusive lower truncation bounds for integer responses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,11 @@ Thanks to Gidon Frischkorn. (#1450)
 
 ### Bug Fixes
 
+* Normalize truncated `log_lik` by `P(lb <= Y <= ub)` rather than 
+`P(lb < Y <= ub)` for integer responses, matching the bound convention of 
+the generated Stan code. Previously `loo` and `waic` disagreed with the 
+fitted model for truncated count families. 
+Thanks to Ahmed Eldeeb. (#1903)
 * Improve the numerical stability of `log_lik` for truncated and 
 interval-censored models, which previously returned `Inf` or `NaN` whenever 
 both bounds fell far into the same tail. Families whose CDF is not itself 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,11 +27,9 @@ Thanks to Gidon Frischkorn. (#1450)
 
 ### Bug Fixes
 
-* Normalize truncated `log_lik` by `P(lb <= Y <= ub)` rather than 
-`P(lb < Y <= ub)` for integer responses, matching the bound convention of 
-the generated Stan code. Previously `loo` and `waic` disagreed with the 
-fitted model for truncated count families. 
-Thanks to Ahmed Eldeeb. (#1903)
+* Normalize truncated `log_lik` by `P(lb <= Y <= ub)` for integer
+responses, matching the generated Stan code, so that `loo` and `waic`
+agree with the model that was fitted. Thanks to Ahmed Eldeeb. (#1903)
 * Improve the numerical stability of `log_lik` for truncated and 
 interval-censored models, which previously returned `Inf` or `NaN` whenever 
 both bounds fell far into the same tail. Families whose CDF is not itself 

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -1095,6 +1095,13 @@ log_lik_truncate <- function(x, cdf, args, i, prep) {
   if (is.null(lb) && is.null(ub)) {
     return(x)
   }
+  if (!is.null(lb) && use_int(prep$family)) {
+    # the lower bound is inclusive for integer responses, so the normalizer
+    # is P(lb <= Y <= ub). This mirrors the 'lb - 1' that
+    # stan_log_lik_trunc() emits, without which log_lik disagrees with the
+    # model that was fitted; see #1903
+    lb <- lb - 1
+  }
   x - log_prob_interval(cdf, args, lower = lb, upper = ub)
 }
 

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -1096,11 +1096,10 @@ log_lik_truncate <- function(x, cdf, args, i, prep) {
     return(x)
   }
   if (!is.null(lb) && use_int(prep$family)) {
-    # the lower bound is inclusive for integer responses, so the normalizer
-    # is P(lb <= Y <= ub). This mirrors the 'lb - 1' that
-    # stan_log_lik_trunc() emits, without which log_lik disagrees with the
-    # model that was fitted; see #1903
-    lb <- lb - 1
+    # inclusive lower bound, mirroring the 'lb - 1' of stan_log_lik_trunc().
+    # ceiling() additionally keeps a non-integer bound, which newdata can
+    # introduce, on the support it actually admits
+    lb <- ceiling(lb) - 1
   }
   x - log_prob_interval(cdf, args, lower = lb, upper = ub)
 }

--- a/tests/testthat/tests.log_lik.R
+++ b/tests/testthat/tests.log_lik.R
@@ -752,12 +752,11 @@ test_that("infinite log_lik values are warned about", {
 
 test_that("truncated log_lik uses inclusive lower bounds for integers", {
   # the generated Stan code evaluates the normalizer at lb - 1 for integer
-  # responses, so the truncated distribution is supported on lb:ub. Without
-  # the same convention here, log_lik normalizes by P(lb < Y <= ub) and
-  # disagrees with the model that was fitted; see #1903
-  int_prep <- function(mu, lb = NULL, ub = NULL, Y, family = poisson()) {
+  # responses, so the truncated distribution is supported on lb:ub; see #1903
+  trunc_int_prep <- function(mu, lb = NULL, ub = NULL, Y,
+                             family = poisson(), ...) {
     prep <- structure(list(ndraws = 1L, nobs = 1L), class = "brmsprep")
-    prep$dpars <- list(mu = matrix(mu, ncol = 1))
+    prep$dpars <- c(list(mu = matrix(mu, ncol = 1)), list(...))
     prep$family <- family
     prep$data <- list(Y = Y, lb = lb, ub = ub)
     prep
@@ -766,34 +765,53 @@ test_that("truncated log_lik uses inclusive lower bounds for integers", {
   # the truncated pmf sums to one over its support
   lambda <- 3
   probs <- sapply(2:6, function(y) {
-    exp(brms:::log_lik_poisson(1, int_prep(lambda, 2, 6, Y = y)))
+    exp(brms:::log_lik_poisson(1, trunc_int_prep(lambda, 2, 6, Y = y)))
   })
   expect_equal(sum(probs), 1)
 
   # and matches the normalizer the fitted model uses, F(ub) - F(lb - 1)
   expect_equal(
-    brms:::log_lik_poisson(1, int_prep(lambda, 2, 6, Y = 2)),
+    brms:::log_lik_poisson(1, trunc_int_prep(lambda, 2, 6, Y = 2)),
     dpois(2, lambda, log = TRUE) - log(ppois(6, lambda) - ppois(1, lambda))
   )
   # one-sided lower truncation keeps lb in the support
   expect_equal(
-    brms:::log_lik_poisson(1, int_prep(lambda, 2, Y = 2)),
+    brms:::log_lik_poisson(1, trunc_int_prep(lambda, 2, Y = 2)),
     dpois(2, lambda, log = TRUE) -
       ppois(1, lambda, lower.tail = FALSE, log.p = TRUE)
   )
   # an upper bound alone is unaffected, as it is already inclusive
   expect_equal(
-    brms:::log_lik_poisson(1, int_prep(lambda, ub = 6, Y = 2)),
+    brms:::log_lik_poisson(1, trunc_int_prep(lambda, ub = 6, Y = 2)),
     dpois(2, lambda, log = TRUE) - ppois(6, lambda, log.p = TRUE)
+  )
+  # lb at the lower end of the support sends lb - 1 outside it
+  expect_equal(
+    brms:::log_lik_poisson(1, trunc_int_prep(lambda, 0, Y = 2)),
+    dpois(2, lambda, log = TRUE)
+  )
+
+  # negbinomial covers the pnbinom-backed families
+  expect_equal(
+    brms:::log_lik_negbinomial(
+      1, trunc_int_prep(lambda, 2, 6, Y = 2, family = negbinomial(), shape = 2)
+    ),
+    dnbinom(2, size = 2, mu = lambda, log = TRUE) -
+      log(pnbinom(6, size = 2, mu = lambda) - pnbinom(1, size = 2, mu = lambda))
+  )
+
+  # a non-integer bound, which newdata can introduce, keeps the support it
+  # admits: Y >= 3 rather than Y >= 2
+  expect_equal(
+    brms:::log_lik_poisson(1, trunc_int_prep(lambda, 2.5, 6, Y = 3)),
+    dpois(3, lambda, log = TRUE) - log(ppois(6, lambda) - ppois(2, lambda))
   )
 
   # continuous responses keep the exclusive lower bound
-  cont <- structure(list(ndraws = 1L, nobs = 1L), class = "brmsprep")
-  cont$dpars <- list(mu = matrix(0, ncol = 1), sigma = 1)
-  cont$family <- gaussian()
-  cont$data <- list(Y = 0.5, lb = 0, ub = 1)
   expect_equal(
-    brms:::log_lik_gaussian(1, cont),
+    brms:::log_lik_gaussian(
+      1, trunc_int_prep(0, 0, 1, Y = 0.5, family = gaussian(), sigma = 1)
+    ),
     dnorm(0.5, 0, 1, log = TRUE) - log(pnorm(1) - pnorm(0))
   )
 })

--- a/tests/testthat/tests.log_lik.R
+++ b/tests/testthat/tests.log_lik.R
@@ -749,3 +749,51 @@ test_that("infinite log_lik values are warned about", {
     brms:::warn_infinite_log_lik(matrix(c(-1, NaN, NA, -3), nrow = 2))
   )
 })
+
+test_that("truncated log_lik uses inclusive lower bounds for integers", {
+  # the generated Stan code evaluates the normalizer at lb - 1 for integer
+  # responses, so the truncated distribution is supported on lb:ub. Without
+  # the same convention here, log_lik normalizes by P(lb < Y <= ub) and
+  # disagrees with the model that was fitted; see #1903
+  int_prep <- function(mu, lb = NULL, ub = NULL, Y, family = poisson()) {
+    prep <- structure(list(ndraws = 1L, nobs = 1L), class = "brmsprep")
+    prep$dpars <- list(mu = matrix(mu, ncol = 1))
+    prep$family <- family
+    prep$data <- list(Y = Y, lb = lb, ub = ub)
+    prep
+  }
+
+  # the truncated pmf sums to one over its support
+  lambda <- 3
+  probs <- sapply(2:6, function(y) {
+    exp(brms:::log_lik_poisson(1, int_prep(lambda, 2, 6, Y = y)))
+  })
+  expect_equal(sum(probs), 1)
+
+  # and matches the normalizer the fitted model uses, F(ub) - F(lb - 1)
+  expect_equal(
+    brms:::log_lik_poisson(1, int_prep(lambda, 2, 6, Y = 2)),
+    dpois(2, lambda, log = TRUE) - log(ppois(6, lambda) - ppois(1, lambda))
+  )
+  # one-sided lower truncation keeps lb in the support
+  expect_equal(
+    brms:::log_lik_poisson(1, int_prep(lambda, 2, Y = 2)),
+    dpois(2, lambda, log = TRUE) -
+      ppois(1, lambda, lower.tail = FALSE, log.p = TRUE)
+  )
+  # an upper bound alone is unaffected, as it is already inclusive
+  expect_equal(
+    brms:::log_lik_poisson(1, int_prep(lambda, ub = 6, Y = 2)),
+    dpois(2, lambda, log = TRUE) - ppois(6, lambda, log.p = TRUE)
+  )
+
+  # continuous responses keep the exclusive lower bound
+  cont <- structure(list(ndraws = 1L, nobs = 1L), class = "brmsprep")
+  cont$dpars <- list(mu = matrix(0, ncol = 1), sigma = 1)
+  cont$family <- gaussian()
+  cont$data <- list(Y = 0.5, lb = 0, ub = 1)
+  expect_equal(
+    brms:::log_lik_gaussian(1, cont),
+    dnorm(0.5, 0, 1, log = TRUE) - log(pnorm(1) - pnorm(0))
+  )
+})


### PR DESCRIPTION
Closes #1903.

## Summary

For truncated integer responses `log_lik()` normalized by $P(lb < Y \le ub)$ while the fitted model uses $P(lb \le Y \le ub)$, so `loo()` and `waic()` disagreed with the model that was sampled.

## Problem

`stan_log_lik_trunc()` emits `lb - 1` for integer responses, so the support is `lb:ub`. `log_lik_truncate()` passed `lb` through unmodified. For `poisson(3)` truncated to `[2, 6]` the pmf summed to 1.41, and disagreed with `posterior_predict()` — which already includes `lb` — by up to 0.12:

| | Y=2 | Y=3 | Y=4 | Y=5 | Y=6 | sum |
|---|---|---|---|---|---|---|
| `posterior_predict()`, 50k draws | 0.2918 | 0.2930 | 0.2183 | 0.1326 | 0.0644 | 1.000 |
| `log_lik()` before | 0.4124 | 0.4124 | 0.3093 | 0.1856 | 0.0928 | **1.412** |
| `log_lik()` after | 0.2920 | 0.2920 | 0.2190 | 0.1314 | 0.0657 | 1.000 |

## Suggested solution

Subtract one from `lb` when `use_int(prep$family)`. Affects poisson, negbinomial, binomial, geometric, beta_binomial, discrete_weibull and the zero-inflated and hurdle counts.

## Note

Continuous responses and upper-only bounds are unaffected, as is interval censoring — the generated Stan emits no `- 1` there. `ceiling()` is applied because `log_lik(fit, newdata = ...)` can introduce a non-integer bound through a data column, which Stan cannot receive.

Before this, `log_lik()`, `posterior_epred()` and `pp_cdf()` all used the exclusive bound and agreed with each other, while `posterior_predict(output = "random")` and the fitted model used the inclusive one. Fixing `log_lik()` leaves two paths behind:

- `posterior_epred_trunc_discrete()` sums over `(lb+1):ub`, running ~14% high on a truncated `poisson(3)` in `[2, 6]`
- `pp_cdf()`, `pp_density()` and `pp_quantile()` normalize by `F(ub) - F(lb)`, disagreeing with `pp_random_discrete()` beside them: `pp_density(2, "pois", lb = 2, ub = 6, lambda = 3)` is 0.4124 against an empirical 0.291

Also `log_lik_com_poisson()` never calls `log_lik_truncate()`, so a truncated com_poisson likelihood is unnormalized either way. All three predate this PR — happy to take them in a follow-up, or here if you prefer one change.

## TODO

+ [x] inclusive lower bound for integer responses, rounded for non-integer bounds
+ [x] tests: pmf sums to one, the Stan normalizer, one-sided and `lb = 0` cases, negbinomial, continuous unchanged
