### PR TITLE
Add physical sum-to-zero foundation for group effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,11 @@ group-effect mean vector and reconstructs conventional Bayesian coefficients
 and effects in generated quantities. Gaussian and Student-t group effects are
 supported, with the latter handled exactly as a conditional Gaussian scale
 mixture. Blocks with one varying coefficient and blocks with any number of
-independent coefficients use dedicated component-wise scalar implementations.
+coefficients in diagonal covariance blocks use dedicated component-wise scalar
+implementations.
+Multiple S2Z grouping factors may occur in one linear predictor; their omitted
+mean vectors are integrated and recovered jointly while retaining separate
+shared scales and correlation structures for each factor.
 (#1916)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,15 @@
 
 ### New Features
 
-* Add an experimental marginalized physical sum-to-zero parameterization via
+* Add an experimental physical sum-to-zero parameterization via
 `gr(..., s2z = TRUE)` for hierarchical models with varying intercepts, slopes,
-and interactions. Gaussian and Student-t group effects are supported, with
-the latter handled exactly as a conditional Gaussian scale mixture. Blocks
-with one varying coefficient and blocks with any number of independent
-coefficients use dedicated component-wise scalar implementations. (#1916)
+and interactions. It analytically integrates out the omitted common
+group-effect mean vector and reconstructs conventional Bayesian coefficients
+and effects in generated quantities. Gaussian and Student-t group effects are
+supported, with the latter handled exactly as a conditional Gaussian scale
+mixture. Blocks with one varying coefficient and blocks with any number of
+independent coefficients use dedicated component-wise scalar implementations.
+(#1916)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
 * Add an experimental marginalized physical sum-to-zero parameterization via
 `gr(..., s2z = TRUE)` for hierarchical models with varying intercepts, slopes,
 and interactions. Gaussian and Student-t group effects are supported, with
-the latter handled exactly as a conditional Gaussian scale mixture. (#1916)
+the latter handled exactly as a conditional Gaussian scale mixture. Blocks
+with one varying coefficient use a dedicated scalar implementation. (#1916)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel
@@ -2299,4 +2300,3 @@ have proper priors by default.
 # brms 0.1.0
 
 * Initial release version
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ### New Features
 
+* Add an experimental marginalized physical sum-to-zero parameterization via
+`gr(..., s2z = TRUE)` for hierarchical models with varying intercepts, slopes,
+and interactions. Gaussian and Student-t group effects are supported, with
+the latter handled exactly as a conditional Gaussian scale mixture. (#1916)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel
@@ -2295,5 +2299,4 @@ have proper priors by default.
 # brms 0.1.0
 
 * Initial release version
-
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,22 +3,29 @@
 ### New Features
 
 * Add an experimental physical sum-to-zero parameterization via
-`gr(..., s2z = TRUE)` for hierarchical models with varying intercepts, slopes,
-and interactions. It analytically integrates out the omitted common
-group-effect mean vector and reconstructs conventional Bayesian coefficients
-and effects in generated quantities. Gaussian and Student-t group effects are
-supported, with the latter handled exactly as a conditional Gaussian scale
-mixture. Blocks with one varying coefficient and blocks with any number of
-coefficients in diagonal covariance blocks use dedicated component-wise scalar
-implementations.
-Multiple S2Z grouping factors may occur in one linear predictor; their omitted
-mean vectors are integrated and recovered jointly while retaining separate
-shared scales and correlation structures for each factor. For Gaussian
-blocks, brms uses a lower-dimensional induced-covariance calculation
-and joint Matheron recovery whenever that system is smaller than the stacked
-omitted-mean system. In the common crossed-intercept case this reduces to a
-scalar update with no matrix factorization, irrespective of the number of
-grouping factors.
+`gr(..., s2z = TRUE)` for ordinary matched varying intercepts, numeric and
+factor slopes, and interactions. The likelihood uses group deviations that
+sum exactly to zero over observed levels, while conventional population
+coefficients and group effects are reconstructed for the public output.
+Gaussian and Student-t group effects, correlated and independent blocks,
+coefficient-specific scales shared across levels, and multiple local S2Z
+blocks are supported. Separate S2Z IDs may be used in otherwise eligible
+location, distributional, nonlinear, categorical, multinomial, and
+multivariate predictors.
+
+Population coordinates touched by an S2Z omitted-mean map support exact flat,
+normal, Student-t, Cauchy, and logistic priors with numeric constant arguments.
+Logistic priors use explicitly sampled standardized omitted means with their
+exact target density and Jacobian; this includes the default `logistic(0, 1)`
+intercept prior of auxiliary probability predictors. Fixed-only population
+coordinates retain ordinary brms prior handling. The omitted means of multiple
+local blocks are handled jointly, with specialized scalar, diagonal, and
+Gaussian Matheron paths where applicable.
+
+This foundation deliberately excludes ordinal location predictors, centered,
+partially centered, or automatically centered modes, group scales varying by
+level, and structural extensions such as `by`, `cov`, `pw`, multi-membership,
+special group coefficients, cross-predictor IDs, and sparse or QR designs.
 (#1916)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,12 @@ coefficients in diagonal covariance blocks use dedicated component-wise scalar
 implementations.
 Multiple S2Z grouping factors may occur in one linear predictor; their omitted
 mean vectors are integrated and recovered jointly while retaining separate
-shared scales and correlation structures for each factor.
+shared scales and correlation structures for each factor. For Gaussian
+blocks, brms uses a lower-dimensional induced-covariance calculation
+and joint Matheron recovery whenever that system is smaller than the stacked
+omitted-mean system. In the common crossed-intercept case this reduces to a
+scalar update with no matrix factorization, irrespective of the number of
+grouping factors.
 (#1916)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@
 `gr(..., s2z = TRUE)` for hierarchical models with varying intercepts, slopes,
 and interactions. Gaussian and Student-t group effects are supported, with
 the latter handled exactly as a conditional Gaussian scale mixture. Blocks
-with one varying coefficient use a dedicated scalar implementation. (#1916)
+with one varying coefficient and blocks with any number of independent
+coefficients use dedicated component-wise scalar implementations. (#1916)
 * Specify a prior `tag` for use in prior sensitivity analysis
 via `priorsense` thanks to Kallioinen. (#1585)
 * Specify group-level prior weights via argument `pw` in multilevel

--- a/R/brmsframe.R
+++ b/R/brmsframe.R
@@ -42,6 +42,20 @@ brmsframe.brmsterms <- function(x, data, frame = NULL, basis = NULL, ...) {
   data <- subset_data(data, x)
   x$frame$resp <- frame_resp(x, data = data)
   x$frame$ac <- frame_ac(x, data = data)
+  # Keep top-level response and family labels available to local predictor
+  # validation. Category and mixture predictors otherwise carry only their
+  # dpar prefix, even though the enclosing model context is known here.
+  s2z_response <- x$resp %||% ""
+  if (!length(s2z_response) || !nzchar(s2z_response)) {
+    response_vars <- all.vars(x$respform)
+    if (length(response_vars)) {
+      s2z_response <- response_vars[1L]
+    }
+  }
+  x$frame$s2z_context <- list(
+    response = s2z_response,
+    family = x$family$family %||% ""
+  )
   for (dp in names(x$dpars)) {
     x$dpars[[dp]] <- brmsframe(
       x$dpars[[dp]], data, frame = x$frame,
@@ -85,7 +99,11 @@ brmsframe.btl <- function(x, data, frame = list(), basis = NULL, ...) {
   # only store the ranefs of this specific linear formula
   x$frame$re <- subset2(frame$re, ls = check_prefix(x))
   class(x) <- c("bframel", class(x))
+  validate_re_s2z_structure(x, data = data)
   validate_re_s2z_design(x, data = data)
+  if (has_re_s2z(x)) {
+    x$frame$re_s2z <- re_s2z_infos(x)
+  }
   # these data_ functions may require the outputs of the corresponding
   # frame_ functions (but not vice versa) and are thus evaluated last
   x$sdata$gp <- data_gp(x, data, internal = TRUE)

--- a/R/brmsframe.R
+++ b/R/brmsframe.R
@@ -85,6 +85,7 @@ brmsframe.btl <- function(x, data, frame = list(), basis = NULL, ...) {
   # only store the ranefs of this specific linear formula
   x$frame$re <- subset2(frame$re, ls = check_prefix(x))
   class(x) <- c("bframel", class(x))
+  validate_re_s2z_design(x, data = data)
   # these data_ functions may require the outputs of the corresponding
   # frame_ functions (but not vice versa) and are thus evaluated last
   x$sdata$gp <- data_gp(x, data, internal = TRUE)

--- a/R/exclude_pars.R
+++ b/R/exclude_pars.R
@@ -111,6 +111,7 @@ exclude_pars_re <- function(bframe, save_pars, ...) {
         "z_s2z", "r_s2z", "H_s2z", "prior_mean_s2z",
         "prior_prec_s2z", "group_scale_s2z", "group_prec_s2z",
         "L_Sigma_s2z", "Q_Sigma_s2z", "P_s2z", "L_P_s2z",
+        "D_s2z", "sqrt_D_s2z",
         "mhat_s2z", "qhat_s2z", "white_s2z", "mean_r_s2z",
         "q_recovered_s2z"
       )

--- a/R/exclude_pars.R
+++ b/R/exclude_pars.R
@@ -80,6 +80,11 @@ exclude_pars.bframel <- function(x, save_pars, ...) {
       "scales", "merged_Intercept", "zcar", "nszcar", "zerr"
     )
     c(out) <- paste0(par_classes, p)
+    if (has_re_s2z(x)) {
+      c(out) <- paste0("theta_s2z", p)
+      q <- length(x$frame$fe$vars)
+      c(out) <- paste0("udf_b_s2z", p, "_", seq_len(q))
+    }
     smframe <- x$frame$sm
     for (i in seq_rows(smframe)) {
       nb <- seq_len(smframe$nbases[i])
@@ -100,6 +105,19 @@ exclude_pars_re <- function(bframe, save_pars, ...) {
   rm_re_pars <- c(if (!save_pars$all) c("z", "L"), "Cor", "r")
   for (id in unique(reframe$id)) {
     c(out) <- paste0(rm_re_pars, "_", id)
+    r <- subset2(reframe, id = id)
+    if (!save_pars$all && isTRUE(r$s2z[1])) {
+      s2z_classes <- c(
+        "z_s2z", "r_s2z", "H_s2z", "prior_mean_s2z",
+        "prior_prec_s2z", "group_scale_s2z", "group_prec_s2z",
+        "L_Sigma_s2z", "Q_Sigma_s2z", "P_s2z", "L_P_s2z",
+        "mhat_s2z", "qhat_s2z", "white_s2z", "mean_r_s2z",
+        "q_recovered_s2z"
+      )
+      c(out) <- paste0(s2z_classes, "_", id)
+      rp <- usc(combine_prefix(r))
+      c(out) <- paste0("r_s2z_", r$id, rp, "_", r$cn)
+    }
   }
   if (isFALSE(save_pars$group)) {
     p <- usc(combine_prefix(reframe))

--- a/R/exclude_pars.R
+++ b/R/exclude_pars.R
@@ -111,7 +111,8 @@ exclude_pars_re <- function(bframe, save_pars, ...) {
         "z_s2z", "r_s2z", "H_s2z", "prior_mean_s2z",
         "prior_prec_s2z", "group_scale_s2z", "group_prec_s2z",
         "L_Sigma_s2z", "Q_Sigma_s2z", "P_s2z", "L_P_s2z",
-        "D_s2z", "sqrt_D_s2z",
+        "D_s2z", "sqrt_D_s2z", "D_diag_s2z", "intercept_map_s2z",
+        "rank1_info_s2z", "group_quad_s2z",
         "mhat_s2z", "qhat_s2z", "white_s2z", "mean_r_s2z",
         "q_recovered_s2z"
       )

--- a/R/exclude_pars.R
+++ b/R/exclude_pars.R
@@ -81,7 +81,20 @@ exclude_pars.bframel <- function(x, save_pars, ...) {
     )
     c(out) <- paste0(par_classes, p)
     if (has_re_s2z(x)) {
-      c(out) <- paste0("theta_s2z", p)
+      c(out) <- paste0(
+        c(
+          "theta_s2z", "theta_s2z_active", "fixed_s2z",
+          "zfixed_s2z", "sdfixed_s2z"
+        ),
+        p
+      )
+      infos_s2z <- re_s2z_infos(x)
+      if (length(infos_s2z)) {
+        n_inactive_s2z <- length(infos_s2z[[1L]]$inactive_q)
+        c(out) <- paste0(
+          "par_fixed_s2z", p, "_", seq_len(n_inactive_s2z)
+        )
+      }
       q <- length(x$frame$fe$vars)
       c(out) <- paste0("udf_b_s2z", p, "_", seq_len(q))
     }
@@ -108,7 +121,8 @@ exclude_pars_re <- function(bframe, save_pars, ...) {
     r <- subset2(reframe, id = id)
     if (!save_pars$all && isTRUE(r$s2z[1])) {
       s2z_classes <- c(
-        "z_s2z", "r_s2z", "H_s2z", "prior_mean_s2z",
+        "z_s2z", "z_mean_s2z", "r_s2z", "H_s2z",
+        "q_explicit_s2z", "prior_mean_s2z",
         "prior_prec_s2z", "prior_scale_s2z",
         "W_matheron_s2z", "sqrt_W_matheron_s2z",
         "L_W_matheron_s2z", "theta_white_matheron_s2z",

--- a/R/exclude_pars.R
+++ b/R/exclude_pars.R
@@ -109,7 +109,10 @@ exclude_pars_re <- function(bframe, save_pars, ...) {
     if (!save_pars$all && isTRUE(r$s2z[1])) {
       s2z_classes <- c(
         "z_s2z", "r_s2z", "H_s2z", "prior_mean_s2z",
-        "prior_prec_s2z", "group_scale_s2z", "group_prec_s2z",
+        "prior_prec_s2z", "prior_scale_s2z",
+        "W_matheron_s2z", "sqrt_W_matheron_s2z",
+        "L_W_matheron_s2z", "theta_white_matheron_s2z",
+        "group_scale_s2z", "group_prec_s2z",
         "L_Sigma_s2z", "Q_Sigma_s2z", "P_group_s2z", "h_group_s2z",
         "P_s2z", "L_P_s2z", "H_joint_s2z", "h_joint_s2z",
         "D_s2z", "sqrt_D_s2z", "D_diag_s2z", "intercept_map_s2z",

--- a/R/exclude_pars.R
+++ b/R/exclude_pars.R
@@ -110,9 +110,10 @@ exclude_pars_re <- function(bframe, save_pars, ...) {
       s2z_classes <- c(
         "z_s2z", "r_s2z", "H_s2z", "prior_mean_s2z",
         "prior_prec_s2z", "group_scale_s2z", "group_prec_s2z",
-        "L_Sigma_s2z", "Q_Sigma_s2z", "P_s2z", "L_P_s2z",
+        "L_Sigma_s2z", "Q_Sigma_s2z", "P_group_s2z", "h_group_s2z",
+        "P_s2z", "L_P_s2z", "H_joint_s2z", "h_joint_s2z",
         "D_s2z", "sqrt_D_s2z", "D_diag_s2z", "intercept_map_s2z",
-        "rank1_info_s2z", "group_quad_s2z",
+        "rank1_info_s2z", "group_quad_s2z", "joint_quad_s2z",
         "mhat_s2z", "qhat_s2z", "white_s2z", "mean_r_s2z",
         "q_recovered_s2z"
       )

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -24,7 +24,10 @@
 #'   \code{dist = "student"} through a Gaussian scale mixture. Every varying
 #'   design column must have an identical population-level design column.
 #'   Blocks with one varying coefficient use a dedicated scalar
-#'   implementation.
+#'   implementation. Blocks with any number of independent coefficients
+#'   (\code{cor = FALSE} or \code{||} syntax) use a component-wise scalar
+#'   implementation that also accounts exactly for the shared centered
+#'   intercept prior.
 #'   Usual priors on group-level standard deviations, correlations, and
 #'   Student degrees of freedom remain available, including separate
 #'   standard-deviation priors for varying intercepts, slopes, and

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -17,8 +17,9 @@
 #' @param cor Logical. If \code{TRUE} (the default), group-level terms will be
 #'   modelled as correlated.
 #' @param s2z Logical. If \code{TRUE}, use a physical sum-to-zero
-#'   parameterization and analytically integrate out the omitted common
-#'   group-effect mean vector. This experimental option preserves the usual
+#'   analytically integrate out the omitted common group-effect mean vector of
+#'   each S2Z block, jointly when multiple blocks share a linear predictor.
+#'   This experimental option preserves the usual
 #'   population- and group-level parameter semantics by reconstructing them in
 #'   generated quantities. It is exact for \code{dist = "gaussian"} and for
 #'   \code{dist = "student"} through a Gaussian scale mixture. Every varying
@@ -30,13 +31,18 @@
 #'   intercept prior.
 #'   Usual priors on group-level standard deviations, correlations, and
 #'   Student-t degrees of freedom remain available, including separate
-#'   standard-deviation priors for varying intercepts, slopes, and
-#'   interactions.
+#'   \code{sd} priors for varying intercepts, slopes, and interactions. For
+#'   \code{dist = "student"}, \code{sd} retains its existing \pkg{brms}
+#'   Student-t scale semantics and is not rescaled to a marginal standard
+#'   deviation.
 #'   The physical coordinates are intended for well-informed group
 #'   coefficients and may be slower than the default non-centered
 #'   parameterization when those coefficients are weakly informed.
-#'   Currently, only one such grouping term per linear predictor is supported,
-#'   without the \code{by}, \code{cov}, or \code{pw} arguments.
+#'   Multiple S2Z covariance blocks may be used in the same linear predictor.
+#'   Their omitted group means are integrated and recovered jointly, while each
+#'   block retains its own grouping factor, shared scales, and correlation
+#'   structure.
+#'   The \code{by}, \code{cov}, and \code{pw} arguments remain unsupported.
 #'   Population-level priors must currently be flat, normal, Student-t, or
 #'   Cauchy with numeric constant arguments. Bounds, tags, special priors,
 #'   prior-only sampling, ordinal thresholds, sparse and QR designs, and

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -16,6 +16,24 @@
 #'   must be nested in levels of the \code{by} variable.
 #' @param cor Logical. If \code{TRUE} (the default), group-level terms will be
 #'   modelled as correlated.
+#' @param s2z Logical. If \code{TRUE}, use a physical sum-to-zero
+#'   parameterization and analytically marginalize the common group-effect
+#'   mean. This experimental option preserves the usual population- and
+#'   group-level parameter semantics by reconstructing them in generated
+#'   quantities. It is exact for \code{dist = "gaussian"} and for
+#'   \code{dist = "student"} through a Gaussian scale mixture. Every varying
+#'   design column must have an identical population-level design column.
+#'   The physical coordinates are intended for well-informed group
+#'   coefficients and may be slower than the default non-centered
+#'   parameterization when those coefficients are weakly informed.
+#'   Currently, only one such grouping term per linear predictor is supported,
+#'   without the \code{by}, \code{cov}, or \code{pw} arguments.
+#'   Population-level priors must currently be flat, normal, Student-t, or
+#'   Cauchy with numeric constant arguments. Bounds, tags, special priors,
+#'   prior-only sampling, ordinal thresholds, sparse and QR designs, and
+#'   non-positive fixed group-level standard deviations are not supported.
+#'   Custom Stan code must not use the conventional population- or group-level
+#'   coefficients before they are reconstructed in generated quantities.
 #' @param id Optional character string. All group-level terms across the model
 #'   with the same \code{id} will be modeled as correlated (if \code{cor} is
 #'   \code{TRUE}). See \code{\link{brmsformula}} for more details.
@@ -29,8 +47,8 @@
 #'   can be used, among others, to model pedigrees and phylogenetic effects. See
 #'   \code{vignette("brms_phylogenetics")} for more details. By default, levels
 #'   of the same grouping factor are modeled as independent of each other.
-#' @param dist Name of the distribution of the group-level effects.
-#' Currently \code{"gaussian"} is the only option.
+#' @param dist Name of the distribution of the group-level effects. Supported
+#'   options are \code{"gaussian"} and \code{"student"}.
 #'
 #' @seealso \code{\link{brmsformula}}
 #'
@@ -53,11 +71,16 @@
 #' fit4 <- brm(count ~ Trt + (1|gr(patient, pw = patient_samp_wgt)),
 #'             data = epilepsy)
 #' summary(fit4)
+#'
+#' # marginalized sum-to-zero varying intercepts, slopes, and interactions
+#' fit5 <- brm(count ~ zAge * Trt +
+#'               (1 + zAge * Trt | gr(patient, s2z = TRUE)),
+#'             data = epilepsy, family = poisson())
 #' }
 #'
 #' @export
 gr <- function(..., by = NULL, cor = TRUE, id = NA, pw = NULL,
-               cov = NULL, dist = "gaussian") {
+               cov = NULL, dist = "gaussian", s2z = FALSE) {
   label <- deparse0(match.call())
   groups <- as.character(as.list(substitute(list(...)))[-1])
   if (length(groups) > 1L) {
@@ -65,6 +88,7 @@ gr <- function(..., by = NULL, cor = TRUE, id = NA, pw = NULL,
   }
   stopif_illegal_group(groups[1])
   cor <- as_one_logical(cor)
+  s2z <- as_one_logical(s2z)
   id <- as_one_character(id, allow_na = TRUE)
   by <- substitute(by)
   if (!is.null(by)) {
@@ -91,7 +115,7 @@ gr <- function(..., by = NULL, cor = TRUE, id = NA, pw = NULL,
   byvars <- all_vars(by)
   pwvars <- all_vars(pw)
   allvars <- str2formula(c(groups, byvars, pwvars))
-  nlist(groups, allvars, label, by, cor, id, pw, cov, dist, type = "")
+  nlist(groups, allvars, label, by, cor, s2z, id, pw, cov, dist, type = "")
 }
 
 #' Set up multi-membership grouping terms in \pkg{brms}
@@ -560,6 +584,7 @@ get_re.btl <- function(x, ...) {
 #   dpar: name of the distributional parameter
 #   nlpar: name of the non-linear parameter
 #   cor: are correlations modeled for this effect?
+#   s2z: use a sum-to-zero parameterization for this effect?
 #   ggn: global number of the grouping factor
 #   type: special effects type; can be 'sp' or 'cs'
 #   gcall: output of functions 'gr' or 'mm'
@@ -605,6 +630,7 @@ frame_re <- function(bterms, data, old_levels = NULL) {
       nlpar = re$nlpar[[i]],
       ggn = NA,
       cor = re$cor[[i]],
+      s2z = re$gcall[[i]]$s2z %||% FALSE,
       type = re$type[[i]],
       by = re$gcall[[i]]$by,
       cov = re$gcall[[i]]$cov,
@@ -763,7 +789,8 @@ empty_reframe <- function() {
     id = numeric(0), group = character(0), gn = numeric(0),
     coef = character(0), cn = numeric(0), resp = character(0),
     dpar = character(0), nlpar = character(0), ggn = numeric(0),
-    cor = logical(0), type = character(0), form = character(0),
+    cor = logical(0), s2z = logical(0), type = character(0),
+    form = character(0),
     stringsAsFactors = FALSE
   )
   class(out) <- reframe_class()

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -23,6 +23,8 @@
 #'   quantities. It is exact for \code{dist = "gaussian"} and for
 #'   \code{dist = "student"} through a Gaussian scale mixture. Every varying
 #'   design column must have an identical population-level design column.
+#'   Blocks with one varying coefficient use a dedicated scalar
+#'   implementation.
 #'   The physical coordinates are intended for well-informed group
 #'   coefficients and may be slower than the default non-centered
 #'   parameterization when those coefficients are weakly informed.

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -25,6 +25,10 @@
 #'   design column must have an identical population-level design column.
 #'   Blocks with one varying coefficient use a dedicated scalar
 #'   implementation.
+#'   Usual priors on group-level standard deviations, correlations, and
+#'   Student degrees of freedom remain available, including separate
+#'   standard-deviation priors for varying intercepts, slopes, and
+#'   interactions.
 #'   The physical coordinates are intended for well-informed group
 #'   coefficients and may be slower than the default non-centered
 #'   parameterization when those coefficients are weakly informed.
@@ -75,9 +79,13 @@
 #' summary(fit4)
 #'
 #' # marginalized sum-to-zero varying intercepts, slopes, and interactions
+#' s2z_prior <- prior(exponential(2), class = "sd", group = "patient",
+#'                    coef = "Intercept") +
+#'   prior(exponential(3), class = "sd", group = "patient", coef = "zAge") +
+#'   prior(lkj(2), class = "cor", group = "patient")
 #' fit5 <- brm(count ~ zAge * Trt +
 #'               (1 + zAge * Trt | gr(patient, s2z = TRUE)),
-#'             data = epilepsy, family = poisson())
+#'             data = epilepsy, family = poisson(), prior = s2z_prior)
 #' }
 #'
 #' @export

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -13,7 +13,8 @@
 #' @param by An optional factor variable, specifying sub-populations of the
 #'   groups. For each level of the \code{by} variable, a separate
 #'   variance-covariance matrix will be fitted. Levels of the grouping factor
-#'   must be nested in levels of the \code{by} variable.
+#'   must be nested in levels of the \code{by} variable. This argument is not
+#'   currently supported with \code{s2z = TRUE}.
 #' @param cor Logical. If \code{TRUE} (the default), group-level terms will be
 #'   modelled as correlated.
 #' @param s2z Logical. If \code{TRUE}, use the experimental physical
@@ -21,29 +22,35 @@
 #'   \dQuote{Physical sum-to-zero effects}. The default is \code{FALSE}.
 #' @param id Optional character string. All group-level terms across the model
 #'   with the same \code{id} will be modeled as correlated (if \code{cor} is
-#'   \code{TRUE}). See \code{\link{brmsformula}} for more details.
+#'   \code{TRUE}). With \code{s2z = TRUE}, this sharing is limited to terms in
+#'   one linear predictor: an ID cannot span responses, categories, or
+#'   distributional or nonlinear predictors. See \code{\link{brmsformula}}
+#'   for more details.
 #' @param pw Optional numeric variable specifying prior weights. They weight the
 #'   contribution of each group to the log-prior of the group-level
 #'   coefficients. Should have one distinct value for each level of the
-#'   grouping variable.
+#'   grouping variable. This argument is not currently supported with
+#'   \code{s2z = TRUE}.
 #' @param cov An optional matrix which is proportional to the within-group
 #'   covariance matrix of the group-level effects. All levels of the grouping
 #'   factor should appear as rownames of the corresponding matrix. This argument
 #'   can be used, among others, to model pedigrees and phylogenetic effects. See
 #'   \code{vignette("brms_phylogenetics")} for more details. By default, levels
 #'   of the same grouping factor are modeled as independent of each other.
+#'   This argument is not currently supported with \code{s2z = TRUE}.
 #' @param dist Name of the distribution of the group-level effects. Supported
 #'   options are \code{"gaussian"} and \code{"student"}.
 #'
 #' @section Physical sum-to-zero effects:
-#' Setting \code{s2z = TRUE} expresses every coefficient vector in the
-#' grouping block as a physical deviation whose entries sum exactly to zero
-#' over the observed grouping levels. The likelihood is evaluated in these
-#' constrained coordinates. The omitted common group-effect mean is handled
-#' jointly with the matching population coefficients, and conventional
-#' population- and group-level draws are reconstructed in generated
-#' quantities. Thus functions such as \code{fixef}, \code{ranef}, and
-#' \code{coef} retain their usual interpretation.
+#' With \code{s2z = TRUE}, \pkg{brms} samples each varying coefficient as
+#' deviations whose sum is exactly zero over the grouping levels observed in
+#' the model data. For
+#' \code{1 + x + (1 + x | gr(g, s2z = TRUE))}, the constraint is applied
+#' separately to the varying intercepts and the varying \code{x} slopes.
+#' \pkg{brms} handles each omitted group-effect mean jointly with its matching
+#' population coefficient, then reconstructs conventional population and
+#' group effects. Thus \code{fixef}, \code{ranef}, \code{coef}, and prediction
+#' retain their usual interpretation.
 #'
 #' Every S2Z varying design column must have a population-level column with the
 #' same coefficient name and numerically identical values. This applies to
@@ -52,24 +59,59 @@
 #' sides of the grouping bar when all of its expanded columns vary. At least
 #' two grouping levels must be observed.
 #'
-#' The current support matrix is:
+#' The main support boundaries are:
 #'
-#' \tabular{ll}{
-#' Design \tab Ordinary matched intercepts, slopes, factors, and interactions.\cr
-#' Group distribution \tab Gaussian or Student-t.\cr
-#' Covariance \tab Correlated or independent coefficients; one or multiple
-#' local S2Z blocks.\cr
-#' Group scales \tab Coefficient-specific \code{sd} parameters shared across
-#' observed grouping levels.\cr
-#' Active population priors \tab Flat, \code{normal}, \code{student_t},
-#' \code{cauchy}, or \code{logistic}, with numeric constant arguments.\cr
-#' Fixed-only population priors \tab Any otherwise valid \pkg{brms} prior.\cr
-#' Predictors \tab Separate local S2Z IDs in otherwise eligible location,
-#' distributional, nonlinear, categorical, multinomial, and multivariate
-#' predictors.\cr
-#' Public output \tab Conventional population coefficients and group effects
-#' reconstructed exactly.\cr
+#' \tabular{lll}{
+#' Feature \tab Supported? \tab Details\cr
+#' Ordinary designs \tab Yes \tab Matched intercepts, numeric or factor slopes,
+#' and interactions.\cr
+#' Group distribution \tab Yes \tab Gaussian or Student-t.\cr
+#' Coefficient correlation \tab Yes \tab \code{cor = TRUE} or \code{FALSE}
+#' within one predictor-local ID.\cr
+#' Multiple blocks \tab Yes \tab One or more local S2Z IDs in a linear
+#' predictor.\cr
+#' Multiple predictors \tab Yes \tab Separate S2Z IDs in otherwise eligible
+#' response, distributional, nonlinear, or category predictors.\cr
+#' Shared cross-predictor ID \tab No \tab Includes \code{| q |} shared by
+#' responses in \code{mvbind(...)}.\cr
+#' Known level covariance \tab No \tab Includes \code{cov = A} for
+#' phylogenetic or pedigree models.\cr
+#' Structural extensions \tab No \tab \code{by}, \code{pw},
+#' multi-membership, and special group coefficients.\cr
+#' Group scales \tab Yes \tab Coefficient-specific \code{sd} parameters shared
+#' across observed grouping levels.\cr
+#' Active population priors \tab Limited \tab Flat, \code{normal},
+#' \code{student_t}, \code{cauchy}, or \code{logistic}, with numeric constant
+#' arguments.\cr
+#' Public output \tab Yes \tab Conventional population coefficients and group
+#' effects are reconstructed exactly.\cr
 #' }
+#'
+#' A phylogenetic or pedigree covariance supplied through \code{cov} is a
+#' covariance among grouping levels, not the coefficient correlation selected
+#' by \code{cor}. It is not yet available with S2Z. In particular,
+#' \code{gr(phylo, s2z = TRUE)} without \code{cov = A} is an ordinary
+#' exchangeable grouping effect and does not use \code{A}; it is not a
+#' substitute for \code{gr(phylo, cov = A)}.
+#'
+#' In a multivariate shorthand formula, an ID between the bars is not merely a
+#' label. For example,
+#' \code{(1 | q | gr(phylo, s2z = TRUE))} inside
+#' \code{mvbind(phen, cofactor)} requests one group-effect covariance block
+#' with ID \code{q} spanning both response predictors. Cross-predictor S2Z IDs
+#' are not yet supported. Omit \code{q} to request separate response-local S2Z
+#' blocks:
+#' \preformatted{
+#' bf(mvbind(phen, cofactor) ~ 1 +
+#'      (1 | gr(phylo, s2z = TRUE)))
+#' }
+#' Alternatively, write a separate \code{bf()} formula for each response and
+#' give each block a distinct ID. These response-local blocks do not model a
+#' cross-response covariance among their group effects. Residual response
+#' correlation, when supported by the response families, is separate and may
+#' still be selected with \code{set_rescor(TRUE)}. If cross-response
+#' group-effect correlation is required, use conventional group effects with
+#' \code{s2z = FALSE}.
 #'
 #' A population coordinate is \emph{S2Z-active} when it is touched by an
 #' omitted-mean map from at least one local S2Z block. Only active coordinates
@@ -90,12 +132,11 @@
 #' Student-t scale semantics and is not rescaled to a marginal standard
 #' deviation. Multiple S2Z blocks in one linear predictor retain separate
 #' grouping factors, scales, and correlation structures while their omitted
-#' means are handled jointly. An S2Z \code{id} cannot span linear predictors.
-#' For categorical, multinomial, and simplex families, omit \code{id} in a
-#' shared shorthand term so that the generated category predictors receive
-#' separate internal IDs, or specify the eligible non-reference category
-#' predictors explicitly and give each a distinct ID. A user-supplied ID that
-#' spans categories is a cross-predictor ID and is rejected.
+#' means are handled jointly. The same predictor-local ID rule applies to
+#' categorical, multinomial, and simplex families: omit \code{id} in a shared
+#' shorthand term so that generated category predictors receive separate
+#' internal IDs, or specify eligible non-reference category predictors with a
+#' distinct ID for each one.
 #'
 #' This foundation intentionally provides physical S2Z coordinates only.
 #' Centered, partially centered, and automatically centered modes are deferred;

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -16,44 +16,9 @@
 #'   must be nested in levels of the \code{by} variable.
 #' @param cor Logical. If \code{TRUE} (the default), group-level terms will be
 #'   modelled as correlated.
-#' @param s2z Logical. If \code{TRUE}, use a physical sum-to-zero
-#'   analytically integrate out the omitted common group-effect mean vector of
-#'   each S2Z block, jointly when multiple blocks share a linear predictor.
-#'   This experimental option preserves the usual
-#'   population- and group-level parameter semantics by reconstructing them in
-#'   generated quantities. It is exact for \code{dist = "gaussian"} and for
-#'   \code{dist = "student"} through a Gaussian scale mixture. Every varying
-#'   design column must have an identical population-level design column.
-#'   Blocks with one varying coefficient use a dedicated scalar
-#'   implementation. Blocks with any number of independent coefficients
-#'   (\code{cor = FALSE} or \code{||} syntax) use a component-wise scalar
-#'   implementation that also accounts exactly for the shared centered
-#'   intercept prior.
-#'   Usual priors on group-level standard deviations, correlations, and
-#'   Student-t degrees of freedom remain available, including separate
-#'   \code{sd} priors for varying intercepts, slopes, and interactions. For
-#'   \code{dist = "student"}, \code{sd} retains its existing \pkg{brms}
-#'   Student-t scale semantics and is not rescaled to a marginal standard
-#'   deviation.
-#'   The physical coordinates are intended for well-informed group
-#'   coefficients and may be slower than the default non-centered
-#'   parameterization when those coefficients are weakly informed.
-#'   Multiple S2Z covariance blocks may be used in the same linear predictor.
-#'   Their omitted group means are integrated and recovered jointly, while each
-#'   block retains its own grouping factor, shared scales, and correlation
-#'   structure. When all such blocks are Gaussian, \pkg{brms} uses an
-#'   induced population-coordinate covariance and joint Matheron recovery if
-#'   that system is smaller than the stacked omitted-mean system. Crossed
-#'   varying-intercept models then require only a scalar update, regardless of
-#'   the number of grouping factors. Flat population-level prior coordinates
-#'   are handled exactly rather than approximated by a large finite variance.
-#'   The \code{by}, \code{cov}, and \code{pw} arguments remain unsupported.
-#'   Population-level priors must currently be flat, normal, Student-t, or
-#'   Cauchy with numeric constant arguments. Bounds, tags, special priors,
-#'   prior-only sampling, ordinal thresholds, sparse and QR designs, and
-#'   non-positive fixed group-level standard deviations are not supported.
-#'   Custom Stan code must not use the conventional population- or group-level
-#'   coefficients before they are reconstructed in generated quantities.
+#' @param s2z Logical. If \code{TRUE}, use the experimental physical
+#'   sum-to-zero parameterization described in the section
+#'   \dQuote{Physical sum-to-zero effects}. The default is \code{FALSE}.
 #' @param id Optional character string. All group-level terms across the model
 #'   with the same \code{id} will be modeled as correlated (if \code{cor} is
 #'   \code{TRUE}). See \code{\link{brmsformula}} for more details.
@@ -69,6 +34,82 @@
 #'   of the same grouping factor are modeled as independent of each other.
 #' @param dist Name of the distribution of the group-level effects. Supported
 #'   options are \code{"gaussian"} and \code{"student"}.
+#'
+#' @section Physical sum-to-zero effects:
+#' Setting \code{s2z = TRUE} expresses every coefficient vector in the
+#' grouping block as a physical deviation whose entries sum exactly to zero
+#' over the observed grouping levels. The likelihood is evaluated in these
+#' constrained coordinates. The omitted common group-effect mean is handled
+#' jointly with the matching population coefficients, and conventional
+#' population- and group-level draws are reconstructed in generated
+#' quantities. Thus functions such as \code{fixef}, \code{ranef}, and
+#' \code{coef} retain their usual interpretation.
+#'
+#' Every S2Z varying design column must have a population-level column with the
+#' same coefficient name and numerically identical values. This applies to
+#' varying intercepts, numeric and factor slopes, and interaction columns,
+#' including their contrasts. For example, \code{x * f} must appear on both
+#' sides of the grouping bar when all of its expanded columns vary. At least
+#' two grouping levels must be observed.
+#'
+#' The current support matrix is:
+#'
+#' \tabular{ll}{
+#' Design \tab Ordinary matched intercepts, slopes, factors, and interactions.\cr
+#' Group distribution \tab Gaussian or Student-t.\cr
+#' Covariance \tab Correlated or independent coefficients; one or multiple
+#' local S2Z blocks.\cr
+#' Group scales \tab Coefficient-specific \code{sd} parameters shared across
+#' observed grouping levels.\cr
+#' Active population priors \tab Flat, \code{normal}, \code{student_t},
+#' \code{cauchy}, or \code{logistic}, with numeric constant arguments.\cr
+#' Fixed-only population priors \tab Any otherwise valid \pkg{brms} prior.\cr
+#' Predictors \tab Separate local S2Z IDs in otherwise eligible location,
+#' distributional, nonlinear, categorical, multinomial, and multivariate
+#' predictors.\cr
+#' Public output \tab Conventional population coefficients and group effects
+#' reconstructed exactly.\cr
+#' }
+#'
+#' A population coordinate is \emph{S2Z-active} when it is touched by an
+#' omitted-mean map from at least one local S2Z block. Only active coordinates
+#' enter the S2Z prior calculation and are subject to the active-prior row of
+#' the table. Other population coordinates are fixed-only: they retain the
+#' ordinary \pkg{brms} declaration and prior handling. The \code{logistic}
+#' case is exact, not a Gaussian approximation. Generated Stan explicitly
+#' samples standardized omitted block means for a logistic-active system and
+#' includes their exact density and Jacobian. This supports, among others, the
+#' default \code{logistic(0, 1)} intercept prior in auxiliary probability
+#' predictors such as \code{zi}, \code{hu}, \code{zoi}, \code{coi}, mixture
+#' weights, Wiener \code{bias}, and asym-Laplace \code{quantile}.
+#'
+#' Usual priors on shared group-level standard deviations, correlations, and
+#' Student-t degrees of freedom remain available, including separate
+#' \code{sd} priors for varying intercepts, slopes, factors, and interactions.
+#' For \code{dist = "student"}, \code{sd} retains its existing \pkg{brms}
+#' Student-t scale semantics and is not rescaled to a marginal standard
+#' deviation. Multiple S2Z blocks in one linear predictor retain separate
+#' grouping factors, scales, and correlation structures while their omitted
+#' means are handled jointly. An S2Z \code{id} cannot span linear predictors.
+#' For categorical, multinomial, and simplex families, omit \code{id} in a
+#' shared shorthand term so that the generated category predictors receive
+#' separate internal IDs, or specify the eligible non-reference category
+#' predictors explicitly and give each a distinct ID. A user-supplied ID that
+#' spans categories is a cross-predictor ID and is rejected.
+#'
+#' This foundation intentionally provides physical S2Z coordinates only.
+#' Centered, partially centered, and automatically centered modes are deferred;
+#' there is no S2Z \code{center} argument. Group-level scales that vary across
+#' grouping levels and priors on realized level-specific scales are also
+#' deferred. Ordinal location predictors and ordered mixture intercepts are not
+#' supported. Structural extensions including \code{by}, \code{cov},
+#' \code{pw}, multi-membership, category-specific or other special group
+#' coefficients, cross-predictor IDs, and sparse or QR population designs are
+#' deferred as well. Bounds, tags, and special priors on S2Z-active
+#' population coordinates, prior-only sampling, and non-positive fixed
+#' group-level standard deviations are unsupported. Custom Stan code must not
+#' use conventional population- or group-level coefficients before they are
+#' reconstructed in generated quantities.
 #'
 #' @seealso \code{\link{brmsformula}}
 #'

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -17,10 +17,10 @@
 #' @param cor Logical. If \code{TRUE} (the default), group-level terms will be
 #'   modelled as correlated.
 #' @param s2z Logical. If \code{TRUE}, use a physical sum-to-zero
-#'   parameterization and analytically marginalize the common group-effect
-#'   mean. This experimental option preserves the usual population- and
-#'   group-level parameter semantics by reconstructing them in generated
-#'   quantities. It is exact for \code{dist = "gaussian"} and for
+#'   parameterization and analytically integrate out the omitted common
+#'   group-effect mean vector. This experimental option preserves the usual
+#'   population- and group-level parameter semantics by reconstructing them in
+#'   generated quantities. It is exact for \code{dist = "gaussian"} and for
 #'   \code{dist = "student"} through a Gaussian scale mixture. Every varying
 #'   design column must have an identical population-level design column.
 #'   Blocks with one varying coefficient use a dedicated scalar
@@ -29,7 +29,7 @@
 #'   implementation that also accounts exactly for the shared centered
 #'   intercept prior.
 #'   Usual priors on group-level standard deviations, correlations, and
-#'   Student degrees of freedom remain available, including separate
+#'   Student-t degrees of freedom remain available, including separate
 #'   standard-deviation priors for varying intercepts, slopes, and
 #'   interactions.
 #'   The physical coordinates are intended for well-informed group
@@ -81,7 +81,7 @@
 #'             data = epilepsy)
 #' summary(fit4)
 #'
-#' # marginalized sum-to-zero varying intercepts, slopes, and interactions
+#' # physical sum-to-zero varying intercepts, slopes, and interactions
 #' s2z_prior <- prior(exponential(2), class = "sd", group = "patient",
 #'                    coef = "Intercept") +
 #'   prior(exponential(3), class = "sd", group = "patient", coef = "zAge") +

--- a/R/formula-re.R
+++ b/R/formula-re.R
@@ -41,7 +41,12 @@
 #'   Multiple S2Z covariance blocks may be used in the same linear predictor.
 #'   Their omitted group means are integrated and recovered jointly, while each
 #'   block retains its own grouping factor, shared scales, and correlation
-#'   structure.
+#'   structure. When all such blocks are Gaussian, \pkg{brms} uses an
+#'   induced population-coordinate covariance and joint Matheron recovery if
+#'   that system is smaller than the stacked omitted-mean system. Crossed
+#'   varying-intercept models then require only a scalar update, regardless of
+#'   the number of grouping factors. Flat population-level prior coordinates
+#'   are handled exactly rather than approximated by a large finite variance.
 #'   The \code{by}, \code{cov}, and \code{pw} arguments remain unsupported.
 #'   Population-level priors must currently be flat, normal, Student-t, or
 #'   Cauchy with numeric constant arguments. Bounds, tags, special priors,

--- a/R/priors.R
+++ b/R/priors.R
@@ -1358,6 +1358,10 @@ validate_prior <- function(prior, formula, data, family = gaussian(),
   prior <- prior + prior_no_checks
   rownames(prior) <- NULL
   attr(prior, "sample_prior") <- sample_prior
+  # S2Z prior and cross-predictor constraints depend on the complete effective
+  # prior table, so validate them only after ordinary and special priors have
+  # been resolved. This also makes public validate_prior() authoritative.
+  validate_re_s2z_prior_global(bframe, prior = prior)
   if (is_verbose()) {
     # show remaining default priors added to the model
     def_prior <- prepare_print_prior(prior)

--- a/R/re-s2z.R
+++ b/R/re-s2z.R
@@ -20,6 +20,100 @@ all_bframel <- function(x) {
   list()
 }
 
+# A neutral placeholder used for fixed-only coordinates. Keeping the prior
+# list full-length makes the descriptor backwards compatible with Stan code
+# that still indexes it in population-coordinate order.
+re_s2z_flat_prior <- function() {
+  list(dist = "flat", location = 0, scale = 1, df = NA_real_)
+}
+
+# Collect the model coordinates needed to make an S2Z diagnostic actionable.
+re_s2z_context <- function(bframe, r = NULL, coef = NULL, prior = NULL) {
+  stopifnot(is.bframel(bframe))
+  px <- check_prefix(bframe, keep_mu = TRUE)
+  response <- px$resp %||% ""
+  if ((!length(response) || !nzchar(response)) &&
+      is.formula(bframe$respform)) {
+    response_vars <- all.vars(bframe$respform)
+    if (length(response_vars)) {
+      response <- response_vars[1L]
+    }
+  }
+  if ((!length(response) || !nzchar(response)) &&
+      nzchar(bframe$frame$s2z_context$response %||% "")) {
+    response <- bframe$frame$s2z_context$response
+  }
+  if (!length(response) || !nzchar(response)) {
+    response <- "<unspecified>"
+  }
+  family <- bframe$family$family %||% ""
+  if (!length(family) || !nzchar(family)) {
+    family <- bframe$frame$s2z_context$family %||% ""
+  }
+  if (!length(family) || !nzchar(family)) {
+    family <- "<unspecified>"
+  }
+  dpar <- px$dpar %||% ""
+  nlpar <- px$nlpar %||% ""
+  if (!nzchar(dpar)) {
+    dpar <- "mu"
+  }
+  if (!nzchar(nlpar)) {
+    nlpar <- "<none>"
+  }
+  group <- id <- "<unspecified>"
+  if (!is.null(r) && has_rows(r)) {
+    groups <- unique(r$group[nzchar(r$group)])
+    if (length(groups)) {
+      group <- paste(groups, collapse = ", ")
+    }
+    public_id <- r$gcall[[1L]]$id %||% NA
+    if (length(public_id) == 1L && !is.na(public_id) &&
+        nzchar(as.character(public_id))) {
+      id <- as.character(public_id)
+    } else {
+      ids <- unique(r$id)
+      if (length(ids)) {
+        id <- paste(ids, collapse = ", ")
+      }
+    }
+    if (is.null(coef)) {
+      coef <- unique(r$coef)
+    }
+  }
+  coef <- unique(as.character(coef %||% character()))
+  coef <- coef[nzchar(coef)]
+  list(
+    response = response, family = family, dpar = dpar, nlpar = nlpar,
+    group = group, id = id, coef = coef, prior = prior
+  )
+}
+
+format_re_s2z_context <- function(context) {
+  stopifnot(is.list(context))
+  out <- paste0(
+    "response '", context$response, "', family '", context$family,
+    "', dpar '", context$dpar, "', nlpar '", context$nlpar,
+    "', group '", context$group, "', ID '", context$id, "'"
+  )
+  if (length(context$coef)) {
+    out <- paste0(
+      out, ", coefficient(s) '", paste(context$coef, collapse = ", "), "'"
+    )
+  }
+  if (!is.null(context$prior) && nzchar(as.character(context$prior))) {
+    out <- paste0(out, ", prior '", as.character(context$prior), "'")
+  }
+  out
+}
+
+stop_re_s2z <- function(context, capability, problem, remedy) {
+  stop2(
+    problem, "\nS2Z capability '", capability, "' is unavailable for ",
+    format_re_s2z_context(context), ". Remedy: ", remedy
+  )
+}
+
 # Find the local linear predictor frame belonging to a group-level block.
 re_s2z_bframel <- function(bframe, r) {
   stopifnot(is.anybrmsframe(bframe), is.reframe(r), has_rows(r))
@@ -35,14 +129,19 @@ re_s2z_bframel <- function(bframe, r) {
   out[[1]]
 }
 
-# Effective scalar population-level prior for one coefficient.
-re_s2z_prior <- function(prior, bframe, class, coef = "") {
+# Effective scalar population-level prior for one active coefficient.
+re_s2z_prior <- function(prior, bframe, class, coef = "", r = NULL) {
   stopifnot(is.brmsprior(prior), is.bframel(bframe))
+  context <- re_s2z_context(bframe, r = r, coef = coef)
   px <- check_prefix(bframe)
   p <- subset2(prior, class = class, ls = px)
   if (class == "b" && nzchar(coef)) {
     pcoef <- subset2(p, coef = coef)
-    if (nrow(pcoef) == 1L && nzchar(pcoef$prior)) {
+    populated <- nrow(pcoef) == 1L && any(
+      nzchar(pcoef$prior) | nzchar(pcoef$lb) | nzchar(pcoef$ub) |
+        nzchar(pcoef$tag)
+    )
+    if (populated) {
       ans <- pcoef
     } else {
       ans <- subset2(p, coef = "")
@@ -51,7 +150,7 @@ re_s2z_prior <- function(prior, bframe, class, coef = "") {
     ans <- subset2(p, coef = "")
   }
   if (!nrow(ans)) {
-    return(list(dist = "flat", location = 0, scale = 1, df = NA_real_))
+    return(re_s2z_flat_prior())
   }
   if (nrow(ans) > 1L) {
     # Follow stan_prior() and prefer the most specific populated base row.
@@ -64,38 +163,70 @@ re_s2z_prior <- function(prior, bframe, class, coef = "") {
     }
   }
   if (nrow(ans) && (nzchar(ans$lb) || nzchar(ans$ub))) {
-    stop2("The sum-to-zero parameterization does not yet ",
-          "support bounded population-level priors (coefficient '", coef,
-          "').")
+    stop_re_s2z(
+      context, "active_prior_bounds",
+      paste0(
+        "The sum-to-zero parameterization does not yet support bounded ",
+        "population-level priors (coefficient '", coef, "')."
+      ),
+      "remove the bound or make this coefficient fixed-only."
+    )
   }
   if (nrow(ans) && nzchar(ans$tag)) {
-    stop2("The sum-to-zero parameterization does not yet ",
-          "support tagged population-level priors (coefficient '", coef,
-          "').")
+    stop_re_s2z(
+      context, "active_prior_tag",
+      paste0(
+        "The sum-to-zero parameterization does not yet support tagged ",
+        "population-level priors (coefficient '", coef, "')."
+      ),
+      "remove the tag or make this coefficient fixed-only."
+    )
   }
   value <- if (nrow(ans)) ans$prior else ""
-  parse_re_s2z_prior(value, coef = coef)
+  context$prior <- value
+  parse_re_s2z_prior(value, coef = coef, context = context)
 }
 
-# Parse the conditionally Gaussian scalar priors supported by the fast path.
-parse_re_s2z_prior <- function(prior, coef = "") {
+# Parse the exact scalar priors supported by the S2Z paths. Logistic priors
+# use an explicit omitted-mean fallback; the remaining proper distributions
+# are conditionally Gaussian.
+parse_re_s2z_prior <- function(prior, coef = "", context = NULL) {
   prior <- gsub("[[:space:]]+", "", prior)
   if (!nzchar(prior)) {
-    return(list(dist = "flat", location = 0, scale = 1, df = NA_real_))
+    return(re_s2z_flat_prior())
+  }
+  fail <- function(capability, problem, remedy) {
+    if (is.null(context)) {
+      stop2(problem, " Remedy: ", remedy)
+    }
+    context$prior <- prior
+    stop_re_s2z(context, capability, problem, remedy)
   }
   call <- try(str2lang(prior), silent = TRUE)
   if (inherits(call, "try-error") || !is.call(call)) {
-    stop2("Prior '", prior, "' is not supported by the ",
-          "sum-to-zero parameterization (coefficient '", coef, "').")
+    fail(
+      "active_prior_distribution",
+      paste0(
+        "Prior '", prior, "' is not supported by the sum-to-zero ",
+        "parameterization (coefficient '", coef, "')."
+      ),
+      "use flat, normal, student_t, cauchy, or logistic with numeric constants."
+    )
   }
   dist <- as.character(call[[1]])
   args <- as.list(call[-1])
   number <- function(x) {
     out <- suppressWarnings(as.numeric(deparse0(x)))
     if (length(out) != 1L || !is.finite(out)) {
-      stop2("All arguments of population-level priors used with the ",
-            "sum-to-zero parameterization must currently be ",
-            "numeric constants (coefficient '", coef, "').")
+      fail(
+        "active_prior_arguments",
+        paste0(
+          "All arguments of population-level priors used with the ",
+          "sum-to-zero parameterization must currently be numeric ",
+          "constants (coefficient '", coef, "')."
+        ),
+        "replace symbolic arguments with finite numeric constants."
+      )
     }
     out
   }
@@ -116,23 +247,38 @@ parse_re_s2z_prior <- function(prior, coef = "") {
       dist = "student", df = 1, location = number(args[[1]]),
       scale = number(args[[2]])
     )
+  } else if (dist == "logistic" && length(args) == 2L) {
+    out <- list(
+      dist = "logistic", location = number(args[[1]]),
+      scale = number(args[[2]]), df = NA_real_
+    )
   } else {
-    stop2(
-      "Prior '", prior, "' is not supported by the ",
-      "sum-to-zero parameterization. Supported population-level priors ",
-      "are flat, normal, student_t, and cauchy (coefficient '", coef, "')."
+    fail(
+      "active_prior_distribution",
+      paste0(
+        "Prior '", prior, "' is not supported by the sum-to-zero ",
+        "parameterization. Supported population-level priors are flat, ",
+        "normal, student_t, cauchy, and logistic (coefficient '", coef, "')."
+      ),
+      "choose one of the supported priors or make this coefficient fixed-only."
     )
   }
   if (!(out$scale > 0) || out$dist == "student" && !(out$df > 0)) {
-    stop2("Scale and degrees-of-freedom arguments must be positive in ",
-          "population-level priors used with the sum-to-zero ",
-          "parameterization (coefficient '", coef, "').")
+    fail(
+      "active_prior_arguments",
+      paste0(
+        "Scale and degrees-of-freedom arguments must be positive in ",
+        "population-level priors used with the sum-to-zero ",
+        "parameterization (coefficient '", coef, "')."
+      ),
+      "supply a positive finite scale and, for student_t, positive degrees of freedom."
+    )
   }
   out
 }
 
 # Check fixed group scales before the Gaussian precision is constructed.
-validate_re_s2z_sd_prior <- function(prior, r) {
+validate_re_s2z_sd_prior <- function(prior, r, bframe = NULL) {
   stopifnot(is.brmsprior(prior), is.reframe(r), has_rows(r))
   px <- check_prefix(r)
   p <- subset2(
@@ -159,76 +305,143 @@ validate_re_s2z_sd_prior <- function(prior, r) {
       suppressWarnings(as.numeric(deparse0(call[[2]])))
     }
     if (length(fixed) != 1L || !is.finite(fixed) || fixed <= 0) {
-      stop2("Group-level standard deviations fixed with 'constant' must ",
-            "be positive numeric scalars for gr(..., s2z = TRUE) ",
-            "(coefficient '", coef, "').")
+      problem <- paste0(
+        "Group-level standard deviations fixed with 'constant' must be ",
+        "positive numeric scalars for gr(..., s2z = TRUE) ",
+        "(coefficient '", coef, "')."
+      )
+      if (is.null(bframe)) {
+        stop2(problem)
+      }
+      stop_re_s2z(
+        re_s2z_context(bframe, r = r, coef = coef, prior = value),
+        "fixed_sd_positive", problem,
+        "use constant(value) with a finite value greater than zero, or estimate the scale."
+      )
     }
   }
   invisible(NULL)
 }
 
-# Describe one local S2Z block, including the fixed/group design mapping.
-re_s2z_info <- function(bframe, prior = NULL, id = NULL) {
+# Build validated-block descriptors without looking at priors. Active rows are
+# the union of all rows touched by the local omitted-mean maps. In a centered
+# fixed design, any matched non-intercept slope also structurally touches the
+# temporary intercept row, even when its realized column mean happens to be 0.
+.re_s2z_descriptors <- function(bframe) {
   stopifnot(is.bframel(bframe))
   if (!has_re_s2z(bframe)) {
-    return(NULL)
+    return(list())
   }
-  r <- bframe$frame$re[bframe$frame$re$s2z, , drop = FALSE]
-  ids <- unique(r$id)
-  if (is.null(id) && length(ids) != 1L) {
-    stop2("An explicit group-level ID is required when describing multiple ",
-          "sum-to-zero blocks.")
-  }
-  if (!is.null(id)) {
-    if (length(id) != 1L || !id %in% ids) {
-      stop2("Invalid sum-to-zero group-level ID.")
-    }
-    ids <- id
-  }
-  r_id <- subset2(bframe$frame$re, id = ids)
-  if (!all(r_id$s2z)) {
-    stop2("All coefficients sharing a group-level ID must use the same ",
-          "'s2z' setting.")
-  }
-  r <- r_id
+  re <- bframe$frame$re
+  ids <- unique(re$id[re$s2z])
   qnames <- bframe$frame$fe$vars
-  match_q <- match(r$coef, qnames)
-  if (anyNA(match_q)) {
-    missing <- collapse_comma(r$coef[is.na(match_q)])
-    stop2("Every sum-to-zero group-level coefficient must have a matching ",
-          "population-level design column. Missing: ", missing, ".")
-  }
-  out <- nlist(
-    id = ids, r, qnames, match_q,
-    center = bframe$frame$fe$center,
-    fixef = bframe$frame$fe$vars_stan,
-    p = usc(combine_prefix(check_prefix(bframe)))
-  )
-  if (!is.null(prior)) {
-    specs <- vector("list", length(qnames))
-    for (i in seq_along(qnames)) {
-      if (out$center && qnames[i] == "Intercept") {
-        specs[[i]] <- re_s2z_prior(prior, bframe, class = "Intercept")
-      } else {
-        specs[[i]] <- re_s2z_prior(
-          prior, bframe, class = "b", coef = qnames[i]
-        )
-      }
+  center <- bframe$frame$fe$center
+  out <- lapply(ids, function(id) {
+    r <- subset2(re, id = id)
+    match_q <- match(r$coef, qnames)
+    nlist(
+      id, r, qnames, match_q, center,
+      fixef = bframe$frame$fe$vars_stan,
+      p = usc(combine_prefix(check_prefix(bframe))),
+      context = re_s2z_context(bframe, r = r)
+    )
+  })
+  active_q <- sort(unique(unlist(lapply(out, function(info) {
+    rows <- info$match_q[!is.na(info$match_q)]
+    if (info$center && any(info$r$coef != "Intercept")) {
+      rows <- c(rows, 1L)
     }
-    out$prior <- specs
+    rows
+  }), use.names = FALSE)))
+  inactive_q <- setdiff(seq_along(qnames), active_q)
+  active_names <- qnames[active_q]
+  inactive_names <- qnames[inactive_q]
+  active_index <- match(seq_along(qnames), active_q)
+  lapply(out, function(info) {
+    info$block_active_q <- sort(unique(c(
+      info$match_q[!is.na(info$match_q)],
+      if (info$center && any(info$r$coef != "Intercept")) 1L
+    )))
+    info$active_q <- active_q
+    info$inactive_q <- inactive_q
+    info$active_names <- active_names
+    info$inactive_names <- inactive_names
+    info$active_index <- active_index
+    info$match_active <- match(info$match_q, active_q)
+    info
+  })
+}
+
+# Attach active-coordinate priors while leaving fixed-only slots as neutral
+# placeholders for q-length consumers in the existing Stan generators.
+.re_s2z_attach_priors <- function(infos, bframe, prior) {
+  if (!length(infos)) {
+    return(infos)
   }
-  out
+  qnames <- infos[[1L]]$qnames
+  active_q <- infos[[1L]]$active_q
+  specs <- rep(list(re_s2z_flat_prior()), length(qnames))
+  for (i in active_q) {
+    # Attribute prior diagnostics to a block that actually touches this
+    # population coordinate. In a multi-block predictor the first block need
+    # not contain the failing coefficient.
+    touching <- which(vapply(infos, function(info) {
+      i %in% info$block_active_q
+    }, logical(1)))
+    r_context <- infos[[touching[1L]]]$r
+    if (infos[[1L]]$center && qnames[i] == "Intercept") {
+      specs[[i]] <- re_s2z_prior(
+        prior, bframe, class = "Intercept", r = r_context
+      )
+    } else {
+      specs[[i]] <- re_s2z_prior(
+        prior, bframe, class = "b", coef = qnames[i], r = r_context
+      )
+    }
+  }
+  lapply(infos, function(info) {
+    info$prior <- specs
+    info
+  })
 }
 
 # Describe all local S2Z blocks in one linear predictor. Blocks retain their
-# own covariance models but share one joint omitted-mean system.
+# own covariance models but share one active-coordinate omitted-mean system.
 re_s2z_infos <- function(bframe, prior = NULL) {
   stopifnot(is.bframel(bframe))
   if (!has_re_s2z(bframe)) {
     return(list())
   }
-  ids <- unique(bframe$frame$re$id[bframe$frame$re$s2z])
-  lapply(ids, function(id) re_s2z_info(bframe, prior = prior, id = id))
+  if (is.list(bframe$frame$re_s2z) && length(bframe$frame$re_s2z)) {
+    out <- bframe$frame$re_s2z
+  } else {
+    out <- .re_s2z_descriptors(bframe)
+  }
+  if (!is.null(prior)) {
+    out <- .re_s2z_attach_priors(out, bframe = bframe, prior = prior)
+  }
+  out
+}
+
+# Describe one local S2Z block, including the fixed/group design mapping.
+re_s2z_info <- function(bframe, prior = NULL, id = NULL) {
+  stopifnot(is.bframel(bframe))
+  infos <- re_s2z_infos(bframe, prior = prior)
+  if (!length(infos)) {
+    return(NULL)
+  }
+  ids <- vapply(infos, `[[`, numeric(1), "id")
+  if (is.null(id) && length(ids) != 1L) {
+    stop2("An explicit group-level ID is required when describing multiple ",
+          "sum-to-zero blocks.")
+  }
+  if (is.null(id)) {
+    return(infos[[1L]])
+  }
+  if (length(id) != 1L || !id %in% ids) {
+    stop2("Invalid sum-to-zero group-level ID.")
+  }
+  infos[[match(id, ids)]]
 }
 
 # Construct an S2Z design matrix in covariance-block coefficient order. A
@@ -254,96 +467,168 @@ re_s2z_design_matrix <- function(bframe, data, id = NULL) {
   out
 }
 
-# Validate S2Z structure after formulas, data, and priors have been resolved.
-validate_re_s2z <- function(bframe, prior) {
-  stopifnot(is.anybrmsframe(bframe), is.brmsprior(prior))
-  all_frames <- all_bframel(bframe)
-  # IDs may couple ordinary group effects across linear predictors. Such a
-  # coupling is not compatible with the local S2Z omitted-mean systems, even
-  # if only one occurrence of the shared ID requests S2Z. Check all terms
-  # before filtering to S2Z-containing predictors so mixed conventional/S2Z
-  # uses fail with the same clear error in either predictor order.
-  s2z_ids <- unique(unlist(lapply(all_frames, function(x) {
-    r <- x$frame$re
-    if (!has_rows(r)) {
-      return(integer())
-    }
-    r$id[r$s2z]
-  }), use.names = FALSE))
-  for (id in s2z_ids) {
-    n_frames <- sum(vapply(all_frames, function(x) {
-      r <- x$frame$re
-      has_rows(r) && id %in% r$id
-    }, logical(1)))
-    if (n_frames > 1L) {
-      stop2("A sum-to-zero group-level ID cannot span multiple ",
-            "linear predictors.")
-    }
-  }
-  frames <- Filter(has_re_s2z, all_frames)
-  if (!length(frames)) {
+# Validate local structural eligibility before any fixed/group design match is
+# attempted. The ordering here is intentional: family and term capabilities
+# should diagnose themselves even when the corresponding ordinary fixed column
+# is absent (for example, ordinal threshold models).
+validate_re_s2z_structure <- function(bframe, data) {
+  stopifnot(is.bframel(bframe), is.data.frame(data))
+  if (!has_re_s2z(bframe)) {
     return(invisible(NULL))
   }
-  if (get_sample_prior(prior) != "no") {
-    stop2("Argument 'sample_prior' is not yet supported together with ",
-          "gr(..., s2z = TRUE).")
+  re <- bframe$frame$re
+  ids <- unique(re$id[re$s2z])
+  first_r <- subset2(re, id = ids[1L])
+  if (is_ordinal(bframe$family)) {
+    stop_re_s2z(
+      re_s2z_context(bframe, r = first_r), "ordinal_location",
+      paste0(
+        "Ordinal thresholds are not yet supported together with ",
+        "gr(..., s2z = TRUE)."
+      ),
+      "use a conventional group-level term for this ordinal predictor, or wait for ordinal S2Z support."
+    )
   }
-  ids <- integer()
-  for (x in frames) {
-    infos <- re_s2z_infos(x, prior = prior)
-    for (info in infos) {
-      r <- info$r
-      if (info$id %in% ids) {
-        stop2("A sum-to-zero group-level ID cannot span multiple ",
-              "linear predictors.")
+  if (order_intercepts(bframe)) {
+    stop_re_s2z(
+      re_s2z_context(bframe, r = first_r), "ordered_mixture",
+      paste0(
+        "Ordered mixture intercepts are not yet supported together with ",
+        "gr(..., s2z = TRUE)."
+      ),
+      "disable ordered mixture intercepts or use a conventional group-level term."
+    )
+  }
+  for (id in ids) {
+    r <- subset2(re, id = id)
+    context <- re_s2z_context(bframe, r = r)
+    if (!all(r$s2z)) {
+      stop_re_s2z(
+        context, "same_id_s2z",
+        paste0(
+          "All coefficients sharing a group-level ID must use the same ",
+          "'s2z' setting."
+        ),
+        "give every term with this ID the same s2z setting or use distinct IDs."
+      )
+    }
+    if (length(unique(r$group)) != 1L) {
+      stop_re_s2z(
+        context, "same_id_group",
+        paste0(
+          "All coefficients sharing a sum-to-zero group-level ID must use ",
+          "the same grouping factor."
+        ),
+        "use one grouping factor per S2Z ID or assign distinct IDs."
+      )
+    }
+    if (length(unique(r$dist)) != 1L) {
+      stop_re_s2z(
+        context, "same_id_distribution",
+        paste0(
+          "All coefficients sharing a group-level ID must use the same ",
+          "group-level distribution."
+        ),
+        "use one group-effect distribution per S2Z ID or assign distinct IDs."
+      )
+    }
+    if (length(unique(r$cor)) != 1L) {
+      stop_re_s2z(
+        context, "same_id_correlation",
+        paste0(
+          "All coefficients sharing a group-level ID must use the same ",
+          "'cor' setting."
+        ),
+        "use one correlation setting per S2Z ID or assign distinct IDs."
+      )
+    }
+    if (any(nzchar(r$gtype), na.rm = TRUE) ||
+        any(nzchar(r$type), na.rm = TRUE)) {
+      stop_re_s2z(
+        context, "ordinary_gr_only",
+        paste0(
+          "The sum-to-zero parameterization currently supports only ",
+          "ordinary 'gr' terms."
+        ),
+        "remove the special group coefficient or use s2z = FALSE for this term."
+      )
+    }
+    has_pw <- any(vapply(r$gcall, function(gcall) {
+      isTRUE(nzchar(gcall$pw %||% ""))
+    }, logical(1)))
+    has_by <- any(nzchar(r$by), na.rm = TRUE)
+    has_cov <- any(nzchar(r$cov), na.rm = TRUE)
+    if (has_by || has_cov || has_pw) {
+      capability <- if (has_by) "by" else if (has_cov) "cov" else "pw"
+      stop_re_s2z(
+        context, capability,
+        paste0(
+          "Arguments 'by', 'cov', and 'pw' are not yet supported together ",
+          "with gr(..., s2z = TRUE)."
+        ),
+        "remove the unsupported argument or use s2z = FALSE for this term."
+      )
+    }
+    if (isTRUE(bframe$frame$fe$sparse)) {
+      stop_re_s2z(
+        context, "sparse",
+        paste0(
+          "Sparse and QR-decomposed population-level design matrices are ",
+          "not yet supported together with gr(..., s2z = TRUE)."
+        ),
+        "disable sparse fixed-effect design generation for this predictor."
+      )
+    }
+    if (!identical(bframe$frame$fe$decomp, "none")) {
+      stop_re_s2z(
+        context, "qr",
+        paste0(
+          "Sparse and QR-decomposed population-level design matrices are ",
+          "not yet supported together with gr(..., s2z = TRUE)."
+        ),
+        "set decomp = 'none' for this predictor."
+      )
+    }
+    # During model construction the physical constraint is defined over the
+    # levels actually represented in the likelihood. Retained but unused
+    # factor levels would otherwise introduce unobserved balancing effects.
+    # Post-processing frames carry a fitted basis and may legitimately contain
+    # only a subset of the fitted levels in newdata.
+    levels <- get_levels(r)[[r$group[1L]]]
+    if (is.null(bframe$basis)) {
+      group_name <- r$gcall[[1L]]$groups
+      group_data <- get(group_name, data)
+      observed_levels <- unique(as.character(group_data[!is.na(group_data)]))
+      if (length(observed_levels) < 2L) {
+        stop_re_s2z(
+          context, "minimum_levels",
+          paste0(
+            "The sum-to-zero parameterization requires at least two observed ",
+            "grouping levels."
+          ),
+          "supply data with at least two observed levels or use a fixed effect."
+        )
       }
-      ids <- c(ids, info$id)
-      if (length(unique(r$group)) != 1L) {
-        stop2("All coefficients sharing a sum-to-zero group-level ID must ",
-              "use the same grouping factor.")
+      unused_levels <- setdiff(as.character(levels), observed_levels)
+      if (length(unused_levels)) {
+        stop_re_s2z(
+          context, "unused_levels",
+          paste0(
+            "The sum-to-zero parameterization cannot retain unobserved ",
+            "grouping levels: ", paste(unused_levels, collapse = ", "), "."
+          ),
+          "drop unused factor levels or set drop_unused_levels = TRUE."
+        )
       }
-      if (length(unique(r$dist)) != 1L) {
-        stop2("All coefficients sharing a group-level ID must use the same ",
-              "group-level distribution.")
-      }
-      if (length(unique(r$cor)) != 1L) {
-        stop2("All coefficients sharing a group-level ID must use the same ",
-              "'cor' setting.")
-      }
-      if (any(nzchar(r$gtype)) || any(nzchar(r$type))) {
-        stop2("The sum-to-zero parameterization currently ",
-              "supports only ordinary 'gr' terms.")
-      }
-      has_pw <- any(vapply(r$gcall, function(gcall) {
-        isTRUE(nzchar(gcall$pw))
-      }, logical(1)))
-      if (any(nzchar(r$by), na.rm = TRUE) ||
-          any(nzchar(r$cov), na.rm = TRUE) || has_pw) {
-        stop2("Arguments 'by', 'cov', and 'pw' are not yet supported ",
-              "together with gr(..., s2z = TRUE).")
-      }
-      if (length(get_levels(r)[[r$group[1]]]) < 2L) {
-        stop2("The sum-to-zero parameterization requires at ",
-              "least two observed grouping levels.")
-      }
-      if (is_ordinal(x$family)) {
-        stop2("Ordinal thresholds are not yet supported together with ",
-              "gr(..., s2z = TRUE).")
-      }
-      if (order_intercepts(x)) {
-        stop2("Ordered mixture intercepts are not yet supported together ",
-              "with gr(..., s2z = TRUE).")
-      }
-      if (x$frame$fe$sparse || x$frame$fe$decomp != "none") {
-        stop2("Sparse and QR-decomposed population-level design matrices ",
-              "are not yet supported together with gr(..., s2z = TRUE).")
-      }
-      if (has_special_prior(prior, check_prefix(r), class = "sd") ||
-          has_special_prior(prior, x, class = "b")) {
-        stop2("Special priors are not yet supported together with ",
-              "gr(..., s2z = TRUE).")
-      }
-      validate_re_s2z_sd_prior(prior, r)
+    } else if (length(levels) < 2L) {
+      stop_re_s2z(
+        context, "minimum_levels",
+        paste0(
+          "The sum-to-zero parameterization requires at least two observed ",
+          "grouping levels."
+        ),
+        "supply data with at least two observed levels or use a fixed effect."
+      )
     }
   }
   invisible(NULL)
@@ -356,22 +641,174 @@ validate_re_s2z_design <- function(bframe, data) {
     return(invisible(NULL))
   }
   X <- bframe$sdata$fe$X
-  for (info in re_s2z_infos(bframe)) {
+  infos <- re_s2z_infos(bframe)
+  missing <- unique(unlist(lapply(infos, function(info) {
+    info$r$coef[is.na(info$match_q)]
+  }), use.names = FALSE))
+  if (length(missing)) {
+    first <- which(vapply(infos, function(info) {
+      any(is.na(info$match_q))
+    }, logical(1)))[1L]
+    stop_re_s2z(
+      re_s2z_context(bframe, r = infos[[first]]$r, coef = missing),
+      "matching_name",
+      paste0(
+        "Every sum-to-zero group-level coefficient must have a matching ",
+        "population-level design column. Missing: ",
+        paste(missing, collapse = ", "), "."
+      ),
+      "add population-level terms with these coefficient names or remove the unmatched group effects."
+    )
+  }
+  mismatches <- list()
+  for (info in infos) {
     Z <- re_s2z_design_matrix(bframe, data = data, id = info$id)
     if (ncol(Z) != nrow(info$r)) {
-      stop2("Internal mismatch in the sum-to-zero group-level design matrix.")
+      stop_re_s2z(
+        info$context, "internal_design",
+        "Internal mismatch in the sum-to-zero group-level design matrix.",
+        "report this model and data as a brms issue."
+      )
     }
     for (j in seq_len(ncol(Z))) {
-      same <- isTRUE(all.equal(
-        unname(Z[, j]), unname(X[, info$match_q[j]]),
-        tolerance = sqrt(.Machine$double.eps), check.attributes = FALSE
-      ))
+      # The omitted-mean identity is exact only when the two likelihood design
+      # columns are numerically identical; even a tiny tolerance would define
+      # a different posterior.
+      same <- identical(
+        unname(Z[, j]), unname(X[, info$match_q[j]])
+      )
       if (!same) {
-        stop2("Population- and group-level design columns must be identical ",
-              "for gr(..., s2z = TRUE). Mismatch for coefficient '",
-              info$r$coef[j], "'.")
+        mismatches[[length(mismatches) + 1L]] <- list(
+          info = info, coef = info$r$coef[j]
+        )
       }
     }
   }
+  if (length(mismatches)) {
+    coef <- unique(vapply(mismatches, `[[`, character(1), "coef"))
+    first <- mismatches[[1L]]$info
+    stop_re_s2z(
+      re_s2z_context(bframe, r = first$r, coef = coef),
+      "matching_values",
+      paste0(
+        "Population- and group-level design columns must be identical for ",
+        "gr(..., s2z = TRUE). Mismatch for coefficient(s) '",
+        paste(coef, collapse = ", "), "'."
+      ),
+      "use the identical population- and group-level term expressions and contrasts."
+    )
+  }
   invisible(NULL)
+}
+
+# Validate prior-dependent and cross-predictor constraints only after the
+# complete effective prior table exists.
+validate_re_s2z_prior_global <- function(bframe, prior) {
+  stopifnot(is.anybrmsframe(bframe), is.brmsprior(prior))
+  all_frames <- all_bframel(bframe)
+  frames <- Filter(has_re_s2z, all_frames)
+  if (!length(frames)) {
+    return(invisible(NULL))
+  }
+  s2z_ids <- unique(unlist(lapply(frames, function(x) {
+    x$frame$re$id[x$frame$re$s2z]
+  }), use.names = FALSE))
+  for (id in s2z_ids) {
+    occurrences <- Filter(function(x) {
+      r <- x$frame$re
+      has_rows(r) && id %in% r$id
+    }, all_frames)
+    if (length(occurrences) > 1L) {
+      first <- occurrences[[1L]]
+      r <- subset2(first$frame$re, id = id)
+      stop_re_s2z(
+        re_s2z_context(first, r = r), "cross_predictor_id",
+        paste0(
+          "A sum-to-zero group-level ID cannot span multiple linear ",
+          "predictors."
+        ),
+        "assign a distinct group-level ID within each linear predictor."
+      )
+    }
+  }
+  if (get_sample_prior(prior) != "no") {
+    first <- frames[[1L]]
+    r <- first$frame$re[first$frame$re$s2z, , drop = FALSE]
+    stop_re_s2z(
+      re_s2z_context(first, r = r), "sample_prior",
+      paste0(
+        "Argument 'sample_prior' is not yet supported together with ",
+        "gr(..., s2z = TRUE)."
+      ),
+      "set sample_prior = 'no' for this model."
+    )
+  }
+  for (x in frames) {
+    infos <- re_s2z_infos(x)
+    active_q <- infos[[1L]]$active_q
+    active_names <- infos[[1L]]$qnames[active_q]
+    active_intercept <- infos[[1L]]$center & active_names == "Intercept"
+    active_b <- active_names[!active_intercept]
+    if (length(active_b) && has_special_prior(prior, x, class = "b")) {
+      active_b_q <- active_q[!active_intercept]
+      touching <- which(vapply(infos, function(info) {
+        active_b_q[1L] %in% info$block_active_q
+      }, logical(1)))
+      r_context <- infos[[touching[1L]]]$r
+      stop_re_s2z(
+        re_s2z_context(
+          x, r = r_context, coef = active_b, prior = "special b prior"
+        ),
+        "active_special_prior",
+        paste0(
+          "Special population-level priors are not yet supported on ",
+          "S2Z-active coordinates."
+        ),
+        "use a supported scalar prior on the active coordinates or make them fixed-only."
+      )
+    }
+    if (any(active_intercept) &&
+        has_special_prior(prior, x, class = "Intercept")) {
+      stop_re_s2z(
+        re_s2z_context(
+          x, r = infos[[1L]]$r, coef = "Intercept",
+          prior = "special Intercept prior"
+        ),
+        "active_special_prior",
+        paste0(
+          "Special population-level priors are not yet supported on ",
+          "S2Z-active coordinates."
+        ),
+        "use a supported scalar intercept prior or remove the active intercept map."
+      )
+    }
+    for (info in infos) {
+      if (has_special_prior(prior, check_prefix(info$r), class = "sd")) {
+        stop_re_s2z(
+          re_s2z_context(
+            x, r = info$r, prior = "special group-scale prior"
+          ),
+          "active_special_prior",
+          paste0(
+            "Special priors are not yet supported on S2Z group-level ",
+            "standard deviations."
+          ),
+          "use an ordinary sd prior or use s2z = FALSE for this block."
+        )
+      }
+    }
+    # Attaching priors performs bounds, tags, argument, and distribution
+    # validation, restricted to the union of S2Z-active coordinates.
+    re_s2z_infos(x, prior = prior)
+    for (info in infos) {
+      validate_re_s2z_sd_prior(prior, info$r, bframe = x)
+    }
+  }
+  invisible(NULL)
+}
+
+# Compatibility entry point for downstream code while callers migrate to the
+# explicitly named prior/global phase.
+validate_re_s2z <- function(bframe, prior) {
+  validate_re_s2z_prior_global(bframe, prior = prior)
 }

--- a/R/re-s2z.R
+++ b/R/re-s2z.R
@@ -1,0 +1,300 @@
+# Helpers for the marginalized sum-to-zero parameterization of group effects
+
+# Does a local linear predictor contain a sum-to-zero group-level block?
+has_re_s2z <- function(x) {
+  is.bframel(x) && has_rows(x$frame$re) &&
+    "s2z" %in% names(x$frame$re) && any(x$frame$re$s2z)
+}
+
+# Return all local linear predictor frames contained in a brms frame.
+all_bframel <- function(x) {
+  if (is.bframel(x)) {
+    return(list(x))
+  }
+  if (is.mvbrmsframe(x)) {
+    return(unlist(lapply(x$terms, all_bframel), recursive = FALSE))
+  }
+  if (is.brmsframe(x)) {
+    return(unlist(lapply(c(x$dpars, x$nlpars), all_bframel), recursive = FALSE))
+  }
+  list()
+}
+
+# Find the local linear predictor frame belonging to a group-level block.
+re_s2z_bframel <- function(bframe, r) {
+  stopifnot(is.anybrmsframe(bframe), is.reframe(r), has_rows(r))
+  rp <- unique(combine_prefix(check_prefix(r)))
+  out <- Filter(
+    function(x) identical(combine_prefix(check_prefix(x)), rp),
+    all_bframel(bframe)
+  )
+  if (length(out) != 1L) {
+    stop2("Internal error while matching a sum-to-zero group-level block ",
+          "to its linear predictor.")
+  }
+  out[[1]]
+}
+
+# Effective scalar population-level prior for one coefficient.
+re_s2z_prior <- function(prior, bframe, class, coef = "") {
+  stopifnot(is.brmsprior(prior), is.bframel(bframe))
+  px <- check_prefix(bframe)
+  p <- subset2(prior, class = class, ls = px)
+  if (class == "b" && nzchar(coef)) {
+    pcoef <- subset2(p, coef = coef)
+    if (nrow(pcoef) == 1L && nzchar(pcoef$prior)) {
+      ans <- pcoef
+    } else {
+      ans <- subset2(p, coef = "")
+    }
+  } else {
+    ans <- subset2(p, coef = "")
+  }
+  if (!nrow(ans)) {
+    return(list(dist = "flat", location = 0, scale = 1, df = NA_real_))
+  }
+  if (nrow(ans) > 1L) {
+    # Follow stan_prior() and prefer the most specific populated base row.
+    take <- nzchar(ans$prior) | nzchar(ans$lb) | nzchar(ans$ub) |
+      nzchar(ans$tag)
+    ans <- ans[take, , drop = FALSE]
+    if (nrow(ans) > 1L) {
+      specificity <- rowSums(nzchar(ans[, vars_prefix(), drop = FALSE]))
+      ans <- ans[which.max(specificity), , drop = FALSE]
+    }
+  }
+  if (nrow(ans) && (nzchar(ans$lb) || nzchar(ans$ub))) {
+    stop2("The marginalized sum-to-zero parameterization does not yet ",
+          "support bounded population-level priors (coefficient '", coef,
+          "').")
+  }
+  if (nrow(ans) && nzchar(ans$tag)) {
+    stop2("The marginalized sum-to-zero parameterization does not yet ",
+          "support tagged population-level priors (coefficient '", coef,
+          "').")
+  }
+  value <- if (nrow(ans)) ans$prior else ""
+  parse_re_s2z_prior(value, coef = coef)
+}
+
+# Parse the conditionally Gaussian scalar priors supported by the fast path.
+parse_re_s2z_prior <- function(prior, coef = "") {
+  prior <- gsub("[[:space:]]+", "", prior)
+  if (!nzchar(prior)) {
+    return(list(dist = "flat", location = 0, scale = 1, df = NA_real_))
+  }
+  call <- try(str2lang(prior), silent = TRUE)
+  if (inherits(call, "try-error") || !is.call(call)) {
+    stop2("Prior '", prior, "' is not supported by the marginalized ",
+          "sum-to-zero parameterization (coefficient '", coef, "').")
+  }
+  dist <- as.character(call[[1]])
+  args <- as.list(call[-1])
+  number <- function(x) {
+    out <- suppressWarnings(as.numeric(deparse0(x)))
+    if (length(out) != 1L || !is.finite(out)) {
+      stop2("All arguments of population-level priors used with the ",
+            "marginalized sum-to-zero parameterization must currently be ",
+            "numeric constants (coefficient '", coef, "').")
+    }
+    out
+  }
+  if (dist == "std_normal" && !length(args)) {
+    out <- list(dist = "normal", location = 0, scale = 1, df = NA_real_)
+  } else if (dist == "normal" && length(args) == 2L) {
+    out <- list(
+      dist = "normal", location = number(args[[1]]),
+      scale = number(args[[2]]), df = NA_real_
+    )
+  } else if (dist == "student_t" && length(args) == 3L) {
+    out <- list(
+      dist = "student", df = number(args[[1]]),
+      location = number(args[[2]]), scale = number(args[[3]])
+    )
+  } else if (dist == "cauchy" && length(args) == 2L) {
+    out <- list(
+      dist = "student", df = 1, location = number(args[[1]]),
+      scale = number(args[[2]])
+    )
+  } else {
+    stop2(
+      "Prior '", prior, "' is not supported by the marginalized ",
+      "sum-to-zero parameterization. Supported population-level priors ",
+      "are flat, normal, student_t, and cauchy (coefficient '", coef, "')."
+    )
+  }
+  if (!(out$scale > 0) || out$dist == "student" && !(out$df > 0)) {
+    stop2("Scale and degrees-of-freedom arguments must be positive in ",
+          "population-level priors used with the marginalized sum-to-zero ",
+          "parameterization (coefficient '", coef, "').")
+  }
+  out
+}
+
+# Check fixed group scales before the Gaussian precision is constructed.
+validate_re_s2z_sd_prior <- function(prior, r) {
+  stopifnot(is.brmsprior(prior), is.reframe(r), has_rows(r))
+  px <- check_prefix(r)
+  p <- subset2(
+    prior, class = "sd", coef = c(r$coef, ""),
+    group = c(r$group[1], ""), ls = px
+  )
+  base_prior <- stan_base_prior(p)
+  for (coef in r$coef) {
+    pcoef <- subset2(p, coef = coef)
+    coef_prior <- pcoef$prior[nzchar(pcoef$prior)]
+    stopifnot(length(coef_prior) <= 1L)
+    value <- if (length(coef_prior)) {
+      coef_prior[[1]]
+    } else {
+      base_prior
+    }
+    if (!stan_is_constant_prior(value)) {
+      next
+    }
+    call <- try(str2lang(value), silent = TRUE)
+    fixed <- if (inherits(call, "try-error") || length(call) < 2L) {
+      NA_real_
+    } else {
+      suppressWarnings(as.numeric(deparse0(call[[2]])))
+    }
+    if (length(fixed) != 1L || !is.finite(fixed) || fixed <= 0) {
+      stop2("Group-level standard deviations fixed with 'constant' must ",
+            "be positive numeric scalars for gr(..., s2z = TRUE) ",
+            "(coefficient '", coef, "').")
+    }
+  }
+  invisible(NULL)
+}
+
+# Describe one local S2Z block, including the fixed/group design mapping.
+re_s2z_info <- function(bframe, prior = NULL) {
+  stopifnot(is.bframel(bframe))
+  if (!has_re_s2z(bframe)) {
+    return(NULL)
+  }
+  r <- bframe$frame$re[bframe$frame$re$s2z, , drop = FALSE]
+  ids <- unique(r$id)
+  if (length(ids) != 1L) {
+    stop2("Only one marginalized sum-to-zero group-level block is currently ",
+          "supported per linear predictor.")
+  }
+  r_id <- subset2(bframe$frame$re, id = ids)
+  if (!all(r_id$s2z)) {
+    stop2("All coefficients sharing a group-level ID must use the same ",
+          "'s2z' setting.")
+  }
+  r <- r_id
+  qnames <- bframe$frame$fe$vars
+  match_q <- match(r$coef, qnames)
+  if (anyNA(match_q)) {
+    missing <- collapse_comma(r$coef[is.na(match_q)])
+    stop2("Every sum-to-zero group-level coefficient must have a matching ",
+          "population-level design column. Missing: ", missing, ".")
+  }
+  out <- nlist(
+    id = ids, r, qnames, match_q,
+    center = bframe$frame$fe$center,
+    fixef = bframe$frame$fe$vars_stan,
+    p = usc(combine_prefix(check_prefix(bframe)))
+  )
+  if (!is.null(prior)) {
+    specs <- vector("list", length(qnames))
+    for (i in seq_along(qnames)) {
+      if (out$center && qnames[i] == "Intercept") {
+        specs[[i]] <- re_s2z_prior(prior, bframe, class = "Intercept")
+      } else {
+        specs[[i]] <- re_s2z_prior(
+          prior, bframe, class = "b", coef = qnames[i]
+        )
+      }
+    }
+    out$prior <- specs
+  }
+  out
+}
+
+# Validate S2Z structure after formulas, data, and priors have been resolved.
+validate_re_s2z <- function(bframe, prior) {
+  stopifnot(is.anybrmsframe(bframe), is.brmsprior(prior))
+  frames <- Filter(has_re_s2z, all_bframel(bframe))
+  if (!length(frames)) {
+    return(invisible(NULL))
+  }
+  if (get_sample_prior(prior) != "no") {
+    stop2("Argument 'sample_prior' is not yet supported together with ",
+          "gr(..., s2z = TRUE).")
+  }
+  ids <- integer()
+  for (x in frames) {
+    info <- re_s2z_info(x, prior = prior)
+    r <- info$r
+    if (info$id %in% ids) {
+      stop2("A marginalized sum-to-zero group-level ID cannot span multiple ",
+            "linear predictors.")
+    }
+    ids <- c(ids, info$id)
+    if (r$gtype[1] != "" || any(nzchar(r$type))) {
+      stop2("The marginalized sum-to-zero parameterization currently ",
+            "supports only ordinary 'gr' terms.")
+    }
+    if (nzchar(r$by[1]) || nzchar(r$cov[1]) ||
+        isTRUE(nzchar(r$gcall[[1]]$pw))) {
+      stop2("Arguments 'by', 'cov', and 'pw' are not yet supported together ",
+            "with gr(..., s2z = TRUE).")
+    }
+    if (length(unique(r$gn)) != 1L) {
+      stop2("A marginalized sum-to-zero covariance block must be specified ",
+            "in one group-level term.")
+    }
+    if (length(get_levels(r)[[r$group[1]]]) < 2L) {
+      stop2("The marginalized sum-to-zero parameterization requires at ",
+            "least two observed grouping levels.")
+    }
+    if (is_ordinal(x$family)) {
+      stop2("Ordinal thresholds are not yet supported together with ",
+            "gr(..., s2z = TRUE).")
+    }
+    if (order_intercepts(x)) {
+      stop2("Ordered mixture intercepts are not yet supported together with ",
+            "gr(..., s2z = TRUE).")
+    }
+    if (x$frame$fe$sparse || x$frame$fe$decomp != "none") {
+      stop2("Sparse and QR-decomposed population-level design matrices are ",
+            "not yet supported together with gr(..., s2z = TRUE).")
+    }
+    if (has_special_prior(prior, check_prefix(r), class = "sd") ||
+        has_special_prior(prior, x, class = "b")) {
+      stop2("Special priors are not yet supported together with ",
+            "gr(..., s2z = TRUE).")
+    }
+    validate_re_s2z_sd_prior(prior, r)
+  }
+  invisible(NULL)
+}
+
+# Validate that matched fixed and group columns are numerically identical.
+validate_re_s2z_design <- function(bframe, data) {
+  stopifnot(is.bframel(bframe))
+  if (!has_re_s2z(bframe)) {
+    return(invisible(NULL))
+  }
+  info <- re_s2z_info(bframe)
+  Z <- get_model_matrix(info$r$form[[1]], data = data, rename = FALSE)
+  X <- bframe$sdata$fe$X
+  if (ncol(Z) != nrow(info$r)) {
+    stop2("Internal mismatch in the sum-to-zero group-level design matrix.")
+  }
+  for (j in seq_len(ncol(Z))) {
+    same <- isTRUE(all.equal(
+      unname(Z[, j]), unname(X[, info$match_q[j]]),
+      tolerance = sqrt(.Machine$double.eps), check.attributes = FALSE
+    ))
+    if (!same) {
+      stop2("Population- and group-level design columns must be identical ",
+            "for gr(..., s2z = TRUE). Mismatch for coefficient '",
+            info$r$coef[j], "'.")
+    }
+  }
+  invisible(NULL)
+}

--- a/R/re-s2z.R
+++ b/R/re-s2z.R
@@ -1,4 +1,4 @@
-# Helpers for the marginalized sum-to-zero parameterization of group effects
+# Helpers for the physical sum-to-zero parameterization of group effects
 
 # Does a local linear predictor contain a sum-to-zero group-level block?
 has_re_s2z <- function(x) {
@@ -64,12 +64,12 @@ re_s2z_prior <- function(prior, bframe, class, coef = "") {
     }
   }
   if (nrow(ans) && (nzchar(ans$lb) || nzchar(ans$ub))) {
-    stop2("The marginalized sum-to-zero parameterization does not yet ",
+    stop2("The sum-to-zero parameterization does not yet ",
           "support bounded population-level priors (coefficient '", coef,
           "').")
   }
   if (nrow(ans) && nzchar(ans$tag)) {
-    stop2("The marginalized sum-to-zero parameterization does not yet ",
+    stop2("The sum-to-zero parameterization does not yet ",
           "support tagged population-level priors (coefficient '", coef,
           "').")
   }
@@ -85,7 +85,7 @@ parse_re_s2z_prior <- function(prior, coef = "") {
   }
   call <- try(str2lang(prior), silent = TRUE)
   if (inherits(call, "try-error") || !is.call(call)) {
-    stop2("Prior '", prior, "' is not supported by the marginalized ",
+    stop2("Prior '", prior, "' is not supported by the ",
           "sum-to-zero parameterization (coefficient '", coef, "').")
   }
   dist <- as.character(call[[1]])
@@ -94,7 +94,7 @@ parse_re_s2z_prior <- function(prior, coef = "") {
     out <- suppressWarnings(as.numeric(deparse0(x)))
     if (length(out) != 1L || !is.finite(out)) {
       stop2("All arguments of population-level priors used with the ",
-            "marginalized sum-to-zero parameterization must currently be ",
+            "sum-to-zero parameterization must currently be ",
             "numeric constants (coefficient '", coef, "').")
     }
     out
@@ -118,14 +118,14 @@ parse_re_s2z_prior <- function(prior, coef = "") {
     )
   } else {
     stop2(
-      "Prior '", prior, "' is not supported by the marginalized ",
+      "Prior '", prior, "' is not supported by the ",
       "sum-to-zero parameterization. Supported population-level priors ",
       "are flat, normal, student_t, and cauchy (coefficient '", coef, "')."
     )
   }
   if (!(out$scale > 0) || out$dist == "student" && !(out$df > 0)) {
     stop2("Scale and degrees-of-freedom arguments must be positive in ",
-          "population-level priors used with the marginalized sum-to-zero ",
+          "population-level priors used with the sum-to-zero ",
           "parameterization (coefficient '", coef, "').")
   }
   out
@@ -176,7 +176,7 @@ re_s2z_info <- function(bframe, prior = NULL) {
   r <- bframe$frame$re[bframe$frame$re$s2z, , drop = FALSE]
   ids <- unique(r$id)
   if (length(ids) != 1L) {
-    stop2("Only one marginalized sum-to-zero group-level block is currently ",
+    stop2("Only one sum-to-zero group-level block is currently ",
           "supported per linear predictor.")
   }
   r_id <- subset2(bframe$frame$re, id = ids)
@@ -230,12 +230,12 @@ validate_re_s2z <- function(bframe, prior) {
     info <- re_s2z_info(x, prior = prior)
     r <- info$r
     if (info$id %in% ids) {
-      stop2("A marginalized sum-to-zero group-level ID cannot span multiple ",
+      stop2("A sum-to-zero group-level ID cannot span multiple ",
             "linear predictors.")
     }
     ids <- c(ids, info$id)
     if (r$gtype[1] != "" || any(nzchar(r$type))) {
-      stop2("The marginalized sum-to-zero parameterization currently ",
+      stop2("The sum-to-zero parameterization currently ",
             "supports only ordinary 'gr' terms.")
     }
     if (nzchar(r$by[1]) || nzchar(r$cov[1]) ||
@@ -244,11 +244,11 @@ validate_re_s2z <- function(bframe, prior) {
             "with gr(..., s2z = TRUE).")
     }
     if (length(unique(r$gn)) != 1L) {
-      stop2("A marginalized sum-to-zero covariance block must be specified ",
+      stop2("A sum-to-zero covariance block must be specified ",
             "in one group-level term.")
     }
     if (length(get_levels(r)[[r$group[1]]]) < 2L) {
-      stop2("The marginalized sum-to-zero parameterization requires at ",
+      stop2("The sum-to-zero parameterization requires at ",
             "least two observed grouping levels.")
     }
     if (is_ordinal(x$family)) {

--- a/R/re-s2z.R
+++ b/R/re-s2z.R
@@ -168,16 +168,22 @@ validate_re_s2z_sd_prior <- function(prior, r) {
 }
 
 # Describe one local S2Z block, including the fixed/group design mapping.
-re_s2z_info <- function(bframe, prior = NULL) {
+re_s2z_info <- function(bframe, prior = NULL, id = NULL) {
   stopifnot(is.bframel(bframe))
   if (!has_re_s2z(bframe)) {
     return(NULL)
   }
   r <- bframe$frame$re[bframe$frame$re$s2z, , drop = FALSE]
   ids <- unique(r$id)
-  if (length(ids) != 1L) {
-    stop2("Only one sum-to-zero group-level block is currently ",
-          "supported per linear predictor.")
+  if (is.null(id) && length(ids) != 1L) {
+    stop2("An explicit group-level ID is required when describing multiple ",
+          "sum-to-zero blocks.")
+  }
+  if (!is.null(id)) {
+    if (length(id) != 1L || !id %in% ids) {
+      stop2("Invalid sum-to-zero group-level ID.")
+    }
+    ids <- id
   }
   r_id <- subset2(bframe$frame$re, id = ids)
   if (!all(r_id$s2z)) {
@@ -214,10 +220,67 @@ re_s2z_info <- function(bframe, prior = NULL) {
   out
 }
 
+# Describe all local S2Z blocks in one linear predictor. Blocks retain their
+# own covariance models but share one joint omitted-mean system.
+re_s2z_infos <- function(bframe, prior = NULL) {
+  stopifnot(is.bframel(bframe))
+  if (!has_re_s2z(bframe)) {
+    return(list())
+  }
+  ids <- unique(bframe$frame$re$id[bframe$frame$re$s2z])
+  lapply(ids, function(id) re_s2z_info(bframe, prior = prior, id = id))
+}
+
+# Construct an S2Z design matrix in covariance-block coefficient order. A
+# block may be assembled from multiple grouping terms that share an ID.
+re_s2z_design_matrix <- function(bframe, data, id = NULL) {
+  stopifnot(is.bframel(bframe))
+  info <- re_s2z_info(bframe, id = id)
+  if (is.null(info)) {
+    return(matrix(numeric(), nrow = nrow(data), ncol = 0L))
+  }
+  r <- info$r
+  out <- matrix(NA_real_, nrow = nrow(data), ncol = nrow(r))
+  for (gn in unique(r$gn)) {
+    take <- which(r$gn == gn)
+    rg <- r[take, , drop = FALSE]
+    Zg <- get_model_matrix(rg$form[[1]], data = data, rename = FALSE)
+    if (ncol(Zg) != length(take)) {
+      stop2("Internal mismatch in the sum-to-zero group-level design matrix.")
+    }
+    out[, take] <- Zg
+  }
+  colnames(out) <- r$coef
+  out
+}
+
 # Validate S2Z structure after formulas, data, and priors have been resolved.
 validate_re_s2z <- function(bframe, prior) {
   stopifnot(is.anybrmsframe(bframe), is.brmsprior(prior))
-  frames <- Filter(has_re_s2z, all_bframel(bframe))
+  all_frames <- all_bframel(bframe)
+  # IDs may couple ordinary group effects across linear predictors. Such a
+  # coupling is not compatible with the local S2Z omitted-mean systems, even
+  # if only one occurrence of the shared ID requests S2Z. Check all terms
+  # before filtering to S2Z-containing predictors so mixed conventional/S2Z
+  # uses fail with the same clear error in either predictor order.
+  s2z_ids <- unique(unlist(lapply(all_frames, function(x) {
+    r <- x$frame$re
+    if (!has_rows(r)) {
+      return(integer())
+    }
+    r$id[r$s2z]
+  }), use.names = FALSE))
+  for (id in s2z_ids) {
+    n_frames <- sum(vapply(all_frames, function(x) {
+      r <- x$frame$re
+      has_rows(r) && id %in% r$id
+    }, logical(1)))
+    if (n_frames > 1L) {
+      stop2("A sum-to-zero group-level ID cannot span multiple ",
+            "linear predictors.")
+    }
+  }
+  frames <- Filter(has_re_s2z, all_frames)
   if (!length(frames)) {
     return(invisible(NULL))
   }
@@ -227,48 +290,61 @@ validate_re_s2z <- function(bframe, prior) {
   }
   ids <- integer()
   for (x in frames) {
-    info <- re_s2z_info(x, prior = prior)
-    r <- info$r
-    if (info$id %in% ids) {
-      stop2("A sum-to-zero group-level ID cannot span multiple ",
-            "linear predictors.")
+    infos <- re_s2z_infos(x, prior = prior)
+    for (info in infos) {
+      r <- info$r
+      if (info$id %in% ids) {
+        stop2("A sum-to-zero group-level ID cannot span multiple ",
+              "linear predictors.")
+      }
+      ids <- c(ids, info$id)
+      if (length(unique(r$group)) != 1L) {
+        stop2("All coefficients sharing a sum-to-zero group-level ID must ",
+              "use the same grouping factor.")
+      }
+      if (length(unique(r$dist)) != 1L) {
+        stop2("All coefficients sharing a group-level ID must use the same ",
+              "group-level distribution.")
+      }
+      if (length(unique(r$cor)) != 1L) {
+        stop2("All coefficients sharing a group-level ID must use the same ",
+              "'cor' setting.")
+      }
+      if (any(nzchar(r$gtype)) || any(nzchar(r$type))) {
+        stop2("The sum-to-zero parameterization currently ",
+              "supports only ordinary 'gr' terms.")
+      }
+      has_pw <- any(vapply(r$gcall, function(gcall) {
+        isTRUE(nzchar(gcall$pw))
+      }, logical(1)))
+      if (any(nzchar(r$by), na.rm = TRUE) ||
+          any(nzchar(r$cov), na.rm = TRUE) || has_pw) {
+        stop2("Arguments 'by', 'cov', and 'pw' are not yet supported ",
+              "together with gr(..., s2z = TRUE).")
+      }
+      if (length(get_levels(r)[[r$group[1]]]) < 2L) {
+        stop2("The sum-to-zero parameterization requires at ",
+              "least two observed grouping levels.")
+      }
+      if (is_ordinal(x$family)) {
+        stop2("Ordinal thresholds are not yet supported together with ",
+              "gr(..., s2z = TRUE).")
+      }
+      if (order_intercepts(x)) {
+        stop2("Ordered mixture intercepts are not yet supported together ",
+              "with gr(..., s2z = TRUE).")
+      }
+      if (x$frame$fe$sparse || x$frame$fe$decomp != "none") {
+        stop2("Sparse and QR-decomposed population-level design matrices ",
+              "are not yet supported together with gr(..., s2z = TRUE).")
+      }
+      if (has_special_prior(prior, check_prefix(r), class = "sd") ||
+          has_special_prior(prior, x, class = "b")) {
+        stop2("Special priors are not yet supported together with ",
+              "gr(..., s2z = TRUE).")
+      }
+      validate_re_s2z_sd_prior(prior, r)
     }
-    ids <- c(ids, info$id)
-    if (r$gtype[1] != "" || any(nzchar(r$type))) {
-      stop2("The sum-to-zero parameterization currently ",
-            "supports only ordinary 'gr' terms.")
-    }
-    if (nzchar(r$by[1]) || nzchar(r$cov[1]) ||
-        isTRUE(nzchar(r$gcall[[1]]$pw))) {
-      stop2("Arguments 'by', 'cov', and 'pw' are not yet supported together ",
-            "with gr(..., s2z = TRUE).")
-    }
-    if (length(unique(r$gn)) != 1L) {
-      stop2("A sum-to-zero covariance block must be specified ",
-            "in one group-level term.")
-    }
-    if (length(get_levels(r)[[r$group[1]]]) < 2L) {
-      stop2("The sum-to-zero parameterization requires at ",
-            "least two observed grouping levels.")
-    }
-    if (is_ordinal(x$family)) {
-      stop2("Ordinal thresholds are not yet supported together with ",
-            "gr(..., s2z = TRUE).")
-    }
-    if (order_intercepts(x)) {
-      stop2("Ordered mixture intercepts are not yet supported together with ",
-            "gr(..., s2z = TRUE).")
-    }
-    if (x$frame$fe$sparse || x$frame$fe$decomp != "none") {
-      stop2("Sparse and QR-decomposed population-level design matrices are ",
-            "not yet supported together with gr(..., s2z = TRUE).")
-    }
-    if (has_special_prior(prior, check_prefix(r), class = "sd") ||
-        has_special_prior(prior, x, class = "b")) {
-      stop2("Special priors are not yet supported together with ",
-            "gr(..., s2z = TRUE).")
-    }
-    validate_re_s2z_sd_prior(prior, r)
   }
   invisible(NULL)
 }
@@ -279,21 +355,22 @@ validate_re_s2z_design <- function(bframe, data) {
   if (!has_re_s2z(bframe)) {
     return(invisible(NULL))
   }
-  info <- re_s2z_info(bframe)
-  Z <- get_model_matrix(info$r$form[[1]], data = data, rename = FALSE)
   X <- bframe$sdata$fe$X
-  if (ncol(Z) != nrow(info$r)) {
-    stop2("Internal mismatch in the sum-to-zero group-level design matrix.")
-  }
-  for (j in seq_len(ncol(Z))) {
-    same <- isTRUE(all.equal(
-      unname(Z[, j]), unname(X[, info$match_q[j]]),
-      tolerance = sqrt(.Machine$double.eps), check.attributes = FALSE
-    ))
-    if (!same) {
-      stop2("Population- and group-level design columns must be identical ",
-            "for gr(..., s2z = TRUE). Mismatch for coefficient '",
-            info$r$coef[j], "'.")
+  for (info in re_s2z_infos(bframe)) {
+    Z <- re_s2z_design_matrix(bframe, data = data, id = info$id)
+    if (ncol(Z) != nrow(info$r)) {
+      stop2("Internal mismatch in the sum-to-zero group-level design matrix.")
+    }
+    for (j in seq_len(ncol(Z))) {
+      same <- isTRUE(all.equal(
+        unname(Z[, j]), unname(X[, info$match_q[j]]),
+        tolerance = sqrt(.Machine$double.eps), check.attributes = FALSE
+      ))
+      if (!same) {
+        stop2("Population- and group-level design columns must be identical ",
+              "for gr(..., s2z = TRUE). Mismatch for coefficient '",
+              info$r$coef[j], "'.")
+      }
     }
   }
   invisible(NULL)

--- a/R/re-s2z.R
+++ b/R/re-s2z.R
@@ -68,9 +68,12 @@ re_s2z_context <- function(bframe, r = NULL, coef = NULL, prior = NULL) {
       group <- paste(groups, collapse = ", ")
     }
     public_id <- r$gcall[[1L]]$id %||% NA
+    if (length(public_id) == 1L && !is.na(public_id)) {
+      public_id <- trimws(as.character(public_id))
+    }
     if (length(public_id) == 1L && !is.na(public_id) &&
-        nzchar(as.character(public_id))) {
-      id <- as.character(public_id)
+        nzchar(public_id)) {
+      id <- public_id
     } else {
       ids <- unique(r$id)
       if (length(ids)) {
@@ -105,6 +108,25 @@ format_re_s2z_context <- function(context) {
     out <- paste0(out, ", prior '", as.character(context$prior), "'")
   }
   out
+}
+
+# Suggest stable, predictor-local IDs when one public ID was reused across
+# linear predictors. These labels are diagnostic examples only; they do not
+# affect the generated model.
+re_s2z_local_id_examples <- function(contexts) {
+  stopifnot(is.list(contexts), length(contexts) > 1L)
+  labels <- vapply(contexts, function(context) {
+    predictor <- if (context$nlpar != "<none>") {
+      context$nlpar
+    } else {
+      context$dpar
+    }
+    label <- paste(context$response, predictor, "s2z", sep = "_")
+    label <- gsub("[^[:alnum:]_]+", "_", label)
+    gsub("^_+|_+$", "", label)
+  }, character(1))
+  labels <- make.unique(labels, sep = "_")
+  paste0('`id = "', labels, '"`', collapse = ", ")
 }
 
 stop_re_s2z <- function(context, capability, problem, remedy) {
@@ -560,13 +582,28 @@ validate_re_s2z_structure <- function(bframe, data) {
     has_cov <- any(nzchar(r$cov), na.rm = TRUE)
     if (has_by || has_cov || has_pw) {
       capability <- if (has_by) "by" else if (has_cov) "cov" else "pw"
+      remedy <- switch(
+        capability,
+        by = paste0(
+          "remove 'by' or use s2z = FALSE to retain separate ",
+          "variance-covariance matrices for its levels."
+        ),
+        cov = paste0(
+          "remove 'cov' to use independent grouping levels, or use ",
+          "s2z = FALSE to retain the supplied group covariance matrix."
+        ),
+        pw = paste0(
+          "remove 'pw' or use s2z = FALSE to retain the group-level ",
+          "prior weights."
+        )
+      )
       stop_re_s2z(
         context, capability,
         paste0(
-          "Arguments 'by', 'cov', and 'pw' are not yet supported together ",
+          "Argument '", capability, "' is not yet supported together ",
           "with gr(..., s2z = TRUE)."
         ),
-        "remove the unsupported argument or use s2z = FALSE for this term."
+        remedy
       )
     }
     if (isTRUE(bframe$frame$fe$sparse)) {
@@ -719,15 +756,33 @@ validate_re_s2z_prior_global <- function(bframe, prior) {
       has_rows(r) && id %in% r$id
     }, all_frames)
     if (length(occurrences) > 1L) {
-      first <- occurrences[[1L]]
-      r <- subset2(first$frame$re, id = id)
+      contexts <- lapply(occurrences, function(x) {
+        re_s2z_context(x, r = subset2(x$frame$re, id = id))
+      })
+      affected <- paste0(
+        "Affected linear predictors:\n  - ",
+        paste(
+          vapply(contexts, format_re_s2z_context, character(1)),
+          collapse = "\n  - "
+        )
+      )
+      public_id <- contexts[[1L]]$id
       stop_re_s2z(
-        re_s2z_context(first, r = r), "cross_predictor_id",
+        contexts[[1L]], "cross_predictor_id",
         paste0(
           "A sum-to-zero group-level ID cannot span multiple linear ",
-          "predictors."
+          "predictors.\n", affected
         ),
-        "assign a distinct group-level ID within each linear predictor."
+        paste0(
+          "use a distinct ID in every listed linear predictor (for example, ",
+          re_s2z_local_id_examples(contexts), "). For `mvbind(...)` or ",
+          "category shorthand, omit the shared `| ", public_id,
+          " |` tag or `id = \"", public_id, "\"` so brms allocates ",
+          "predictor-local IDs; alternatively, expand the model into ",
+          "separate `bf()` response formulas with those distinct IDs. ",
+          "These rewrites do not retain cross-predictor group-effect ",
+          "correlations; use s2z = FALSE if those correlations are required."
+        )
       )
     }
   }

--- a/R/stan-likelihood.R
+++ b/R/stan-likelihood.R
@@ -1367,6 +1367,15 @@ args_glm_primitive <- function(bterms, threads = NULL, ...) {
   }
   x <- glue("X{sfx_X}{resp}{slice}")
   beta <- glue("b{sfx_b}{resp}")
+  if (has_re_s2z(bterms)) {
+    if (center_X) {
+      beta <- glue(
+        "tail(theta_s2z{resp}, {length(bterms$frame$fe$vars_stan)})"
+      )
+    } else {
+      beta <- glue("theta_s2z{resp}")
+    }
+  }
   if (has_special_terms(bterms)) {
     # the intercept vector will contain all the remaining terms
     alpha <- glue("mu{resp}")

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -843,6 +843,49 @@ stan_re <- function(bframe, prior, normalize, ...) {
   out
 }
 
+# The separated Gaussian mean/contrast law permits a Matheron update in the
+# population-coordinate dimension instead of a complete square in the sum of
+# all block dimensions. Conditional Student-t population priors remain
+# eligible because their scale-mixture variables make them proper Gaussians.
+# Student-t group effects do not separate their omitted means from their
+# contrasts and therefore use the general joint system.
+.stan_re_s2z_joint_matheron_info <- function(set) {
+  infos <- set$infos
+  if (length(infos) <= 1L) {
+    return(NULL)
+  }
+  separated <- all(vapply(infos, function(info) {
+    all(info$r$dist == "gaussian")
+  }, logical(1)))
+  if (!separated) {
+    return(NULL)
+  }
+  # Only rows reached by an omitted group mean can couple blocks. A flat
+  # population prior removes its row from that conditioning system, while a
+  # proper row outside the group design remains an ordinary independent prior.
+  active <- unique(unlist(lapply(infos, function(info) {
+    rows <- info$match_q
+    if (info$center && any(info$r$coef != "Intercept")) {
+      rows <- c(rows, 1L)
+    }
+    rows
+  }), use.names = FALSE))
+  proper <- which(vapply(infos[[1L]]$prior, function(spec) {
+    spec$dist %in% c("normal", "student")
+  }, logical(1)))
+  P <- sort(intersect(active, proper))
+  total_M <- sum(vapply(infos, function(info) nrow(info$r), integer(1)))
+  # The general complete square is already preferable at equal or lower
+  # dimension. Strict inequality makes this dispatch a genuine fast path.
+  if (length(P) >= total_M) {
+    return(NULL)
+  }
+  list(P = P, inactive = setdiff(proper, P), total_M = total_M)
+}
+
+.stan_re_s2z_joint_uses_matheron <- function(set) {
+  !is.null(.stan_re_s2z_joint_matheron_info(set))
+}
 # Stan code local to one covariance block participating in a joint S2Z
 # omitted-mean system. The block contributes its physical zero-sum effects and
 # the Gaussian normal equations for its omitted mean in reference-whitened
@@ -866,6 +909,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
   r_s2z <- glue("r_s2z_{idp}_{r$cn}")
   is_cor <- M > 1L && isTRUE(r$cor[1])
   is_student <- identical(r$dist[1], "student")
+  use_matheron <- .stan_re_s2z_joint_uses_matheron(set)
   if (is_cor) {
     str_add(out$data) <- glue(
       "  int<lower=1> NC_{id};  // number of group-level correlations\n"
@@ -891,8 +935,13 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "  matrix[N_{id}, M_{id}] r_s2z_{id};\n",
     "  matrix[{q}, M_{id}] H_s2z_{id};\n",
     "  matrix[M_{id}, M_{id}] L_Sigma_s2z_{id};\n",
-    "  matrix[M_{id}, M_{id}] P_group_s2z_{id};\n",
-    "  vector[M_{id}] h_group_s2z_{id};\n",
+    str_if(
+      !use_matheron,
+      glue(
+        "  matrix[M_{id}, M_{id}] P_group_s2z_{id};\n",
+        "  vector[M_{id}] h_group_s2z_{id};\n"
+      )
+    ),
     "  real<lower=0> group_quad_s2z_{id};\n",
     str_if(
       is_student,
@@ -945,7 +994,23 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "  }}\n"
   )
 
-  if (is_cor) {
+  if (use_matheron && is_cor) {
+    str_add(out$tpar_comp) <- glue(
+      "  {{\n",
+      "    matrix[M_{id}, N_{id}] white_group_s2z = ",
+      "mdivide_left_tri_low(L_Sigma_s2z_{id}, r_s2z_{id}');\n",
+      "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z));\n",
+      "  }}\n"
+    )
+  } else if (use_matheron) {
+    str_add(out$tpar_comp) <- glue(
+      "  {{\n",
+      "    matrix[N_{id}, M_{id}] white_group_s2z = r_s2z_{id} ./ ",
+      "rep_matrix(sd_{id}', N_{id});\n",
+      "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z));\n",
+      "  }}\n"
+    )
+  } else if (is_cor) {
     group_info <- if (is_student) {
       glue("sum(group_prec_s2z_{id})")
     } else {
@@ -1013,6 +1078,375 @@ stan_re <- function(bframe, prior, normalize, ...) {
   out
 }
 
+# Fast separated Gaussian path for multiple S2Z blocks. Rather than factoring
+# the covariance of every omitted block mean, it factors only the induced
+# covariance of theta and uses one Matheron update to recover all conventional
+# means and population coefficients jointly.
+.stan_re_s2z_joint_matheron <- function(set, prior, threads, normalize, ...) {
+  out <- list(tpar_prior = "")
+  infos <- set$infos
+  matheron <- .stan_re_s2z_joint_matheron_info(set)
+  stopifnot(!is.null(matheron))
+  info <- infos[[1L]]
+  q <- length(info$qnames)
+  P <- matheron$P
+  inactive <- matheron$inactive
+  rdim <- length(P)
+  set_id <- set$set_id
+  p <- info$p
+  lpdf <- stan_lpdf_name(normalize)
+
+  # A Student-t population prior is conditionally Gaussian, so the same
+  # update applies after drawing its usual inverse-chi-square mixture scale.
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "student") {
+      str_add(out$par) <- glue(
+        "  real<lower=0> udf_b_s2z{p}_{k};",
+        "  // mixing variable for population coefficient {k}\n"
+      )
+      str_add(out$tpar_prior) <- glue(
+        "  lprior += inv_chi_square_{lpdf}(udf_b_s2z{p}_{k} | ",
+        "{stan_s2z_number(spec$df)});\n"
+      )
+    }
+  }
+
+  str_add(out$tpar_def) <- glue(
+    "  // fast Gaussian Matheron system for S2Z blocks ",
+    "{paste(set$ids, collapse = ', ')}\n",
+    "  vector[{q}] prior_mean_s2z_{set_id};\n",
+    "  vector<lower=0>[{q}] prior_scale_s2z_{set_id};\n",
+    str_if(
+      rdim == 1L,
+      glue(
+        "  real<lower=0> W_matheron_s2z_{set_id};\n",
+        "  real<lower=0> sqrt_W_matheron_s2z_{set_id};\n",
+        "  real theta_white_matheron_s2z_{set_id};\n"
+      )
+    ),
+    str_if(
+      rdim > 1L,
+      glue(
+        "  matrix[{rdim}, {rdim}] W_matheron_s2z_{set_id};\n",
+        "  matrix[{rdim}, {rdim}] L_W_matheron_s2z_{set_id};\n",
+        "  vector[{rdim}] theta_white_matheron_s2z_{set_id};\n"
+      )
+    ),
+    "  real joint_quad_s2z_{set_id};\n"
+  )
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    str_add(out$tpar_comp) <- glue(
+      "  prior_mean_s2z_{set_id}[{k}] = ",
+      "{stan_s2z_number(spec$location)};\n"
+    )
+    cond_scale <- if (spec$dist == "flat") {
+      "1.0"
+    } else if (spec$dist == "normal") {
+      stan_s2z_number(spec$scale)
+    } else {
+      glue(
+        "{stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k})"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  prior_scale_s2z_{set_id}[{k}] = {cond_scale};\n"
+    )
+  }
+  if (rdim == 1L) {
+    str_add(out$tpar_comp) <- glue(
+      "  W_matheron_s2z_{set_id} = ",
+      "square(prior_scale_s2z_{set_id}[{P}]);\n"
+    )
+  } else if (rdim > 1L) {
+    str_add(out$tpar_comp) <- glue(
+      "  W_matheron_s2z_{set_id} = rep_matrix(0.0, {rdim}, {rdim});\n"
+    )
+    for (a in seq_len(rdim)) {
+      str_add(out$tpar_comp) <- glue(
+        "  W_matheron_s2z_{set_id}[{a}, {a}] = ",
+        "square(prior_scale_s2z_{set_id}[{P[a]}]);\n"
+      )
+    }
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  joint_quad_s2z_{set_id} = 0.0;\n"
+  )
+  for (b in seq_along(infos)) {
+    id <- infos[[b]]$id
+    if (rdim == 1L) {
+      str_add(out$tpar_comp) <- glue(
+        "  W_matheron_s2z_{set_id} += dot_self(",
+        "H_s2z_{id}[{P}, ] * L_Sigma_s2z_{id}) / (1.0 * N_{id});\n"
+      )
+    } else if (rdim > 1L) {
+      str_add(out$tpar_comp) <- glue(
+        "  {{\n",
+        "    matrix[{rdim}, M_{id}] H_active_s2z;\n"
+      )
+      for (a in seq_len(rdim)) {
+        str_add(out$tpar_comp) <- glue(
+          "    H_active_s2z[{a}, ] = H_s2z_{id}[{P[a]}, ];\n"
+        )
+      }
+      str_add(out$tpar_comp) <- glue(
+        "    W_matheron_s2z_{set_id} += tcrossprod(",
+        "H_active_s2z * L_Sigma_s2z_{id}) / (1.0 * N_{id});\n",
+        "  }}\n"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  joint_quad_s2z_{set_id} += group_quad_s2z_{id};\n"
+    )
+  }
+  if (rdim == 1L) {
+    str_add(out$tpar_comp) <- glue(
+      "  sqrt_W_matheron_s2z_{set_id} = sqrt(W_matheron_s2z_{set_id});\n",
+      "  theta_white_matheron_s2z_{set_id} = ",
+      "(theta_s2z{p}[{P}] - prior_mean_s2z_{set_id}[{P}]) / ",
+      "sqrt_W_matheron_s2z_{set_id};\n"
+    )
+  } else if (rdim > 1L) {
+    str_add(out$tpar_comp) <- glue(
+      "  L_W_matheron_s2z_{set_id} = ",
+      "cholesky_decompose(W_matheron_s2z_{set_id});\n",
+      "  {{\n",
+      "    vector[{rdim}] theta_difference_s2z;\n"
+    )
+    for (a in seq_len(rdim)) {
+      str_add(out$tpar_comp) <- glue(
+        "    theta_difference_s2z[{a}] = theta_s2z{p}[{P[a]}] - ",
+        "prior_mean_s2z_{set_id}[{P[a]}];\n"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "    theta_white_matheron_s2z_{set_id} = mdivide_left_tri_low(",
+      "L_W_matheron_s2z_{set_id}, theta_difference_s2z);\n",
+      "  }}\n"
+    )
+  }
+
+  for (k in inactive) {
+    str_add(out$tpar_prior) <- glue(
+      "  lprior += normal_{lpdf}(theta_s2z{p}[{k}] | ",
+      "prior_mean_s2z_{set_id}[{k}], prior_scale_s2z_{set_id}[{k}]);\n"
+    )
+  }
+  str_add(out$tpar_prior) <- glue(
+    "  lprior += -0.5 * joint_quad_s2z_{set_id}\n"
+  )
+  if (rdim == 1L) {
+    str_add(out$tpar_prior) <- glue(
+      "    - 0.5 * square(theta_white_matheron_s2z_{set_id})\n",
+      "    - log(sqrt_W_matheron_s2z_{set_id})\n"
+    )
+  } else if (rdim > 1L) {
+    str_add(out$tpar_prior) <- glue(
+      "    - 0.5 * dot_self(theta_white_matheron_s2z_{set_id})\n",
+      "    - sum(log(diagonal(L_W_matheron_s2z_{set_id})))\n"
+    )
+  }
+  for (b in seq_along(infos)) {
+    id <- infos[[b]]$id
+    str_add(out$tpar_prior) <- glue(
+      "    - (N_{id} - 1) * ",
+      "sum(log(diagonal(L_Sigma_s2z_{id})))\n"
+    )
+    if (normalize) {
+      str_add(out$tpar_prior) <- glue(
+        "    - 0.5 * (N_{id} - 1) * M_{id} * log(2 * pi())\n"
+      )
+    }
+  }
+  if (normalize && rdim > 0L) {
+    str_add(out$tpar_prior) <- glue(
+      "    - 0.5 * {rdim} * log(2 * pi())\n"
+    )
+  }
+  str_add(out$tpar_prior) <- "  ;\n"
+
+  str_add(out$gen_def) <- glue(
+    "  vector[{q}] q_recovered_s2z_{set_id};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_def) <- glue(
+      "  real Intercept{p};\n",
+      str_if(length(info$fixef), glue("  vector[Kc{p}] b{p};\n")),
+      "  real b{p}_Intercept;\n"
+    )
+  } else {
+    str_add(out$gen_def) <- glue("  vector[{q}] b{p};\n")
+  }
+  for (b in seq_along(infos)) {
+    r <- infos[[b]]$r
+    id <- infos[[b]]$id
+    idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+    r_public <- glue("r_{idp}_{r$cn}")
+    is_cor <- nrow(r) > 1L && isTRUE(r$cor[1])
+    str_add(out$gen_def) <- glue(
+      "  vector[M_{id}] mean_r_s2z_{id};\n"
+    )
+    if (is_cor) {
+      str_add(out$gen_def) <- glue(
+        "  matrix[N_{id}, M_{id}] r_{id};\n"
+      )
+    }
+    str_add(out$gen_def) <- cglue(
+      "  vector[N_{id}] {r_public};\n"
+    )
+    if (is_cor) {
+      str_add(out$gen_def) <- glue(
+        "  // compute group-level correlations\n",
+        "  corr_matrix[M_{id}] Cor_{id}",
+        " = multiply_lower_tri_self_transpose(L_{id});\n",
+        "  vector<lower=-1,upper=1>[NC_{id}] cor_{id};\n"
+      )
+    }
+  }
+
+  # Draw every m_f* and, when needed, the proper active part of beta*. One
+  # shared innovation conditions them on theta. Flat active coordinates do not
+  # enter W; beta is recovered as theta - sum(H_f m_f), which also enforces the
+  # predictor identity to floating-point precision.
+  str_add(out$gen_comp) <- glue(
+    "  {{\n"
+  )
+  if (rdim > 0L) {
+    str_add(out$gen_comp) <- glue(
+      "    vector[{rdim}] theta_star_s2z;\n",
+      "    vector[{rdim}] delta_s2z;\n"
+    )
+    for (a in seq_len(rdim)) {
+      str_add(out$gen_comp) <- glue(
+        "    theta_star_s2z[{a}] = prior_mean_s2z_{set_id}[{P[a]}] + ",
+        "prior_scale_s2z_{set_id}[{P[a]}] * std_normal_rng();\n"
+      )
+    }
+  }
+  for (b in seq_along(infos)) {
+    id <- infos[[b]]$id
+    str_add(out$gen_comp) <- glue(
+      "    {{\n",
+      "      vector[M_{id}] z_mean_s2z;\n",
+      "      for (k in 1:M_{id}) z_mean_s2z[k] = std_normal_rng();\n",
+      "      mean_r_s2z_{id} = L_Sigma_s2z_{id} * z_mean_s2z / ",
+      "sqrt(1.0 * N_{id});\n",
+      "    }}\n"
+    )
+    if (rdim > 0L) {
+      for (a in seq_len(rdim)) {
+        str_add(out$gen_comp) <- glue(
+          "    theta_star_s2z[{a}] += dot_product(",
+          "H_s2z_{id}[{P[a]}, ], mean_r_s2z_{id}');\n"
+        )
+      }
+    }
+  }
+  if (rdim == 1L) {
+    str_add(out$gen_comp) <- glue(
+      "    delta_s2z[1] = (theta_s2z{p}[{P}] - theta_star_s2z[1]) / ",
+      "W_matheron_s2z_{set_id};\n"
+    )
+  } else if (rdim > 1L) {
+    str_add(out$gen_comp) <- glue(
+      "    {{\n",
+      "      vector[{rdim}] theta_innovation_s2z;\n",
+      "      vector[{rdim}] forward_solve_s2z;\n"
+    )
+    for (a in seq_len(rdim)) {
+      str_add(out$gen_comp) <- glue(
+        "      theta_innovation_s2z[{a}] = theta_s2z{p}[{P[a]}] - ",
+        "theta_star_s2z[{a}];\n"
+      )
+    }
+    str_add(out$gen_comp) <- glue(
+      "      forward_solve_s2z = mdivide_left_tri_low(",
+      "L_W_matheron_s2z_{set_id}, theta_innovation_s2z);\n",
+      "      delta_s2z = (mdivide_right_tri_low(",
+      "forward_solve_s2z', L_W_matheron_s2z_{set_id}))';\n",
+      "    }}\n"
+    )
+  }
+  str_add(out$gen_comp) <- glue(
+    "    q_recovered_s2z_{set_id} = theta_s2z{p};\n"
+  )
+  for (b in seq_along(infos)) {
+    r <- infos[[b]]$r
+    id <- infos[[b]]$id
+    J <- seq_rows(r)
+    idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+    r_s2z <- glue("r_s2z_{idp}_{r$cn}")
+    r_public <- glue("r_{idp}_{r$cn}")
+    is_cor <- nrow(r) > 1L && isTRUE(r$cor[1])
+    if (rdim > 0L) {
+      str_add(out$gen_comp) <- glue(
+        "    {{\n",
+        "      vector[M_{id}] active_score_s2z = ",
+        "rep_vector(0.0, M_{id});\n"
+      )
+      for (a in seq_len(rdim)) {
+        str_add(out$gen_comp) <- glue(
+          "      active_score_s2z += H_s2z_{id}[{P[a]}, ]' * ",
+          "delta_s2z[{a}];\n"
+        )
+      }
+      str_add(out$gen_comp) <- glue(
+        "      mean_r_s2z_{id} += L_Sigma_s2z_{id} * ",
+        "(L_Sigma_s2z_{id}' * active_score_s2z) / (1.0 * N_{id});\n",
+        "    }}\n"
+      )
+    }
+    str_add(out$gen_comp) <- glue(
+      "    q_recovered_s2z_{set_id} -= H_s2z_{id} * mean_r_s2z_{id};\n"
+    )
+    if (is_cor) {
+      str_add(out$gen_comp) <- glue(
+        "    r_{id} = r_s2z_{id} + ",
+        "rep_matrix(mean_r_s2z_{id}', N_{id});\n",
+        cglue("    {r_public} = r_{id}[, {J}];\n")
+      )
+    } else {
+      str_add(out$gen_comp) <- cglue(
+        "    {r_public} = {r_s2z} + mean_r_s2z_{id}[{J}];\n"
+      )
+    }
+  }
+  str_add(out$gen_comp) <- "  }\n"
+  for (b in seq_along(infos)) {
+    r <- infos[[b]]$r
+    id <- infos[[b]]$id
+    if (nrow(r) > 1L && isTRUE(r$cor[1])) {
+      str_add(out$gen_comp) <- stan_cor_gen_comp(
+        cor = glue("cor_{id}"), ncol = glue("M_{id}")
+      )
+    }
+  }
+  if (info$center) {
+    str_add(out$gen_comp) <- glue(
+      "  Intercept{p} = q_recovered_s2z_{set_id}[1];\n",
+      str_if(
+        length(info$fixef),
+        glue(
+          "  b{p} = tail(q_recovered_s2z_{set_id}, Kc{p});\n",
+          "  b{p}_Intercept = Intercept{p} - dot_product(",
+          "means_X{p}, b{p});\n"
+        )
+      ),
+      str_if(
+        !length(info$fixef),
+        glue("  b{p}_Intercept = Intercept{p};\n")
+      )
+    )
+  } else {
+    str_add(out$gen_comp) <- glue(
+      "  b{p} = q_recovered_s2z_{set_id};\n"
+    )
+  }
+  out
+}
+
 # Jointly integrate the omitted group-effect means of all physical S2Z blocks
 # in one linear predictor. Block means are represented in their own reference-
 # whitened coordinates, so the independent group hierarchies contribute a
@@ -1022,6 +1456,11 @@ stan_re <- function(bframe, prior, normalize, ...) {
   out <- list(tpar_prior = "")
   infos <- set$infos
   stopifnot(length(infos) > 1L)
+  if (.stan_re_s2z_joint_uses_matheron(set)) {
+    return(.stan_re_s2z_joint_matheron(
+      set, prior = prior, threads = threads, normalize = normalize, ...
+    ))
+  }
   info <- infos[[1L]]
   q <- length(info$qnames)
   Ms <- vapply(infos, function(x) nrow(x$r), integer(1))

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -288,7 +288,7 @@ stan_fe <- function(bframe, prior, stanvars, threads, primitive,
     K_s2z <- length(bframe$frame$fe$vars)
     str_add(out$par) <- glue(
       "  vector[{K_s2z}] theta_s2z{p};",
-      "  // finite-population coefficients for marginalized S2Z effects\n"
+      "  // finite-population coefficients for physical S2Z effects\n"
     )
     str_add(out$pll_args) <- glue(", vector theta_s2z{p}")
   }
@@ -807,9 +807,10 @@ stan_re <- function(bframe, prior, normalize, ...) {
   out
 }
 
-# Stan code for one marginalized physical sum-to-zero group-level block.
-# Conditional Gaussian scale mixtures are handled by a group-specific scale,
-# which makes this exact for both Gaussian and Student-t group effects.
+# Stan code for one physical sum-to-zero group-level block. The omitted common
+# group-effect mean vector is integrated out analytically. Conditional
+# Gaussian scale mixtures are handled by a group-specific scale, which makes
+# this exact for both Gaussian and Student-t group effects.
 .stan_re_s2z <- function(id, bframe, prior, threads, normalize, out = list()) {
   lpdf <- stan_lpdf_name(normalize)
   # Avoid partial matching of $tpar_prior to $tpar_prior_const when a group
@@ -879,7 +880,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
   }
 
   str_add(out$tpar_def) <- glue(
-    "  // marginalized physical sum-to-zero group-level effects of ID {id}\n",
+    "  // physical sum-to-zero group-level effects of ID {id}\n",
     "  matrix[N_{id}, M_{id}] r_s2z_{id};\n",
     "  matrix[{q}, M_{id}] H_s2z_{id};\n",
     "  vector[{q}] prior_mean_s2z_{id};\n",
@@ -1130,7 +1131,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
   }
 
   str_add(out$tpar_def) <- glue(
-    "  // component-wise marginalized independent S2Z effects of ID {id}\n",
+    "  // component-wise physical S2Z effects of ID {id}\n",
     cglue("  vector[N_{id}] {r_s2z};\n"),
     "  vector[{q}] prior_mean_s2z_{id};\n",
     "  vector<lower=0>[{q}] prior_prec_s2z_{id};\n",
@@ -1412,7 +1413,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
   out
 }
 
-# Scalar specialization of the marginalized physical sum-to-zero block.
+# Scalar specialization of the physical sum-to-zero block.
 # In addition to avoiding all 1 x 1 matrix algebra, the Gaussian branch uses
 # the exact zero sum of the orthonormal contrasts to remove a weighted dot
 # product and the group-scale vectors altogether.
@@ -1450,7 +1451,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
   }
 
   str_add(out$tpar_def) <- glue(
-    "  // specialized scalar marginalized S2Z effects of ID {id}\n",
+    "  // specialized scalar physical S2Z effects of ID {id}\n",
     "  vector[N_{id}] {r_s2z};\n",
     "  vector[{q}] H_s2z_{id};\n",
     "  vector[{q}] prior_mean_s2z_{id};\n",

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -812,6 +812,12 @@ stan_re <- function(bframe, prior, normalize, ...) {
 # which makes this exact for both Gaussian and Student-t group effects.
 .stan_re_s2z <- function(id, bframe, prior, threads, normalize, out = list()) {
   lpdf <- stan_lpdf_name(normalize)
+  # Avoid partial matching of $tpar_prior to $tpar_prior_const when a group
+  # scale is fixed. Otherwise the constant assignment is appended to the
+  # model block when normalize = FALSE.
+  if (is.null(out[["tpar_prior"]])) {
+    out[["tpar_prior"]] <- ""
+  }
   r <- subset2(bframe$frame$re, id = id)
   stopifnot(is.reframe(r), has_rows(r), all(r$s2z))
   bfl <- re_s2z_bframel(bframe, r)
@@ -823,6 +829,12 @@ stan_re <- function(bframe, prior, normalize, ...) {
   idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
   is_cor <- M > 1L && isTRUE(r$cor[1])
   is_student <- identical(r$dist[1], "student")
+
+  if (M == 1L) {
+    return(.stan_re_s2z_scalar(
+      id, r = r, info = info, normalize = normalize, out = out
+    ))
+  }
 
   # Keep brms's existing covariance parameters and priors. Only the
   # group-effect coordinates and their joint prior are replaced.
@@ -1067,6 +1079,224 @@ stan_re <- function(bframe, prior, normalize, ...) {
     str_add(out$gen_comp) <- stan_cor_gen_comp(
       cor = glue("cor_{id}"), ncol = glue("M_{id}")
     )
+  }
+  out
+}
+
+# Scalar specialization of the marginalized physical sum-to-zero block.
+# In addition to avoiding all 1 x 1 matrix algebra, the Gaussian branch uses
+# the exact zero sum of the orthonormal contrasts to remove a weighted dot
+# product and the group-scale vectors altogether.
+.stan_re_s2z_scalar <- function(id, r, info, normalize, out = list()) {
+  lpdf <- stan_lpdf_name(normalize)
+  stopifnot(is.reframe(r), nrow(r) == 1L, all(r$s2z))
+  q <- length(info$qnames)
+  p <- info$p
+  idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+  cn <- r$cn[1]
+  is_student <- identical(r$dist[1], "student")
+  r_s2z <- glue("r_s2z_{idp}_{cn}")
+  r_public <- glue("r_{idp}_{cn}")
+
+  str_add(out$fun) <- "  #include 'fun_sum_to_zero.stan'\n"
+  str_add(out$par) <- glue(
+    "  vector[N_{id} - 1] z_s2z_{id};",
+    "  // physical orthonormal scalar S2Z coordinates\n"
+  )
+
+  # Independent Student-t and Cauchy population priors remain conditionally
+  # Gaussian after introducing one scalar mixing variable per coefficient.
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "student") {
+      str_add(out$par) <- glue(
+        "  real<lower=0> udf_b_s2z{p}_{k};",
+        "  // mixing variable for population coefficient {k}\n"
+      )
+      str_add(out$tpar_prior) <- glue(
+        "  lprior += inv_chi_square_{lpdf}(udf_b_s2z{p}_{k} | ",
+        "{stan_s2z_number(spec$df)});\n"
+      )
+    }
+  }
+
+  str_add(out$tpar_def) <- glue(
+    "  // specialized scalar marginalized S2Z effects of ID {id}\n",
+    "  vector[N_{id}] {r_s2z};\n",
+    "  vector[{q}] H_s2z_{id};\n",
+    "  vector[{q}] prior_mean_s2z_{id};\n",
+    "  vector<lower=0>[{q}] prior_prec_s2z_{id};\n",
+    str_if(
+      is_student,
+      glue(
+        "  vector<lower=0>[N_{id}] group_scale_s2z_{id};\n",
+        "  vector<lower=0>[N_{id}] group_prec_s2z_{id};\n"
+      )
+    ),
+    "  real<lower=0> D_s2z_{id};\n",
+    "  real<lower=0> sqrt_D_s2z_{id};\n",
+    "  real mhat_s2z_{id};\n",
+    "  vector[{q}] qhat_s2z_{id};\n",
+    "  vector[N_{id}] white_s2z_{id};\n"
+  )
+
+  # H maps the omitted scalar group mean into all matching population
+  # coordinates. A centered varying slope also shifts brms's temporary
+  # centered intercept by the mean of its raw design column.
+  qi <- info$match_q[1]
+  str_add(out$tpar_comp) <- glue(
+    "  {r_s2z} = sum_to_zero_constrain_brms(z_s2z_{id});\n",
+    "  H_s2z_{id} = rep_vector(0.0, {q});\n",
+    "  H_s2z_{id}[{qi}] = 1.0;\n",
+    str_if(
+      info$center && info$r$coef[1] != "Intercept",
+      glue("  H_s2z_{id}[1] = means_X{p}[{qi - 1L}];\n")
+    )
+  )
+
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    loc <- stan_s2z_number(spec$location)
+    str_add(out$tpar_comp) <- glue(
+      "  prior_mean_s2z_{id}[{k}] = {loc};\n"
+    )
+    if (spec$dist == "flat") {
+      prec <- "0.0"
+    } else if (spec$dist == "normal") {
+      prec <- glue("inv_square({stan_s2z_number(spec$scale)})")
+    } else {
+      prec <- glue(
+        "inv_square({stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k}))"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  prior_prec_s2z_{id}[{k}] = {prec};\n"
+    )
+  }
+
+  # D = square(sd) * P is the scaled conditional precision of the omitted
+  # mean. Working with D avoids forming inv_square(sd), which can overflow
+  # near zero during warmup. For Gaussian effects, sum(r_s2z) is exactly zero
+  # in the physical coordinates, so its contribution to the mode vanishes.
+  if (is_student) {
+    tr <- subset_reframe_dist(r, "student")
+    g <- usc(tr$ggn[1])
+    str_add(out$tpar_comp) <- glue(
+      "  group_scale_s2z_{id} = dfm{g};\n",
+      "  group_prec_s2z_{id} = inv_square(group_scale_s2z_{id});\n",
+      "  {{\n",
+      "    real tau_sq_s2z = square(sd_{id}[1]);\n",
+      "    real prior_info_s2z = dot_product(prior_prec_s2z_{id}, ",
+      "square(H_s2z_{id}));\n",
+      "    real prior_score_s2z = dot_product(H_s2z_{id}, ",
+      "prior_prec_s2z_{id} .* (theta_s2z{p} - ",
+      "prior_mean_s2z_{id}));\n",
+      "    D_s2z_{id} = tau_sq_s2z * prior_info_s2z + ",
+      "sum(group_prec_s2z_{id});\n",
+      "    mhat_s2z_{id} = (tau_sq_s2z * prior_score_s2z - ",
+      "dot_product({r_s2z}, group_prec_s2z_{id})) / D_s2z_{id};\n",
+      "  }}\n"
+    )
+  } else {
+    str_add(out$tpar_comp) <- glue(
+      "  {{\n",
+      "    real tau_sq_s2z = square(sd_{id}[1]);\n",
+      "    real prior_info_s2z = dot_product(prior_prec_s2z_{id}, ",
+      "square(H_s2z_{id}));\n",
+      "    real prior_score_s2z = dot_product(H_s2z_{id}, ",
+      "prior_prec_s2z_{id} .* (theta_s2z{p} - ",
+      "prior_mean_s2z_{id}));\n",
+      "    D_s2z_{id} = tau_sq_s2z * prior_info_s2z + N_{id};\n",
+      "    mhat_s2z_{id} = tau_sq_s2z * prior_score_s2z / D_s2z_{id};\n",
+      "  }}\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  sqrt_D_s2z_{id} = sqrt(D_s2z_{id});\n",
+    "  qhat_s2z_{id} = theta_s2z{p} - H_s2z_{id} * ",
+    "mhat_s2z_{id};\n",
+    "  white_s2z_{id} = ({r_s2z} + mhat_s2z_{id}) / sd_{id}[1]",
+    str_if(is_student, " ./ group_scale_s2z_{id}"),
+    ";\n"
+  )
+  str_add(out$pll_args) <- glue(", vector {r_s2z}")
+
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "flat") {
+      next
+    }
+    if (spec$dist == "normal") {
+      cond_scale <- stan_s2z_number(spec$scale)
+    } else {
+      cond_scale <- glue(
+        "{stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k})"
+      )
+    }
+    str_add(out$tpar_prior) <- glue(
+      "  lprior += normal_{lpdf}(qhat_s2z_{id}[{k}] | ",
+      "{stan_s2z_number(spec$location)}, {cond_scale});\n"
+    )
+  }
+  str_add(out$tpar_prior) <- glue(
+    "  lprior += -0.5 * dot_self(white_s2z_{id})\n",
+    "    - (N_{id} - 1) * log(sd_{id}[1])\n",
+    str_if(
+      is_student,
+      glue("    - sum(log(group_scale_s2z_{id}))\n")
+    ),
+    "    - 0.5 * log(D_s2z_{id})",
+    str_if(
+      normalize,
+      glue(" - 0.5 * N_{id} * log(2 * pi())",
+           " + 0.5 * log(2 * pi())",
+           " + 0.5 * log(1.0 * N_{id})")
+    ),
+    ";\n"
+  )
+
+  # Reconstruct the conventional coefficient and deviations from one draw
+  # of the analytically omitted scalar group mean.
+  str_add(out$gen_def) <- glue(
+    "  real mean_r_s2z_{id};\n",
+    "  vector[{q}] q_recovered_s2z_{id};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_def) <- glue(
+      "  real Intercept{p};\n",
+      str_if(length(info$fixef), glue("  vector[Kc{p}] b{p};\n")),
+      "  real b{p}_Intercept;\n"
+    )
+  } else {
+    str_add(out$gen_def) <- glue("  vector[{q}] b{p};\n")
+  }
+  str_add(out$gen_def) <- glue("  vector[N_{id}] {r_public};\n")
+
+  str_add(out$gen_comp) <- glue(
+    "  mean_r_s2z_{id} = mhat_s2z_{id} + ",
+    "sd_{id}[1] * std_normal_rng() / sqrt_D_s2z_{id};\n",
+    "  q_recovered_s2z_{id} = theta_s2z{p} - H_s2z_{id} * ",
+    "mean_r_s2z_{id};\n",
+    "  {r_public} = {r_s2z} + mean_r_s2z_{id};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_comp) <- glue(
+      "  Intercept{p} = q_recovered_s2z_{id}[1];\n",
+      str_if(
+        length(info$fixef),
+        glue("  b{p} = tail(q_recovered_s2z_{id}, Kc{p});\n",
+             "  b{p}_Intercept = Intercept{p} - dot_product(",
+             "means_X{p}, b{p});\n")
+      ),
+      str_if(
+        !length(info$fixef),
+        glue("  b{p}_Intercept = Intercept{p};\n")
+      )
+    )
+  } else {
+    str_add(out$gen_comp) <- glue("  b{p} = q_recovered_s2z_{id};\n")
   }
   out
 }

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -836,6 +836,12 @@ stan_re <- function(bframe, prior, normalize, ...) {
     ))
   }
 
+  if (!is_cor) {
+    return(.stan_re_s2z_independent(
+      id, r = r, info = info, normalize = normalize, out = out
+    ))
+  }
+
   # Keep brms's existing covariance parameters and priors. Only the
   # group-effect coordinates and their joint prior are replaced.
   if (is_cor) {
@@ -1079,6 +1085,329 @@ stan_re <- function(bframe, prior, normalize, ...) {
     str_add(out$gen_comp) <- stan_cor_gen_comp(
       cor = glue("cor_{id}"), ncol = glue("M_{id}")
     )
+  }
+  out
+}
+
+# Component-wise specialization for multiple independent group-level effects.
+# The omitted means are conditionally independent except for the single
+# rank-one coupling induced by brms's centered population intercept.  A
+# diagonal-plus-rank-one solve therefore replaces all M x M factorizations.
+.stan_re_s2z_independent <- function(id, r, info, normalize, out = list()) {
+  lpdf <- stan_lpdf_name(normalize)
+  stopifnot(
+    is.reframe(r), nrow(r) > 1L, !isTRUE(r$cor[1]), all(r$s2z)
+  )
+  q <- length(info$qnames)
+  M <- nrow(r)
+  J <- seq_rows(r)
+  p <- info$p
+  idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+  is_student <- identical(r$dist[1], "student")
+  r_s2z <- glue("r_s2z_{idp}_{r$cn}")
+  r_public <- glue("r_{idp}_{r$cn}")
+
+  str_add(out$fun) <- "  #include 'fun_sum_to_zero.stan'\n"
+  str_add(out$par) <- glue(
+    "  array[M_{id}] vector[N_{id} - 1] z_s2z_{id};",
+    "  // physical orthonormal independent S2Z coordinates\n"
+  )
+
+  # Independent Student-t and Cauchy population priors remain conditionally
+  # Gaussian after introducing one scalar mixing variable per coefficient.
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "student") {
+      str_add(out$par) <- glue(
+        "  real<lower=0> udf_b_s2z{p}_{k};",
+        "  // mixing variable for population coefficient {k}\n"
+      )
+      str_add(out$tpar_prior) <- glue(
+        "  lprior += inv_chi_square_{lpdf}(udf_b_s2z{p}_{k} | ",
+        "{stan_s2z_number(spec$df)});\n"
+      )
+    }
+  }
+
+  str_add(out$tpar_def) <- glue(
+    "  // component-wise marginalized independent S2Z effects of ID {id}\n",
+    cglue("  vector[N_{id}] {r_s2z};\n"),
+    "  vector[{q}] prior_mean_s2z_{id};\n",
+    "  vector<lower=0>[{q}] prior_prec_s2z_{id};\n",
+    "  vector[M_{id}] intercept_map_s2z_{id};\n",
+    str_if(
+      is_student,
+      glue(
+        "  vector<lower=0>[N_{id}] group_scale_s2z_{id};\n",
+        "  vector<lower=0>[N_{id}] group_prec_s2z_{id};\n"
+      )
+    ),
+    "  vector<lower=0>[M_{id}] D_diag_s2z_{id};\n",
+    "  real<lower=0> rank1_info_s2z_{id};\n",
+    "  vector[M_{id}] mhat_s2z_{id};\n",
+    "  vector[{q}] qhat_s2z_{id};\n",
+    "  real<lower=0> group_quad_s2z_{id};\n"
+  )
+
+  for (j in seq_len(M)) {
+    str_add(out$tpar_comp) <- glue(
+      "  {r_s2z[j]} = sum_to_zero_constrain_brms(z_s2z_{id}[{j}]);\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  intercept_map_s2z_{id} = rep_vector(0.0, M_{id});\n"
+  )
+  if (info$center) {
+    for (j in seq_len(M)) {
+      qi <- info$match_q[j]
+      value <- if (info$r$coef[j] == "Intercept") {
+        "1.0"
+      } else {
+        glue("means_X{p}[{qi - 1L}]")
+      }
+      str_add(out$tpar_comp) <- glue(
+        "  intercept_map_s2z_{id}[{j}] = {value};\n"
+      )
+    }
+  }
+
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    loc <- stan_s2z_number(spec$location)
+    str_add(out$tpar_comp) <- glue(
+      "  prior_mean_s2z_{id}[{k}] = {loc};\n"
+    )
+    if (spec$dist == "flat") {
+      prec <- "0.0"
+    } else if (spec$dist == "normal") {
+      prec <- glue("inv_square({stan_s2z_number(spec$scale)})")
+    } else {
+      prec <- glue(
+        "inv_square({stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k}))"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  prior_prec_s2z_{id}[{k}] = {prec};\n"
+    )
+  }
+
+  if (is_student) {
+    tr <- subset_reframe_dist(r, "student")
+    g <- usc(tr$ggn[1])
+    str_add(out$tpar_comp) <- glue(
+      "  group_scale_s2z_{id} = dfm{g};\n",
+      "  group_prec_s2z_{id} = inv_square(group_scale_s2z_{id});\n"
+    )
+  }
+
+  # After multiplying each normal equation by its group SD squared, its
+  # diagonal is D.  The only remaining coupling is lambda_Intercept * v v',
+  # where v maps omitted means into the centered intercept.  Sherman-Morrison
+  # gives both the mode and determinant in linear time and avoids unstable
+  # inverse-square group SDs during warmup.
+  str_add(out$tpar_comp) <- glue(
+    "  {{\n",
+    "    vector[M_{id}] base_info_s2z = rep_vector(0.0, M_{id});\n",
+    "    vector[M_{id}] base_score_s2z = rep_vector(0.0, M_{id});\n",
+    "    vector[M_{id}] scaled_score_s2z;\n",
+    "    vector[M_{id}] independent_mode_s2z;\n",
+    "    real group_info_s2z = ",
+    str_if(is_student, glue("sum(group_prec_s2z_{id})"), glue("N_{id}")),
+    ";\n"
+  )
+  for (j in seq_len(M)) {
+    qi <- info$match_q[j]
+    if (!info$center || qi != 1L) {
+      str_add(out$tpar_comp) <- glue(
+        "    base_info_s2z[{j}] = prior_prec_s2z_{id}[{qi}];\n",
+        "    base_score_s2z[{j}] = prior_prec_s2z_{id}[{qi}] * ",
+        "(theta_s2z{p}[{qi}] - prior_mean_s2z_{id}[{qi}]);\n"
+      )
+    }
+  }
+  str_add(out$tpar_comp) <- glue(
+    "    D_diag_s2z_{id} = group_info_s2z + ",
+    "square(sd_{id}) .* base_info_s2z;\n"
+  )
+  for (j in seq_len(M)) {
+    contrast_score <- if (is_student) {
+      glue(" - dot_product({r_s2z[j]}, group_prec_s2z_{id})")
+    } else {
+      ""
+    }
+    str_add(out$tpar_comp) <- glue(
+      "    scaled_score_s2z[{j}] = square(sd_{id}[{j}]) * ",
+      "base_score_s2z[{j}]{contrast_score};\n"
+    )
+  }
+  coupling_prec <- str_if(info$center, glue("prior_prec_s2z_{id}[1]"), "0.0")
+  coupling_resid <- str_if(
+    info$center,
+    glue("theta_s2z{p}[1] - prior_mean_s2z_{id}[1]"),
+    "0.0"
+  )
+  str_add(out$tpar_comp) <- glue(
+    "    independent_mode_s2z = scaled_score_s2z ./ D_diag_s2z_{id};\n",
+    "    rank1_info_s2z_{id} = {coupling_prec} * dot_product(\n",
+    "      square(sd_{id}) .* square(intercept_map_s2z_{id}),\n",
+    "      1.0 ./ D_diag_s2z_{id}\n",
+    "    );\n",
+    "    mhat_s2z_{id} = independent_mode_s2z +\n",
+    "      {coupling_prec} * square(sd_{id}) .* intercept_map_s2z_{id} ./\n",
+    "      D_diag_s2z_{id} * ({coupling_resid} -\n",
+    "      dot_product(intercept_map_s2z_{id}, independent_mode_s2z)) /\n",
+    "      (1.0 + rank1_info_s2z_{id});\n",
+    "  }}\n",
+    "  qhat_s2z_{id} = theta_s2z{p};\n"
+  )
+  if (info$center) {
+    str_add(out$tpar_comp) <- glue(
+      "  qhat_s2z_{id}[1] -= dot_product(",
+      "intercept_map_s2z_{id}, mhat_s2z_{id});\n"
+    )
+    for (j in seq_len(M)) {
+      qi <- info$match_q[j]
+      if (qi != 1L) {
+        str_add(out$tpar_comp) <- glue(
+          "  qhat_s2z_{id}[{qi}] -= mhat_s2z_{id}[{j}];\n"
+        )
+      }
+    }
+  } else {
+    for (j in seq_len(M)) {
+      str_add(out$tpar_comp) <- glue(
+        "  qhat_s2z_{id}[{info$match_q[j]}] -= mhat_s2z_{id}[{j}];\n"
+      )
+    }
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  group_quad_s2z_{id} = 0.0;\n"
+  )
+  for (j in seq_len(M)) {
+    standardized <- glue(
+      "({r_s2z[j]} + mhat_s2z_{id}[{j}]) / sd_{id}[{j}]",
+      str_if(is_student, glue(" ./ group_scale_s2z_{id}"))
+    )
+    str_add(out$tpar_comp) <- glue(
+      "  group_quad_s2z_{id} += dot_self({standardized});\n"
+    )
+  }
+  str_add(out$pll_args) <- cglue(", vector {r_s2z}")
+
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "flat") {
+      next
+    }
+    if (spec$dist == "normal") {
+      cond_scale <- stan_s2z_number(spec$scale)
+    } else {
+      cond_scale <- glue(
+        "{stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k})"
+      )
+    }
+    str_add(out$tpar_prior) <- glue(
+      "  lprior += normal_{lpdf}(qhat_s2z_{id}[{k}] | ",
+      "{stan_s2z_number(spec$location)}, {cond_scale});\n"
+    )
+  }
+  str_add(out$tpar_prior) <- glue(
+    "  lprior += -0.5 * group_quad_s2z_{id}\n",
+    "    - (N_{id} - 1) * sum(log(sd_{id}))\n",
+    str_if(
+      is_student,
+      glue("    - M_{id} * sum(log(group_scale_s2z_{id}))\n")
+    ),
+    "    - 0.5 * sum(log(D_diag_s2z_{id}))\n",
+    "    - 0.5 * log1p(rank1_info_s2z_{id})",
+    str_if(
+      normalize,
+      glue(" - 0.5 * N_{id} * M_{id} * log(2 * pi())",
+           " + 0.5 * M_{id} * log(2 * pi())",
+           " + 0.5 * M_{id} * log(1.0 * N_{id})")
+    ),
+    ";\n"
+  )
+
+  # Draw from the diagonal-minus-rank-one conditional covariance without a
+  # dense Cholesky, then reconstruct conventional public b/r coordinates.
+  str_add(out$gen_def) <- glue(
+    "  vector[M_{id}] mean_r_s2z_{id};\n",
+    "  vector[{q}] q_recovered_s2z_{id};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_def) <- glue(
+      "  real Intercept{p};\n",
+      str_if(length(info$fixef), glue("  vector[Kc{p}] b{p};\n")),
+      "  real b{p}_Intercept;\n"
+    )
+  } else {
+    str_add(out$gen_def) <- glue("  vector[{q}] b{p};\n")
+  }
+  str_add(out$gen_def) <- cglue("  vector[N_{id}] {r_public};\n")
+
+  str_add(out$gen_comp) <- glue(
+    "  {{\n",
+    "    vector[M_{id}] independent_noise_s2z;\n",
+    "    real sqrt_rank1_s2z = sqrt(1.0 + rank1_info_s2z_{id});\n",
+    "    real rank1_adjust_s2z;\n",
+    "    for (k in 1:M_{id}) {{\n",
+    "      independent_noise_s2z[k] = sd_{id}[k] * ",
+    "std_normal_rng() / sqrt(D_diag_s2z_{id}[k]);\n",
+    "    }}\n",
+    "    rank1_adjust_s2z = {coupling_prec} / ",
+    "(sqrt_rank1_s2z * (1.0 + sqrt_rank1_s2z)) *\n",
+    "      dot_product(intercept_map_s2z_{id}, independent_noise_s2z);\n",
+    "    mean_r_s2z_{id} = mhat_s2z_{id} + independent_noise_s2z -\n",
+    "      rank1_adjust_s2z * square(sd_{id}) .* ",
+    "intercept_map_s2z_{id} ./ D_diag_s2z_{id};\n",
+    "  }}\n",
+    "  q_recovered_s2z_{id} = theta_s2z{p};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_comp) <- glue(
+      "  q_recovered_s2z_{id}[1] -= dot_product(",
+      "intercept_map_s2z_{id}, mean_r_s2z_{id});\n"
+    )
+    for (j in seq_len(M)) {
+      qi <- info$match_q[j]
+      if (qi != 1L) {
+        str_add(out$gen_comp) <- glue(
+          "  q_recovered_s2z_{id}[{qi}] -= mean_r_s2z_{id}[{j}];\n"
+        )
+      }
+    }
+  } else {
+    for (j in seq_len(M)) {
+      str_add(out$gen_comp) <- glue(
+        "  q_recovered_s2z_{id}[{info$match_q[j]}] -= ",
+        "mean_r_s2z_{id}[{j}];\n"
+      )
+    }
+  }
+  for (j in seq_len(M)) {
+    str_add(out$gen_comp) <- glue(
+      "  {r_public[j]} = {r_s2z[j]} + mean_r_s2z_{id}[{j}];\n"
+    )
+  }
+  if (info$center) {
+    str_add(out$gen_comp) <- glue(
+      "  Intercept{p} = q_recovered_s2z_{id}[1];\n",
+      str_if(
+        length(info$fixef),
+        glue("  b{p} = tail(q_recovered_s2z_{id}, Kc{p});\n",
+             "  b{p}_Intercept = Intercept{p} - dot_product(",
+             "means_X{p}, b{p});\n")
+      ),
+      str_if(
+        !length(info$fixef),
+        glue("  b{p}_Intercept = Intercept{p};\n")
+      )
+    )
+  } else {
+    str_add(out$gen_comp) <- glue("  b{p} = q_recovered_s2z_{id};\n")
   }
   out
 }

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -492,6 +492,27 @@ stan_re <- function(bframe, prior, normalize, ...) {
   stopifnot(is.reframe(reframe))
   IDs <- unique(reframe$id)
   out <- list()
+  # Multiple S2Z covariance blocks in one linear predictor share the same
+  # finite-population coefficients. Their omitted means must consequently be
+  # integrated in one joint Gaussian system. Keep the established one-block
+  # generators entirely unchanged and only activate the joint path for sets
+  # with more than one local S2Z ID.
+  joint_s2z_sets <- list()
+  for (bfl in Filter(has_re_s2z, all_bframel(bframe))) {
+    infos <- re_s2z_infos(bfl, prior = prior)
+    if (length(infos) > 1L) {
+      set_id <- infos[[1L]]$id
+      joint_s2z_sets[[as.character(set_id)]] <- nlist(
+        set_id, ids = vapply(infos, `[[`, numeric(1), "id"), bfl, infos
+      )
+    }
+  }
+  joint_s2z_by_id <- list()
+  for (set in joint_s2z_sets) {
+    for (id in set$ids) {
+      joint_s2z_by_id[[as.character(id)]] <- set
+    }
+  }
   # special handling of student-t group effects as their 'df' parameters
   # are defined on a per-group basis instead of a per-ID basis
   reframe_t <- subset_reframe_dist(reframe, "student")
@@ -521,17 +542,25 @@ stan_re <- function(bframe, prior, normalize, ...) {
     }
   }
   # the ID syntax requires group-level effects to be evaluated separately
-  tmp <- lapply(
-    IDs, .stan_re, bframe = bframe, prior = prior,
-    normalize = normalize, ...
-  )
-  out <- collapse_lists(ls = c(list(out), tmp))
+  tmp <- lapply(IDs, function(id) {
+    .stan_re(
+      id, bframe = bframe, prior = prior, normalize = normalize,
+      joint_s2z = joint_s2z_by_id[[as.character(id)]], ...
+    )
+  })
+  joint <- lapply(joint_s2z_sets, function(set) {
+    .stan_re_s2z_joint(
+      set, prior = prior, normalize = normalize, ...
+    )
+  })
+  out <- collapse_lists(ls = c(list(out), tmp, joint))
   out
 }
 
 # Stan code for group-level effects per ID
 # @param id the ID of the grouping factor
-.stan_re <- function(id, bframe, prior, threads, normalize, ...) {
+.stan_re <- function(id, bframe, prior, threads, normalize,
+                     joint_s2z = NULL, ...) {
   lpdf <- ifelse(normalize, "lpdf", "lupdf")
   out <- list()
   r <- subset2(bframe$frame$re, id = id)
@@ -645,6 +674,13 @@ stan_re <- function(bframe, prior, normalize, ...) {
         normalize = normalize
       )
     }
+  }
+
+  if (isTRUE(r$s2z[1]) && !is.null(joint_s2z)) {
+    return(.stan_re_s2z_joint_block(
+      id, set = joint_s2z, bframe = bframe, prior = prior,
+      threads = threads, normalize = normalize, out = out
+    ))
   }
 
   if (isTRUE(r$s2z[1])) {
@@ -802,6 +838,444 @@ stan_re <- function(bframe, prior, normalize, ...) {
     }
     str_add(out$pll_args) <- cglue(
       ", vector r_{idp}_{r$cn}"
+    )
+  }
+  out
+}
+
+# Stan code local to one covariance block participating in a joint S2Z
+# omitted-mean system. The block contributes its physical zero-sum effects and
+# the Gaussian normal equations for its omitted mean in reference-whitened
+# coordinates. Population-level priors and mean recovery are handled once by
+# .stan_re_s2z_joint().
+.stan_re_s2z_joint_block <- function(id, set, bframe, prior, threads,
+                                     normalize, out = list()) {
+  lpdf <- stan_lpdf_name(normalize)
+  if (is.null(out[["tpar_prior"]])) {
+    out[["tpar_prior"]] <- ""
+  }
+  r <- subset2(bframe$frame$re, id = id)
+  stopifnot(is.reframe(r), has_rows(r), all(r$s2z), id %in% set$ids)
+  bfl <- set$bfl
+  info <- re_s2z_info(bfl, prior = prior, id = id)
+  q <- length(info$qnames)
+  M <- nrow(r)
+  J <- seq_rows(r)
+  px <- check_prefix(r)
+  idp <- paste0(r$id, usc(combine_prefix(px)))
+  r_s2z <- glue("r_s2z_{idp}_{r$cn}")
+  is_cor <- M > 1L && isTRUE(r$cor[1])
+  is_student <- identical(r$dist[1], "student")
+  if (is_cor) {
+    str_add(out$data) <- glue(
+      "  int<lower=1> NC_{id};  // number of group-level correlations\n"
+    )
+    str_add_list(out) <- stan_prior(
+      prior, class = "L", group = r$group[1], suffix = usc(id),
+      type = glue("cholesky_factor_corr[M_{id}]"),
+      comment = "cholesky factor of correlation matrix",
+      normalize = normalize
+    )
+  }
+  if (identical(id, set$set_id)) {
+    str_add(out$fun) <- "  #include 'fun_sum_to_zero.stan'\n"
+  }
+
+  str_add(out$par) <- glue(
+    "  array[M_{id}] vector[N_{id} - 1] z_s2z_{id};",
+    "  // physical orthonormal S2Z coordinates\n"
+  )
+
+  str_add(out$tpar_def) <- glue(
+    "  // S2Z block {id} in a joint omitted-mean system\n",
+    "  matrix[N_{id}, M_{id}] r_s2z_{id};\n",
+    "  matrix[{q}, M_{id}] H_s2z_{id};\n",
+    "  matrix[M_{id}, M_{id}] L_Sigma_s2z_{id};\n",
+    "  matrix[M_{id}, M_{id}] P_group_s2z_{id};\n",
+    "  vector[M_{id}] h_group_s2z_{id};\n",
+    "  real<lower=0> group_quad_s2z_{id};\n",
+    str_if(
+      is_student,
+      glue(
+        "  vector<lower=0>[N_{id}] group_scale_s2z_{id};\n",
+        "  vector<lower=0>[N_{id}] group_prec_s2z_{id};\n"
+      )
+    ),
+    "  // vectors used by the observation-level likelihood\n",
+    cglue("  vector[N_{id}] {r_s2z};\n")
+  )
+
+  if (is_student) {
+    tr <- subset_reframe_dist(r, "student")
+    g <- usc(tr$ggn[1])
+    str_add(out$tpar_comp) <- glue(
+      "  group_scale_s2z_{id} = dfm{g};\n",
+      "  group_prec_s2z_{id} = inv_square(group_scale_s2z_{id});\n"
+    )
+  }
+
+  str_add(out$tpar_comp) <- glue(
+    "  H_s2z_{id} = rep_matrix(0.0, {q}, M_{id});\n"
+  )
+  for (j in seq_len(M)) {
+    qi <- info$match_q[j]
+    str_add(out$tpar_comp) <- glue(
+      "  H_s2z_{id}[{qi}, {j}] = 1.0;\n"
+    )
+    if (info$center && info$r$coef[j] != "Intercept") {
+      str_add(out$tpar_comp) <- glue(
+        "  H_s2z_{id}[1, {j}] = means_X{info$p}[{qi - 1L}];\n"
+      )
+    }
+  }
+  scale <- glue("sd_{id}")
+  if (is_cor) {
+    str_add(out$tpar_comp) <- glue(
+      "  L_Sigma_s2z_{id} = diag_pre_multiply({scale}, L_{id});\n"
+    )
+  } else {
+    str_add(out$tpar_comp) <- glue(
+      "  L_Sigma_s2z_{id} = diag_matrix({scale});\n"
+    )
+  }
+
+  str_add(out$tpar_comp) <- glue(
+    "  for (k in 1:M_{id}) {{\n",
+    "    r_s2z_{id}[, k] = sum_to_zero_constrain_brms(z_s2z_{id}[k]);\n",
+    "  }}\n"
+  )
+
+  if (is_cor) {
+    group_info <- if (is_student) {
+      glue("sum(group_prec_s2z_{id})")
+    } else {
+      glue("1.0 * N_{id}")
+    }
+    group_score_code <- if (is_student) {
+      glue(
+        "    h_group_s2z_{id} = -white_group_s2z * ",
+        "group_prec_s2z_{id};\n",
+        "    group_quad_s2z_{id} = 0.0;\n",
+        "    for (j in 1:N_{id}) {{\n",
+        "      group_quad_s2z_{id} += group_prec_s2z_{id}[j] * ",
+        "dot_self(white_group_s2z[, j]);\n",
+        "    }}\n"
+      )
+    } else {
+      glue(
+        "    h_group_s2z_{id} = rep_vector(0.0, M_{id});\n",
+        "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z));\n"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  {{\n",
+      "    matrix[M_{id}, N_{id}] white_group_s2z = ",
+      "mdivide_left_tri_low(L_Sigma_s2z_{id}, r_s2z_{id}');\n",
+      "    P_group_s2z_{id} = diag_matrix(rep_vector({group_info}, M_{id}));\n",
+      "{group_score_code}",
+      "  }}\n"
+    )
+  } else {
+    group_info <- if (is_student) {
+      glue("sum(group_prec_s2z_{id})")
+    } else {
+      glue("1.0 * N_{id}")
+    }
+    group_score_code <- if (is_student) {
+      glue(
+        "    h_group_s2z_{id} = -(white_group_s2z' * ",
+        "group_prec_s2z_{id});\n",
+        "    group_quad_s2z_{id} = 0.0;\n",
+        "    for (j in 1:N_{id}) {{\n",
+        "      group_quad_s2z_{id} += group_prec_s2z_{id}[j] * ",
+        "dot_self(white_group_s2z[j]');\n",
+        "    }}\n"
+      )
+    } else {
+      glue(
+        "    h_group_s2z_{id} = rep_vector(0.0, M_{id});\n",
+        "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z));\n"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  {{\n",
+      "    matrix[N_{id}, M_{id}] white_group_s2z = r_s2z_{id} ./ ",
+      "rep_matrix({scale}', N_{id});\n",
+      "    P_group_s2z_{id} = diag_matrix(rep_vector({group_info}, M_{id}));\n",
+      "{group_score_code}",
+      "  }}\n"
+    )
+  }
+  str_add(out$tpar_comp) <- cglue(
+    "  {r_s2z} = r_s2z_{id}[, {J}];\n"
+  )
+  str_add(out$pll_args) <- cglue(", vector {r_s2z}")
+  out
+}
+
+# Jointly integrate the omitted group-effect means of all physical S2Z blocks
+# in one linear predictor. Block means are represented in their own reference-
+# whitened coordinates, so the independent group hierarchies contribute a
+# block-diagonal precision while population-level priors provide the only
+# cross-block coupling.
+.stan_re_s2z_joint <- function(set, prior, threads, normalize, ...) {
+  out <- list(tpar_prior = "")
+  infos <- set$infos
+  stopifnot(length(infos) > 1L)
+  info <- infos[[1L]]
+  q <- length(info$qnames)
+  Ms <- vapply(infos, function(x) nrow(x$r), integer(1))
+  total_M <- sum(Ms)
+  starts <- cumsum(c(1L, head(Ms, -1L)))
+  ends <- starts + Ms - 1L
+  set_id <- set$set_id
+  p <- info$p
+  lpdf <- stan_lpdf_name(normalize)
+
+  # Population Student-t and Cauchy priors use one mixing variable per fixed
+  # coefficient for the entire joint system, rather than one copy per block.
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "student") {
+      str_add(out$par) <- glue(
+        "  real<lower=0> udf_b_s2z{p}_{k};",
+        "  // mixing variable for population coefficient {k}\n"
+      )
+      str_add(out$tpar_prior) <- glue(
+        "  lprior += inv_chi_square_{lpdf}(udf_b_s2z{p}_{k} | ",
+        "{stan_s2z_number(spec$df)});\n"
+      )
+    }
+  }
+
+  str_add(out$tpar_def) <- glue(
+    "  // joint omitted-mean system for S2Z blocks ",
+    "{paste(set$ids, collapse = ', ')}\n",
+    "  vector[{q}] prior_mean_s2z_{set_id};\n",
+    "  vector<lower=0>[{q}] prior_prec_s2z_{set_id};\n",
+    "  matrix[{q}, {total_M}] H_joint_s2z_{set_id};\n",
+    "  matrix[{total_M}, {total_M}] P_s2z_{set_id};\n",
+    "  matrix[{total_M}, {total_M}] L_P_s2z_{set_id};\n",
+    "  vector[{total_M}] h_joint_s2z_{set_id};\n",
+    "  vector[{total_M}] mhat_s2z_{set_id};\n",
+    "  real joint_quad_s2z_{set_id};\n"
+  )
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    loc <- stan_s2z_number(spec$location)
+    str_add(out$tpar_comp) <- glue(
+      "  prior_mean_s2z_{set_id}[{k}] = {loc};\n"
+    )
+    if (spec$dist == "flat") {
+      prec <- "0.0"
+    } else if (spec$dist == "normal") {
+      prec <- glue("inv_square({stan_s2z_number(spec$scale)})")
+    } else {
+      prec <- glue(
+        "inv_square({stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k}))"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  prior_prec_s2z_{set_id}[{k}] = {prec};\n"
+    )
+  }
+
+  str_add(out$tpar_comp) <- glue(
+    "  H_joint_s2z_{set_id} = rep_matrix(0.0, {q}, {total_M});\n",
+    "  P_s2z_{set_id} = rep_matrix(0.0, {total_M}, {total_M});\n",
+    "  h_joint_s2z_{set_id} = rep_vector(0.0, {total_M});\n",
+    "  joint_quad_s2z_{set_id} = 0.0;\n"
+  )
+  for (b in seq_along(infos)) {
+    id <- infos[[b]]$id
+    take <- glue("{starts[b]}:{ends[b]}")
+    str_add(out$tpar_comp) <- glue(
+      "  H_joint_s2z_{set_id}[, {take}] = ",
+      "H_s2z_{id} * L_Sigma_s2z_{id};\n",
+      "  P_s2z_{set_id}[{take}, {take}] = P_group_s2z_{id};\n",
+      "  h_joint_s2z_{set_id}[{take}] = h_group_s2z_{id};\n",
+      "  joint_quad_s2z_{set_id} += group_quad_s2z_{id};\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  {{\n",
+    "    matrix[{q}, {total_M}] prior_factor_s2z = diag_pre_multiply(",
+    "sqrt(prior_prec_s2z_{set_id}), H_joint_s2z_{set_id});\n",
+    "    vector[{q}] prior_difference_s2z = ",
+    "sqrt(prior_prec_s2z_{set_id}) .* (theta_s2z{p} - ",
+    "prior_mean_s2z_{set_id});\n",
+    "    vector[{total_M}] forward_solve_s2z;\n",
+    "    P_s2z_{set_id} += crossprod(prior_factor_s2z);\n",
+    "    h_joint_s2z_{set_id} += prior_factor_s2z' * ",
+    "prior_difference_s2z;\n",
+    "    L_P_s2z_{set_id} = cholesky_decompose(P_s2z_{set_id});\n",
+    "    forward_solve_s2z = mdivide_left_tri_low(",
+    "L_P_s2z_{set_id}, h_joint_s2z_{set_id});\n",
+    "    mhat_s2z_{set_id} = (mdivide_right_tri_low(",
+    "forward_solve_s2z', L_P_s2z_{set_id}))';\n",
+    "    joint_quad_s2z_{set_id} -= dot_self(forward_solve_s2z);\n",
+    "  }}\n"
+  )
+
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "flat") {
+      next
+    }
+    if (spec$dist == "normal") {
+      cond_scale <- stan_s2z_number(spec$scale)
+    } else {
+      cond_scale <- glue(
+        "{stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k})"
+      )
+    }
+    str_add(out$tpar_prior) <- glue(
+      "  lprior += normal_{lpdf}(theta_s2z{p}[{k}] | ",
+      "{stan_s2z_number(spec$location)}, {cond_scale});\n"
+    )
+  }
+  str_add(out$tpar_prior) <- glue(
+    "  lprior += -0.5 * joint_quad_s2z_{set_id}\n",
+    "    - sum(log(diagonal(L_P_s2z_{set_id})))\n"
+  )
+  for (b in seq_along(infos)) {
+    r <- infos[[b]]$r
+    id <- infos[[b]]$id
+    str_add(out$tpar_prior) <- glue(
+      "    - (N_{id} - 1) * ",
+      "sum(log(diagonal(L_Sigma_s2z_{id})))\n"
+    )
+    if (identical(r$dist[1], "student")) {
+      str_add(out$tpar_prior) <- glue(
+        "    - M_{id} * sum(log(group_scale_s2z_{id}))\n"
+      )
+    }
+    if (normalize) {
+      str_add(out$tpar_prior) <- glue(
+        "    - 0.5 * N_{id} * M_{id} * log(2 * pi())\n",
+        "    + 0.5 * M_{id} * log(1.0 * N_{id})\n"
+      )
+    }
+  }
+  if (normalize) {
+    str_add(out$tpar_prior) <- glue(
+      "    + 0.5 * {total_M} * log(2 * pi())\n"
+    )
+  }
+  str_add(out$tpar_prior) <- "  ;\n"
+
+  # One conditional draw preserves cross-block posterior covariance in the
+  # conventional population/group parameterization.
+  str_add(out$gen_def) <- glue(
+    "  vector[{q}] q_recovered_s2z_{set_id};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_def) <- glue(
+      "  real Intercept{p};\n",
+      str_if(length(info$fixef), glue("  vector[Kc{p}] b{p};\n")),
+      "  real b{p}_Intercept;\n"
+    )
+  } else {
+    str_add(out$gen_def) <- glue("  vector[{q}] b{p};\n")
+  }
+  for (b in seq_along(infos)) {
+    r <- infos[[b]]$r
+    id <- infos[[b]]$id
+    idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+    r_public <- glue("r_{idp}_{r$cn}")
+    is_cor <- nrow(r) > 1L && isTRUE(r$cor[1])
+    str_add(out$gen_def) <- glue(
+      "  vector[M_{id}] mean_r_s2z_{id};\n"
+    )
+    if (is_cor) {
+      str_add(out$gen_def) <- glue(
+        "  matrix[N_{id}, M_{id}] r_{id};\n"
+      )
+    }
+    str_add(out$gen_def) <- cglue(
+      "  vector[N_{id}] {r_public};\n"
+    )
+    if (is_cor) {
+      str_add(out$gen_def) <- glue(
+        "  // compute group-level correlations\n",
+        "  corr_matrix[M_{id}] Cor_{id}",
+        " = multiply_lower_tri_self_transpose(L_{id});\n",
+        "  vector<lower=-1,upper=1>[NC_{id}] cor_{id};\n"
+      )
+    }
+  }
+
+  str_add(out$gen_comp) <- glue(
+    "  {{\n",
+    "    vector[{total_M}] z_mean_s2z;\n",
+    "    vector[{total_M}] mean_white_s2z;\n",
+    "    for (k in 1:{total_M}) z_mean_s2z[k] = std_normal_rng();\n",
+    "    mean_white_s2z = mhat_s2z_{set_id} + ",
+    "(mdivide_right_tri_low(z_mean_s2z', L_P_s2z_{set_id}))';\n",
+    "    q_recovered_s2z_{set_id} = theta_s2z{p} - ",
+    "H_joint_s2z_{set_id} * mean_white_s2z;\n"
+  )
+  for (b in seq_along(infos)) {
+    r <- infos[[b]]$r
+    id <- infos[[b]]$id
+    M <- nrow(r)
+    J <- seq_rows(r)
+    take <- glue("{starts[b]}:{ends[b]}")
+    idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+    r_s2z <- glue("r_s2z_{idp}_{r$cn}")
+    r_public <- glue("r_{idp}_{r$cn}")
+    is_cor <- M > 1L && isTRUE(r$cor[1])
+    mean_transform <- if (is_cor) {
+      glue("L_Sigma_s2z_{id} * mean_white_s2z[{take}]")
+    } else {
+      glue("sd_{id} .* mean_white_s2z[{take}]")
+    }
+    str_add(out$gen_comp) <- glue(
+      "    mean_r_s2z_{id} = {mean_transform};\n"
+    )
+    if (is_cor) {
+      str_add(out$gen_comp) <- glue(
+        "    r_{id} = r_s2z_{id} + ",
+        "rep_matrix(mean_r_s2z_{id}', N_{id});\n",
+        cglue("    {r_public} = r_{id}[, {J}];\n")
+      )
+    } else {
+      str_add(out$gen_comp) <- cglue(
+        "    {r_public} = {r_s2z} + mean_r_s2z_{id}[{J}];\n"
+      )
+    }
+  }
+  str_add(out$gen_comp) <- "  }\n"
+  for (b in seq_along(infos)) {
+    r <- infos[[b]]$r
+    id <- infos[[b]]$id
+    if (nrow(r) > 1L && isTRUE(r$cor[1])) {
+      str_add(out$gen_comp) <- stan_cor_gen_comp(
+        cor = glue("cor_{id}"), ncol = glue("M_{id}")
+      )
+    }
+  }
+  if (info$center) {
+    str_add(out$gen_comp) <- glue(
+      "  Intercept{p} = q_recovered_s2z_{set_id}[1];\n",
+      str_if(
+        length(info$fixef),
+        glue(
+          "  b{p} = tail(q_recovered_s2z_{set_id}, Kc{p});\n",
+          "  b{p}_Intercept = Intercept{p} - dot_product(",
+          "means_X{p}, b{p});\n"
+        )
+      ),
+      str_if(
+        !length(info$fixef),
+        glue("  b{p}_Intercept = Intercept{p};\n")
+      )
+    )
+  } else {
+    str_add(out$gen_comp) <- glue(
+      "  b{p} = q_recovered_s2z_{set_id};\n"
     )
   }
   out

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -285,11 +285,76 @@ stan_fe <- function(bframe, prior, stanvars, threads, primitive,
   s2z <- has_re_s2z(bframe)
 
   if (s2z) {
+    infos_s2z <- re_s2z_infos(bframe)
     K_s2z <- length(bframe$frame$fe$vars)
+    active_s2z <- infos_s2z[[1L]]$active_q
+    if (is.null(active_s2z)) {
+      active_s2z <- sort(unique(unlist(lapply(infos_s2z, function(info) {
+        rows <- info$match_q
+        if (info$center && any(info$r$coef != "Intercept")) {
+          rows <- c(rows, 1L)
+        }
+        rows
+      }), use.names = FALSE)))
+    }
+    inactive_s2z <- setdiff(seq_len(K_s2z), active_s2z)
+    special_b_s2z <- has_special_prior(prior, bframe, class = "b")
     str_add(out$par) <- glue(
-      "  vector[{K_s2z}] theta_s2z{p};",
-      "  // finite-population coefficients for physical S2Z effects\n"
+      "  vector[{length(active_s2z)}] theta_s2z_active{p};",
+      "  // S2Z-active finite-population coefficients\n"
     )
+    if (length(inactive_s2z)) {
+      inactive_names <- bframe$frame$fe$vars[inactive_s2z]
+      stopifnot(!"Intercept" %in% inactive_names)
+      if (special_b_s2z) {
+        # Validation permits a class-b shrinkage prior only when every
+        # population slope is fixed-only. In that case the ordinary brms
+        # non-centered representation remains exact, and Kscales is still
+        # Kc (or K for an uncentered predictor).
+        stopifnot(length(inactive_names) == length(fixef))
+        inactive_prior <- stan_prior_non_centered(
+          class = "fixed_s2z", suffix = p, suffix_K = ct,
+          normalize = normalize
+        )
+        # The likelihood receives the assembled theta vector instead.
+        inactive_prior$pll_args <- NULL
+        str_add_list(out) <- inactive_prior
+      } else {
+        inactive_prior <- stan_prior(
+          prior, class = "b", coef = inactive_names,
+          type = glue("vector[{length(inactive_s2z)}]"),
+          suffix = glue("_s2z_inactive{p}"), px = px,
+          comment = "S2Z-inactive regression coefficients",
+          normalize = normalize
+        )
+        # Keep this implementation detail out of public b_* discovery while
+        # retaining stan_prior's coefficient, bound, and constant handling.
+        inactive_prior <- lapply(inactive_prior, function(code) {
+          gsub(
+            glue("b_s2z_inactive{p}"), glue("fixed_s2z{p}"), code,
+            fixed = TRUE
+          )
+        })
+        str_add_list(out) <- inactive_prior
+      }
+    }
+    str_add(out$tpar_def) <- glue(
+      "  vector[{K_s2z}] theta_s2z{p};",
+      "  // assembled finite-population coefficients\n"
+    )
+    theta_comp <- if (special_b_s2z) "tpar_special_prior" else "tpar_comp"
+    for (a in seq_along(active_s2z)) {
+      str_add(out[[theta_comp]]) <- glue(
+        "  theta_s2z{p}[{active_s2z[a]}] = ",
+        "theta_s2z_active{p}[{a}];\n"
+      )
+    }
+    for (a in seq_along(inactive_s2z)) {
+      str_add(out[[theta_comp]]) <- glue(
+        "  theta_s2z{p}[{inactive_s2z[a]}] = ",
+        "fixed_s2z{p}[{a}];\n"
+      )
+    }
     str_add(out$pll_args) <- glue(", vector theta_s2z{p}")
   }
 
@@ -886,6 +951,315 @@ stan_re <- function(bframe, prior, normalize, ...) {
 .stan_re_s2z_joint_uses_matheron <- function(set) {
   !is.null(.stan_re_s2z_joint_matheron_info(set))
 }
+
+# A logistic population prior cannot be integrated by the conditional
+# Gaussian omitted-mean kernels. Such systems retain the omitted means
+# explicitly in standardized coordinates and score the exact requested prior.
+.stan_re_s2z_uses_explicit_mean <- function(set) {
+  any(vapply(set$infos, function(info) {
+    !is.null(info$prior) && any(vapply(
+      info$prior, function(spec) identical(spec$dist, "logistic"), logical(1)
+    ))
+  }, logical(1)))
+}
+
+# Exact scalar population-prior statement for the explicit-mean path.
+stan_re_s2z_prior_target <- function(spec, par, normalize) {
+  stopifnot(is.list(spec), is.character(par), length(par) == 1L)
+  if (identical(spec$dist, "flat")) {
+    return("")
+  }
+  lpdf <- stan_lpdf_name(normalize)
+  location <- stan_s2z_number(spec$location)
+  scale <- stan_s2z_number(spec$scale)
+  if (identical(spec$dist, "normal")) {
+    glue("  lprior += normal_{lpdf}({par} | {location}, {scale});\n")
+  } else if (identical(spec$dist, "student")) {
+    df <- stan_s2z_number(spec$df)
+    glue(
+      "  lprior += student_t_{lpdf}({par} | {df}, {location}, {scale});\n"
+    )
+  } else if (identical(spec$dist, "logistic")) {
+    glue("  lprior += logistic_{lpdf}({par} | {location}, {scale});\n")
+  } else {
+    stop2("Internal error: unsupported explicit S2Z population prior.")
+  }
+}
+
+# One block in an exact explicit-mean system. The sampled mean coordinate is
+# v = sqrt(N) L^-1 m, so m = L v / sqrt(N). With orthonormal S2Z contrasts,
+# the Jacobian back to conventional group effects is |L|.
+.stan_re_s2z_explicit_block <- function(id, set, prior, normalize,
+                                        out = list()) {
+  if (is.null(out[["tpar_prior"]])) {
+    out[["tpar_prior"]] <- ""
+  }
+  take_info <- match(id, vapply(set$infos, `[[`, numeric(1), "id"))
+  stopifnot(!is.na(take_info))
+  info <- set$infos[[take_info]]
+  r <- info$r
+  q <- length(info$qnames)
+  M <- nrow(r)
+  J <- seq_rows(r)
+  p <- info$p
+  px <- check_prefix(r)
+  idp <- paste0(r$id, usc(combine_prefix(px)))
+  r_s2z <- glue("r_s2z_{idp}_{r$cn}")
+  is_cor <- M > 1L && isTRUE(r$cor[1])
+  is_student <- identical(r$dist[1], "student")
+
+  if (is_cor) {
+    str_add(out$data) <- glue(
+      "  int<lower=1> NC_{id};  // number of group-level correlations\n"
+    )
+    str_add_list(out) <- stan_prior(
+      prior, class = "L", group = r$group[1], suffix = usc(id),
+      type = glue("cholesky_factor_corr[M_{id}]"),
+      comment = "cholesky factor of correlation matrix",
+      normalize = normalize
+    )
+  }
+  if (identical(id, set$set_id)) {
+    str_add(out$fun) <- "  #include 'fun_sum_to_zero.stan'\n"
+  }
+
+  str_add(out$par) <- glue(
+    "  vector[M_{id} * (N_{id} - 1)] z_s2z_{id};",
+    "  // physical orthonormal S2Z coordinates\n",
+    "  vector[M_{id}] z_mean_s2z_{id};",
+    "  // standardized omitted group mean\n"
+  )
+  str_add(out$tpar_def) <- glue(
+    "  // exact explicit-mean S2Z block {id}\n",
+    "  matrix[N_{id}, M_{id}] r_s2z_{id};\n",
+    "  matrix[M_{id}, M_{id}] L_Sigma_s2z_{id};\n",
+    "  vector[M_{id}] mean_r_s2z_{id};\n",
+    "  real<lower=0> group_quad_s2z_{id};\n",
+    str_if(
+      is_student,
+      glue(
+        "  vector<lower=0>[N_{id}] group_scale_s2z_{id};\n",
+        "  vector<lower=0>[N_{id}] group_prec_s2z_{id};\n"
+      )
+    ),
+    cglue("  vector[N_{id}] {r_s2z};\n")
+  )
+
+  # H is fixed by the formula and centered predictor means. Build it once in
+  # transformed data so it never enters the reverse-mode expression graph.
+  str_add(out$tdata_def) <- glue(
+    "  matrix[{q}, M_{id}] H_s2z_{id};\n"
+  )
+  str_add(out$tdata_comp) <- glue(
+    "  H_s2z_{id} = rep_matrix(0.0, {q}, M_{id});\n"
+  )
+  for (j in seq_len(M)) {
+    qi <- info$match_q[j]
+    str_add(out$tdata_comp) <- glue(
+      "  H_s2z_{id}[{qi}, {j}] = 1.0;\n"
+    )
+    if (info$center && info$r$coef[j] != "Intercept") {
+      str_add(out$tdata_comp) <- glue(
+        "  H_s2z_{id}[1, {j}] = means_X{p}[{qi - 1L}];\n"
+      )
+    }
+  }
+  if (is_cor) {
+    str_add(out$tpar_comp) <- glue(
+      "  L_Sigma_s2z_{id} = diag_pre_multiply(sd_{id}, L_{id});\n"
+    )
+  } else {
+    str_add(out$tpar_comp) <- glue(
+      "  L_Sigma_s2z_{id} = diag_matrix(sd_{id});\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  for (k in 1:M_{id}) {{\n",
+    "    r_s2z_{id}[, k] = sum_to_zero_constrain_brms(",
+    "segment(z_s2z_{id}, (k - 1) * (N_{id} - 1) + 1, ",
+    "N_{id} - 1));\n",
+    "  }}\n",
+    "  mean_r_s2z_{id} = L_Sigma_s2z_{id} * z_mean_s2z_{id} / ",
+    "sqrt(1.0 * N_{id});\n"
+  )
+  if (is_student) {
+    tr <- subset_reframe_dist(r, "student")
+    g <- usc(tr$ggn[1])
+    str_add(out$tpar_comp) <- glue(
+      "  group_scale_s2z_{id} = dfm{g};\n",
+      "  group_prec_s2z_{id} = inv_square(group_scale_s2z_{id});\n"
+    )
+  }
+  explicit_group_quad_code <- if (is_student) {
+    glue(
+      "    vector[M_{id}] mean_white_s2z = z_mean_s2z_{id} / ",
+      "sqrt(1.0 * N_{id});\n",
+      "    group_quad_s2z_{id} = 0.0;\n",
+      "    for (j in 1:N_{id}) {{\n",
+      "      vector[M_{id}] white_level_s2z = ",
+      "white_group_s2z[, j] + mean_white_s2z;\n",
+      "      group_quad_s2z_{id} += group_prec_s2z_{id}[j] * ",
+      "dot_self(white_level_s2z);\n",
+      "    }}\n"
+    )
+  } else {
+    glue(
+      "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z)) ",
+      "+ dot_self(z_mean_s2z_{id});\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  {{\n",
+    "    matrix[M_{id}, N_{id}] white_group_s2z = ",
+    "mdivide_left_tri_low(L_Sigma_s2z_{id}, r_s2z_{id}');\n",
+    "{explicit_group_quad_code}",
+    "  }}\n",
+    cglue("  {r_s2z} = r_s2z_{id}[, {J}];\n")
+  )
+  str_add(out$pll_args) <- cglue(", vector {r_s2z}")
+
+  str_add(out$tpar_prior) <- glue(
+    "  lprior += -0.5 * group_quad_s2z_{id}\n",
+    "    - (N_{id} - 1) * ",
+    "sum(log(diagonal(L_Sigma_s2z_{id})))\n",
+    str_if(
+      is_student,
+      glue("    - M_{id} * sum(log(group_scale_s2z_{id}))\n")
+    ),
+    str_if(
+      normalize,
+      glue("    - 0.5 * N_{id} * M_{id} * log(2 * pi())\n")
+    ),
+    "  ;\n"
+  )
+  out
+}
+
+# Score and reconstruct one complete explicit-mean system after its blocks
+# have been generated. This path is shared by singleton and multiblock models.
+.stan_re_s2z_explicit_system <- function(set, normalize, out = list()) {
+  infos <- set$infos
+  info <- infos[[1L]]
+  q <- length(info$qnames)
+  set_id <- set$set_id
+  p <- info$p
+  active_q <- info$active_q
+  if (is.null(active_q)) {
+    active_q <- which(vapply(
+      info$prior, function(spec) !identical(spec$dist, "flat"), logical(1)
+    ))
+  }
+
+  str_add(out$tpar_def) <- glue(
+    "  vector[{q}] q_explicit_s2z_{set_id};",
+    "  // conventional coefficients for exact explicit S2Z means\n"
+  )
+  str_add(out$tpar_comp) <- glue(
+    "  q_explicit_s2z_{set_id} = theta_s2z{p};\n"
+  )
+  for (block in infos) {
+    str_add(out$tpar_comp) <- glue(
+      "  q_explicit_s2z_{set_id} -= H_s2z_{block$id} * ",
+      "mean_r_s2z_{block$id};\n"
+    )
+  }
+  for (k in active_q) {
+    str_add(out$tpar_prior) <- stan_re_s2z_prior_target(
+      info$prior[[k]], glue("q_explicit_s2z_{set_id}[{k}]"), normalize
+    )
+  }
+
+  str_add(out$gen_def) <- glue(
+    "  vector[{q}] q_recovered_s2z_{set_id};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_def) <- glue(
+      "  real Intercept{p};\n",
+      str_if(length(info$fixef), glue("  vector[Kc{p}] b{p};\n")),
+      "  real b{p}_Intercept;\n"
+    )
+  } else {
+    str_add(out$gen_def) <- glue("  vector[{q}] b{p};\n")
+  }
+  for (block in infos) {
+    r <- block$r
+    id <- block$id
+    J <- seq_rows(r)
+    idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+    r_s2z <- glue("r_s2z_{idp}_{r$cn}")
+    r_public <- glue("r_{idp}_{r$cn}")
+    is_cor <- nrow(r) > 1L && isTRUE(r$cor[1])
+    if (is_cor) {
+      str_add(out$gen_def) <- glue(
+        "  matrix[N_{id}, M_{id}] r_{id};\n",
+        "  corr_matrix[M_{id}] Cor_{id}",
+        " = multiply_lower_tri_self_transpose(L_{id});\n",
+        "  vector<lower=-1,upper=1>[NC_{id}] cor_{id};\n"
+      )
+    }
+    str_add(out$gen_def) <- cglue(
+      "  vector[N_{id}] {r_public};\n"
+    )
+    if (is_cor) {
+      str_add(out$gen_comp) <- glue(
+        "  r_{id} = r_s2z_{id};\n",
+        "  for (j in 1:N_{id}) r_{id}[j] += mean_r_s2z_{id}';\n",
+        cglue("  {r_public} = r_{id}[, {J}];\n")
+      )
+    } else {
+      str_add(out$gen_comp) <- cglue(
+        "  {r_public} = {r_s2z} + mean_r_s2z_{id}[{J}];\n"
+      )
+    }
+  }
+  str_add(out$gen_comp) <- glue(
+    "  q_recovered_s2z_{set_id} = q_explicit_s2z_{set_id};\n"
+  )
+  for (block in infos) {
+    r <- block$r
+    id <- block$id
+    if (nrow(r) > 1L && isTRUE(r$cor[1])) {
+      str_add(out$gen_comp) <- stan_cor_gen_comp(
+        cor = glue("cor_{id}"), ncol = glue("M_{id}")
+      )
+    }
+  }
+  if (info$center) {
+    str_add(out$gen_comp) <- glue(
+      "  Intercept{p} = q_recovered_s2z_{set_id}[1];\n",
+      str_if(
+        length(info$fixef),
+        glue(
+          "  b{p} = tail(q_recovered_s2z_{set_id}, Kc{p});\n",
+          "  b{p}_Intercept = Intercept{p} - dot_product(",
+          "means_X{p}, b{p});\n"
+        )
+      ),
+      str_if(
+        !length(info$fixef), glue("  b{p}_Intercept = Intercept{p};\n")
+      )
+    )
+  } else {
+    str_add(out$gen_comp) <- glue(
+      "  b{p} = q_recovered_s2z_{set_id};\n"
+    )
+  }
+  out
+}
+
+.stan_re_s2z_explicit <- function(id, bframe, prior, normalize,
+                                   out = list()) {
+  r <- subset2(bframe$frame$re, id = id)
+  bfl <- re_s2z_bframel(bframe, r)
+  infos <- re_s2z_infos(bfl, prior = prior)
+  stopifnot(length(infos) == 1L)
+  set <- nlist(set_id = id, ids = id, bfl, infos)
+  out <- .stan_re_s2z_explicit_block(
+    id, set = set, prior = prior, normalize = normalize, out = out
+  )
+  .stan_re_s2z_explicit_system(set, normalize = normalize, out = out)
+}
+
 # Stan code local to one covariance block participating in a joint S2Z
 # omitted-mean system. The block contributes its physical zero-sum effects and
 # the Gaussian normal equations for its omitted mean in reference-whitened
@@ -896,6 +1270,11 @@ stan_re <- function(bframe, prior, normalize, ...) {
   lpdf <- stan_lpdf_name(normalize)
   if (is.null(out[["tpar_prior"]])) {
     out[["tpar_prior"]] <- ""
+  }
+  if (.stan_re_s2z_uses_explicit_mean(set)) {
+    return(.stan_re_s2z_explicit_block(
+      id, set = set, prior = prior, normalize = normalize, out = out
+    ))
   }
   r <- subset2(bframe$frame$re, id = id)
   stopifnot(is.reframe(r), has_rows(r), all(r$s2z), id %in% set$ids)
@@ -926,14 +1305,13 @@ stan_re <- function(bframe, prior, normalize, ...) {
   }
 
   str_add(out$par) <- glue(
-    "  array[M_{id}] vector[N_{id} - 1] z_s2z_{id};",
+    "  vector[M_{id} * (N_{id} - 1)] z_s2z_{id};",
     "  // physical orthonormal S2Z coordinates\n"
   )
 
   str_add(out$tpar_def) <- glue(
     "  // S2Z block {id} in a joint omitted-mean system\n",
     "  matrix[N_{id}, M_{id}] r_s2z_{id};\n",
-    "  matrix[{q}, M_{id}] H_s2z_{id};\n",
     "  matrix[M_{id}, M_{id}] L_Sigma_s2z_{id};\n",
     str_if(
       !use_matheron,
@@ -954,6 +1332,26 @@ stan_re <- function(bframe, prior, normalize, ...) {
     cglue("  vector[N_{id}] {r_s2z};\n")
   )
 
+  # This map is a deterministic function of formula structure and predictor
+  # centering constants, so construct it outside the autodiff graph.
+  str_add(out$tdata_def) <- glue(
+    "  matrix[{q}, M_{id}] H_s2z_{id};\n"
+  )
+  str_add(out$tdata_comp) <- glue(
+    "  H_s2z_{id} = rep_matrix(0.0, {q}, M_{id});\n"
+  )
+  for (j in seq_len(M)) {
+    qi <- info$match_q[j]
+    str_add(out$tdata_comp) <- glue(
+      "  H_s2z_{id}[{qi}, {j}] = 1.0;\n"
+    )
+    if (info$center && info$r$coef[j] != "Intercept") {
+      str_add(out$tdata_comp) <- glue(
+        "  H_s2z_{id}[1, {j}] = means_X{info$p}[{qi - 1L}];\n"
+      )
+    }
+  }
+
   if (is_student) {
     tr <- subset_reframe_dist(r, "student")
     g <- usc(tr$ggn[1])
@@ -963,20 +1361,6 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
   }
 
-  str_add(out$tpar_comp) <- glue(
-    "  H_s2z_{id} = rep_matrix(0.0, {q}, M_{id});\n"
-  )
-  for (j in seq_len(M)) {
-    qi <- info$match_q[j]
-    str_add(out$tpar_comp) <- glue(
-      "  H_s2z_{id}[{qi}, {j}] = 1.0;\n"
-    )
-    if (info$center && info$r$coef[j] != "Intercept") {
-      str_add(out$tpar_comp) <- glue(
-        "  H_s2z_{id}[1, {j}] = means_X{info$p}[{qi - 1L}];\n"
-      )
-    }
-  }
   scale <- glue("sd_{id}")
   if (is_cor) {
     str_add(out$tpar_comp) <- glue(
@@ -990,7 +1374,9 @@ stan_re <- function(bframe, prior, normalize, ...) {
 
   str_add(out$tpar_comp) <- glue(
     "  for (k in 1:M_{id}) {{\n",
-    "    r_s2z_{id}[, k] = sum_to_zero_constrain_brms(z_s2z_{id}[k]);\n",
+    "    r_s2z_{id}[, k] = sum_to_zero_constrain_brms(",
+    "segment(z_s2z_{id}, (k - 1) * (N_{id} - 1) + 1, ",
+    "N_{id} - 1));\n",
     "  }}\n"
   )
 
@@ -1005,9 +1391,12 @@ stan_re <- function(bframe, prior, normalize, ...) {
   } else if (use_matheron) {
     str_add(out$tpar_comp) <- glue(
       "  {{\n",
-      "    matrix[N_{id}, M_{id}] white_group_s2z = r_s2z_{id} ./ ",
-      "rep_matrix(sd_{id}', N_{id});\n",
-      "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z));\n",
+      "    group_quad_s2z_{id} = 0.0;\n",
+      "    for (k in 1:M_{id}) {{\n",
+      "      vector[N_{id}] white_group_s2z = ",
+      "r_s2z_{id}[, k] / sd_{id}[k];\n",
+      "      group_quad_s2z_{id} += dot_self(white_group_s2z);\n",
+      "    }}\n",
       "  }}\n"
     )
   } else if (is_cor) {
@@ -1020,15 +1409,12 @@ stan_re <- function(bframe, prior, normalize, ...) {
       glue(
         "    h_group_s2z_{id} = -white_group_s2z * ",
         "group_prec_s2z_{id};\n",
-        "    group_quad_s2z_{id} = 0.0;\n",
-        "    for (j in 1:N_{id}) {{\n",
-        "      group_quad_s2z_{id} += group_prec_s2z_{id}[j] * ",
-        "dot_self(white_group_s2z[, j]);\n",
-        "    }}\n"
+        "    group_quad_s2z_{id} = columns_dot_self(white_group_s2z) * ",
+        "group_prec_s2z_{id};\n"
       )
     } else {
       glue(
-        "    h_group_s2z_{id} = rep_vector(0.0, M_{id});\n",
+        "    h_group_s2z_{id} = zeros_vector(M_{id});\n",
         "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z));\n"
       )
     }
@@ -1048,24 +1434,30 @@ stan_re <- function(bframe, prior, normalize, ...) {
     }
     group_score_code <- if (is_student) {
       glue(
-        "    h_group_s2z_{id} = -(white_group_s2z' * ",
-        "group_prec_s2z_{id});\n",
+        "    h_group_s2z_{id} = zeros_vector(M_{id});\n",
         "    group_quad_s2z_{id} = 0.0;\n",
-        "    for (j in 1:N_{id}) {{\n",
-        "      group_quad_s2z_{id} += group_prec_s2z_{id}[j] * ",
-        "dot_self(white_group_s2z[j]');\n",
+        "    for (k in 1:M_{id}) {{\n",
+        "      vector[N_{id}] white_group_s2z = r_s2z_{id}[, k] / ",
+        "{scale}[k];\n",
+        "      h_group_s2z_{id}[k] = -dot_product(",
+        "white_group_s2z, group_prec_s2z_{id});\n",
+        "      group_quad_s2z_{id} += dot_product(",
+        "group_prec_s2z_{id}, square(white_group_s2z));\n",
         "    }}\n"
       )
     } else {
       glue(
-        "    h_group_s2z_{id} = rep_vector(0.0, M_{id});\n",
-        "    group_quad_s2z_{id} = dot_self(to_vector(white_group_s2z));\n"
+        "    h_group_s2z_{id} = zeros_vector(M_{id});\n",
+        "    group_quad_s2z_{id} = 0.0;\n",
+        "    for (k in 1:M_{id}) {{\n",
+        "      vector[N_{id}] white_group_s2z = r_s2z_{id}[, k] / ",
+        "{scale}[k];\n",
+        "      group_quad_s2z_{id} += dot_self(white_group_s2z);\n",
+        "    }}\n"
       )
     }
     str_add(out$tpar_comp) <- glue(
       "  {{\n",
-      "    matrix[N_{id}, M_{id}] white_group_s2z = r_s2z_{id} ./ ",
-      "rep_matrix({scale}', N_{id});\n",
       "    P_group_s2z_{id} = diag_matrix(rep_vector({group_info}, M_{id}));\n",
       "{group_score_code}",
       "  }}\n"
@@ -1092,6 +1484,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
   P <- matheron$P
   inactive <- matheron$inactive
   rdim <- length(P)
+  P_index <- paste0("{", paste(P, collapse = ", "), "}")
   set_id <- set$set_id
   p <- info$p
   lpdf <- stan_lpdf_name(normalize)
@@ -1162,14 +1555,9 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
   } else if (rdim > 1L) {
     str_add(out$tpar_comp) <- glue(
-      "  W_matheron_s2z_{set_id} = rep_matrix(0.0, {rdim}, {rdim});\n"
+      "  W_matheron_s2z_{set_id} = diag_matrix(square(",
+      "prior_scale_s2z_{set_id}[{P_index}]));\n"
     )
-    for (a in seq_len(rdim)) {
-      str_add(out$tpar_comp) <- glue(
-        "  W_matheron_s2z_{set_id}[{a}, {a}] = ",
-        "square(prior_scale_s2z_{set_id}[{P[a]}]);\n"
-      )
-    }
   }
   str_add(out$tpar_comp) <- glue(
     "  joint_quad_s2z_{set_id} = 0.0;\n"
@@ -1184,14 +1572,8 @@ stan_re <- function(bframe, prior, normalize, ...) {
     } else if (rdim > 1L) {
       str_add(out$tpar_comp) <- glue(
         "  {{\n",
-        "    matrix[{rdim}, M_{id}] H_active_s2z;\n"
-      )
-      for (a in seq_len(rdim)) {
-        str_add(out$tpar_comp) <- glue(
-          "    H_active_s2z[{a}, ] = H_s2z_{id}[{P[a]}, ];\n"
-        )
-      }
-      str_add(out$tpar_comp) <- glue(
+        "    matrix[{rdim}, M_{id}] H_active_s2z = ",
+        "H_s2z_{id}[{P_index}, ];\n",
         "    W_matheron_s2z_{set_id} += tcrossprod(",
         "H_active_s2z * L_Sigma_s2z_{id}) / (1.0 * N_{id});\n",
         "  }}\n"
@@ -1213,15 +1595,8 @@ stan_re <- function(bframe, prior, normalize, ...) {
       "  L_W_matheron_s2z_{set_id} = ",
       "cholesky_decompose(W_matheron_s2z_{set_id});\n",
       "  {{\n",
-      "    vector[{rdim}] theta_difference_s2z;\n"
-    )
-    for (a in seq_len(rdim)) {
-      str_add(out$tpar_comp) <- glue(
-        "    theta_difference_s2z[{a}] = theta_s2z{p}[{P[a]}] - ",
-        "prior_mean_s2z_{set_id}[{P[a]}];\n"
-      )
-    }
-    str_add(out$tpar_comp) <- glue(
+      "    vector[{rdim}] theta_difference_s2z = ",
+      "theta_s2z{p}[{P_index}] - prior_mean_s2z_{set_id}[{P_index}];\n",
       "    theta_white_matheron_s2z_{set_id} = mdivide_left_tri_low(",
       "L_W_matheron_s2z_{set_id}, theta_difference_s2z);\n",
       "  }}\n"
@@ -1384,7 +1759,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
       str_add(out$gen_comp) <- glue(
         "    {{\n",
         "      vector[M_{id}] active_score_s2z = ",
-        "rep_vector(0.0, M_{id});\n"
+        "zeros_vector(M_{id});\n"
       )
       for (a in seq_len(rdim)) {
         str_add(out$gen_comp) <- glue(
@@ -1403,8 +1778,8 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
     if (is_cor) {
       str_add(out$gen_comp) <- glue(
-        "    r_{id} = r_s2z_{id} + ",
-        "rep_matrix(mean_r_s2z_{id}', N_{id});\n",
+        "    r_{id} = r_s2z_{id};\n",
+        "    for (j in 1:N_{id}) r_{id}[j] += mean_r_s2z_{id}';\n",
         cglue("    {r_public} = r_{id}[, {J}];\n")
       )
     } else {
@@ -1456,6 +1831,11 @@ stan_re <- function(bframe, prior, normalize, ...) {
   out <- list(tpar_prior = "")
   infos <- set$infos
   stopifnot(length(infos) > 1L)
+  if (.stan_re_s2z_uses_explicit_mean(set)) {
+    return(.stan_re_s2z_explicit_system(
+      set, normalize = normalize, out = out
+    ))
+  }
   if (.stan_re_s2z_joint_uses_matheron(set)) {
     return(.stan_re_s2z_joint_matheron(
       set, prior = prior, threads = threads, normalize = normalize, ...
@@ -1465,7 +1845,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
   q <- length(info$qnames)
   Ms <- vapply(infos, function(x) nrow(x$r), integer(1))
   total_M <- sum(Ms)
-  starts <- cumsum(c(1L, head(Ms, -1L)))
+  starts <- cumsum(c(1L, utils::head(Ms, -1L)))
   ends <- starts + Ms - 1L
   set_id <- set$set_id
   p <- info$p
@@ -1492,7 +1872,6 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "{paste(set$ids, collapse = ', ')}\n",
     "  vector[{q}] prior_mean_s2z_{set_id};\n",
     "  vector<lower=0>[{q}] prior_prec_s2z_{set_id};\n",
-    "  matrix[{q}, {total_M}] H_joint_s2z_{set_id};\n",
     "  matrix[{total_M}, {total_M}] P_s2z_{set_id};\n",
     "  matrix[{total_M}, {total_M}] L_P_s2z_{set_id};\n",
     "  vector[{total_M}] h_joint_s2z_{set_id};\n",
@@ -1521,31 +1900,36 @@ stan_re <- function(bframe, prior, normalize, ...) {
   }
 
   str_add(out$tpar_comp) <- glue(
-    "  H_joint_s2z_{set_id} = rep_matrix(0.0, {q}, {total_M});\n",
-    "  P_s2z_{set_id} = rep_matrix(0.0, {total_M}, {total_M});\n",
-    "  h_joint_s2z_{set_id} = rep_vector(0.0, {total_M});\n",
-    "  joint_quad_s2z_{set_id} = 0.0;\n"
+    "  joint_quad_s2z_{set_id} = 0.0;\n",
+    "  {{\n",
+    "    matrix[{q}, {total_M}] prior_factor_s2z;\n",
+    "    vector[{q}] prior_difference_s2z = ",
+    "sqrt(prior_prec_s2z_{set_id}) .* (theta_s2z{p} - ",
+    "prior_mean_s2z_{set_id});\n",
+    "    vector[{total_M}] forward_solve_s2z;\n"
   )
   for (b in seq_along(infos)) {
     id <- infos[[b]]$id
     take <- glue("{starts[b]}:{ends[b]}")
     str_add(out$tpar_comp) <- glue(
-      "  H_joint_s2z_{set_id}[, {take}] = ",
-      "H_s2z_{id} * L_Sigma_s2z_{id};\n",
-      "  P_s2z_{set_id}[{take}, {take}] = P_group_s2z_{id};\n",
-      "  h_joint_s2z_{set_id}[{take}] = h_group_s2z_{id};\n",
-      "  joint_quad_s2z_{set_id} += group_quad_s2z_{id};\n"
+      "    prior_factor_s2z[, {take}] = diag_pre_multiply(",
+      "sqrt(prior_prec_s2z_{set_id}), H_s2z_{id} * ",
+      "L_Sigma_s2z_{id});\n"
     )
   }
   str_add(out$tpar_comp) <- glue(
-    "  {{\n",
-    "    matrix[{q}, {total_M}] prior_factor_s2z = diag_pre_multiply(",
-    "sqrt(prior_prec_s2z_{set_id}), H_joint_s2z_{set_id});\n",
-    "    vector[{q}] prior_difference_s2z = ",
-    "sqrt(prior_prec_s2z_{set_id}) .* (theta_s2z{p} - ",
-    "prior_mean_s2z_{set_id});\n",
-    "    vector[{total_M}] forward_solve_s2z;\n",
-    "    P_s2z_{set_id} += crossprod(prior_factor_s2z);\n",
+    "    P_s2z_{set_id} = crossprod(prior_factor_s2z);\n"
+  )
+  for (b in seq_along(infos)) {
+    id <- infos[[b]]$id
+    take <- glue("{starts[b]}:{ends[b]}")
+    str_add(out$tpar_comp) <- glue(
+      "    P_s2z_{set_id}[{take}, {take}] += P_group_s2z_{id};\n",
+      "    h_joint_s2z_{set_id}[{take}] = h_group_s2z_{id};\n",
+      "    joint_quad_s2z_{set_id} += group_quad_s2z_{id};\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
     "    h_joint_s2z_{set_id} += prior_factor_s2z' * ",
     "prior_difference_s2z;\n",
     "    L_P_s2z_{set_id} = cholesky_decompose(P_s2z_{set_id});\n",
@@ -1653,8 +2037,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "    for (k in 1:{total_M}) z_mean_s2z[k] = std_normal_rng();\n",
     "    mean_white_s2z = mhat_s2z_{set_id} + ",
     "(mdivide_right_tri_low(z_mean_s2z', L_P_s2z_{set_id}))';\n",
-    "    q_recovered_s2z_{set_id} = theta_s2z{p} - ",
-    "H_joint_s2z_{set_id} * mean_white_s2z;\n"
+    "    q_recovered_s2z_{set_id} = theta_s2z{p};\n"
   )
   for (b in seq_along(infos)) {
     r <- infos[[b]]$r
@@ -1672,12 +2055,14 @@ stan_re <- function(bframe, prior, normalize, ...) {
       glue("sd_{id} .* mean_white_s2z[{take}]")
     }
     str_add(out$gen_comp) <- glue(
-      "    mean_r_s2z_{id} = {mean_transform};\n"
+      "    mean_r_s2z_{id} = {mean_transform};\n",
+      "    q_recovered_s2z_{set_id} -= H_s2z_{id} * ",
+      "mean_r_s2z_{id};\n"
     )
     if (is_cor) {
       str_add(out$gen_comp) <- glue(
-        "    r_{id} = r_s2z_{id} + ",
-        "rep_matrix(mean_r_s2z_{id}', N_{id});\n",
+        "    r_{id} = r_s2z_{id};\n",
+        "    for (j in 1:N_{id}) r_{id}[j] += mean_r_s2z_{id}';\n",
         cglue("    {r_public} = r_{id}[, {J}];\n")
       )
     } else {
@@ -1744,6 +2129,14 @@ stan_re <- function(bframe, prior, normalize, ...) {
   is_cor <- M > 1L && isTRUE(r$cor[1])
   is_student <- identical(r$dist[1], "student")
 
+  single_set <- nlist(set_id = id, ids = id, bfl, infos = list(info))
+  if (.stan_re_s2z_uses_explicit_mean(single_set)) {
+    return(.stan_re_s2z_explicit(
+      id, bframe = bframe, prior = prior,
+      normalize = normalize, out = out
+    ))
+  }
+
   if (M == 1L) {
     return(.stan_re_s2z_scalar(
       id, r = r, info = info, normalize = normalize, out = out
@@ -1772,7 +2165,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
 
   str_add(out$fun) <- "  #include 'fun_sum_to_zero.stan'\n"
   str_add(out$par) <- glue(
-    "  array[M_{id}] vector[N_{id} - 1] z_s2z_{id};",
+    "  vector[M_{id} * (N_{id} - 1)] z_s2z_{id};",
     "  // physical orthonormal S2Z coordinates\n"
   )
 
@@ -1795,7 +2188,6 @@ stan_re <- function(bframe, prior, normalize, ...) {
   str_add(out$tpar_def) <- glue(
     "  // physical sum-to-zero group-level effects of ID {id}\n",
     "  matrix[N_{id}, M_{id}] r_s2z_{id};\n",
-    "  matrix[{q}, M_{id}] H_s2z_{id};\n",
     "  vector[{q}] prior_mean_s2z_{id};\n",
     "  vector<lower=0>[{q}] prior_prec_s2z_{id};\n",
     "  vector<lower=0>[N_{id}] group_scale_s2z_{id};\n",
@@ -1806,24 +2198,27 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "  matrix[M_{id}, M_{id}] L_P_s2z_{id};\n",
     "  vector[M_{id}] mhat_s2z_{id};\n",
     "  vector[{q}] qhat_s2z_{id};\n",
-    "  matrix[M_{id}, N_{id}] white_s2z_{id};\n",
+    "  real<lower=0> group_quad_s2z_{id};\n",
     "  // using vectors speeds up indexing in loops\n",
     cglue("  vector[N_{id}] r_s2z_{idp}_{r$cn};\n")
   )
 
   # The mapping H absorbs the omitted raw group mean into brms's population
-  # coordinates. For centered predictors its first row contains the actual
-  # means of every matching raw design column, including interactions.
-  str_add(out$tpar_comp) <- glue(
+  # coordinates. It is fixed by the formula and centered design-column means,
+  # so construct it once outside the autodiff graph.
+  str_add(out$tdata_def) <- glue(
+    "  matrix[{q}, M_{id}] H_s2z_{id};\n"
+  )
+  str_add(out$tdata_comp) <- glue(
     "  H_s2z_{id} = rep_matrix(0.0, {q}, M_{id});\n"
   )
   for (j in seq_len(M)) {
     qi <- info$match_q[j]
-    str_add(out$tpar_comp) <- glue(
+    str_add(out$tdata_comp) <- glue(
       "  H_s2z_{id}[{qi}, {j}] = 1.0;\n"
     )
     if (info$center && info$r$coef[j] != "Intercept") {
-      str_add(out$tpar_comp) <- glue(
+      str_add(out$tdata_comp) <- glue(
         "  H_s2z_{id}[1, {j}] = means_X{p}[{qi - 1L}];\n"
       )
     }
@@ -1839,7 +2234,9 @@ stan_re <- function(bframe, prior, normalize, ...) {
   }
   str_add(out$tpar_comp) <- glue(
     "  for (k in 1:M_{id}) {{\n",
-    "    r_s2z_{id}[, k] = sum_to_zero_constrain_brms(z_s2z_{id}[k]);\n",
+    "    r_s2z_{id}[, k] = sum_to_zero_constrain_brms(",
+    "segment(z_s2z_{id}, (k - 1) * (N_{id} - 1) + 1, ",
+    "N_{id} - 1));\n",
     "  }}\n"
   )
 
@@ -1875,6 +2272,21 @@ stan_re <- function(bframe, prior, normalize, ...) {
       "  group_scale_s2z_{id} = rep_vector(1.0, N_{id});\n"
     )
   }
+  direct_group_quad_code <- if (is_student) {
+    glue(
+      "    group_quad_s2z_{id} = 0.0;\n",
+      "    for (j in 1:N_{id}) {{\n",
+      "      vector[M_{id}] white_level_s2z = (white_s2z[, j] + ",
+      "mean_white_s2z) / group_scale_s2z_{id}[j];\n",
+      "      group_quad_s2z_{id} += dot_self(white_level_s2z);\n",
+      "    }}\n"
+    )
+  } else {
+    glue(
+      "    group_quad_s2z_{id} = dot_self(to_vector(white_s2z)) + ",
+      "N_{id} * dot_self(mean_white_s2z);\n"
+    )
+  }
   str_add(out$tpar_comp) <- glue(
     "  group_prec_s2z_{id} = inv_square(group_scale_s2z_{id});\n",
     "  {{\n",
@@ -1891,10 +2303,11 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "    L_P_s2z_{id} = cholesky_decompose(P_s2z_{id});\n",
     "    mhat_s2z_{id} = mdivide_left_spd(P_s2z_{id}, h_s2z);\n",
     "    qhat_s2z_{id} = theta_s2z{p} - H_s2z_{id} * mhat_s2z_{id};\n",
-    "    white_s2z_{id} = mdivide_left_tri_low(L_Sigma_s2z_{id}, ",
-    "(r_s2z_{id} + rep_matrix(mhat_s2z_{id}', N_{id}))');\n",
-    "    white_s2z_{id} = white_s2z_{id} .* rep_matrix(",
-    "(1.0 ./ group_scale_s2z_{id})', M_{id});\n",
+    "    matrix[M_{id}, N_{id}] white_s2z = mdivide_left_tri_low(",
+    "L_Sigma_s2z_{id}, r_s2z_{id}');\n",
+    "    vector[M_{id}] mean_white_s2z = mdivide_left_tri_low(",
+    "L_Sigma_s2z_{id}, mhat_s2z_{id});\n",
+    "{direct_group_quad_code}",
     "  }}\n",
     cglue("  r_s2z_{idp}_{r$cn} = r_s2z_{id}[, {J}];\n")
   )
@@ -1924,7 +2337,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
   }
   str_add(out$tpar_prior) <- glue(
-    "  lprior += -0.5 * dot_self(to_vector(white_s2z_{id}))\n",
+    "  lprior += -0.5 * group_quad_s2z_{id}\n",
     "    - N_{id} * sum(log(diagonal(L_Sigma_s2z_{id})))\n",
     "    - M_{id} * sum(log(group_scale_s2z_{id}))\n",
     "    - sum(log(diagonal(L_P_s2z_{id})))",
@@ -1973,7 +2386,8 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "(mdivide_right_tri_low(z_mean_s2z', L_P_s2z_{id}))';\n",
     "  }}\n",
     "  q_recovered_s2z_{id} = theta_s2z{p} - H_s2z_{id} * mean_r_s2z_{id};\n",
-    "  r_{id} = r_s2z_{id} + rep_matrix(mean_r_s2z_{id}', N_{id});\n"
+    "  r_{id} = r_s2z_{id};\n",
+    "  for (j in 1:N_{id}) r_{id}[j] += mean_r_s2z_{id}';\n"
   )
   if (info$center) {
     str_add(out$gen_comp) <- glue(
@@ -2023,7 +2437,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
 
   str_add(out$fun) <- "  #include 'fun_sum_to_zero.stan'\n"
   str_add(out$par) <- glue(
-    "  array[M_{id}] vector[N_{id} - 1] z_s2z_{id};",
+    "  vector[M_{id} * (N_{id} - 1)] z_s2z_{id};",
     "  // physical orthonormal independent S2Z coordinates\n"
   )
 
@@ -2048,7 +2462,6 @@ stan_re <- function(bframe, prior, normalize, ...) {
     cglue("  vector[N_{id}] {r_s2z};\n"),
     "  vector[{q}] prior_mean_s2z_{id};\n",
     "  vector<lower=0>[{q}] prior_prec_s2z_{id};\n",
-    "  vector[M_{id}] intercept_map_s2z_{id};\n",
     str_if(
       is_student,
       glue(
@@ -2063,13 +2476,12 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "  real<lower=0> group_quad_s2z_{id};\n"
   )
 
-  for (j in seq_len(M)) {
-    str_add(out$tpar_comp) <- glue(
-      "  {r_s2z[j]} = sum_to_zero_constrain_brms(z_s2z_{id}[{j}]);\n"
-    )
-  }
-  str_add(out$tpar_comp) <- glue(
-    "  intercept_map_s2z_{id} = rep_vector(0.0, M_{id});\n"
+  # The centered-intercept coupling is determined entirely by the design.
+  str_add(out$tdata_def) <- glue(
+    "  vector[M_{id}] intercept_map_s2z_{id};\n"
+  )
+  str_add(out$tdata_comp) <- glue(
+    "  intercept_map_s2z_{id} = zeros_vector(M_{id});\n"
   )
   if (info$center) {
     for (j in seq_len(M)) {
@@ -2079,10 +2491,18 @@ stan_re <- function(bframe, prior, normalize, ...) {
       } else {
         glue("means_X{p}[{qi - 1L}]")
       }
-      str_add(out$tpar_comp) <- glue(
+      str_add(out$tdata_comp) <- glue(
         "  intercept_map_s2z_{id}[{j}] = {value};\n"
       )
     }
+  }
+
+  for (j in seq_len(M)) {
+    str_add(out$tpar_comp) <- glue(
+      "  {r_s2z[j]} = sum_to_zero_constrain_brms(",
+      "segment(z_s2z_{id}, ({j} - 1) * (N_{id} - 1) + 1, ",
+      "N_{id} - 1));\n"
+    )
   }
 
   for (k in seq_len(q)) {
@@ -2122,8 +2542,8 @@ stan_re <- function(bframe, prior, normalize, ...) {
   # inverse-square group SDs during warmup.
   str_add(out$tpar_comp) <- glue(
     "  {{\n",
-    "    vector[M_{id}] base_info_s2z = rep_vector(0.0, M_{id});\n",
-    "    vector[M_{id}] base_score_s2z = rep_vector(0.0, M_{id});\n",
+    "    vector[M_{id}] base_info_s2z = zeros_vector(M_{id});\n",
+    "    vector[M_{id}] base_score_s2z = zeros_vector(M_{id});\n",
     "    vector[M_{id}] scaled_score_s2z;\n",
     "    vector[M_{id}] independent_mode_s2z;\n",
     "    real group_info_s2z = ",
@@ -2366,7 +2786,6 @@ stan_re <- function(bframe, prior, normalize, ...) {
   str_add(out$tpar_def) <- glue(
     "  // specialized scalar physical S2Z effects of ID {id}\n",
     "  vector[N_{id}] {r_s2z};\n",
-    "  vector[{q}] H_s2z_{id};\n",
     "  vector[{q}] prior_mean_s2z_{id};\n",
     "  vector<lower=0>[{q}] prior_prec_s2z_{id};\n",
     str_if(
@@ -2380,21 +2799,26 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "  real<lower=0> sqrt_D_s2z_{id};\n",
     "  real mhat_s2z_{id};\n",
     "  vector[{q}] qhat_s2z_{id};\n",
-    "  vector[N_{id}] white_s2z_{id};\n"
+    "  real<lower=0> group_quad_s2z_{id};\n"
   )
 
   # H maps the omitted scalar group mean into all matching population
   # coordinates. A centered varying slope also shifts brms's temporary
   # centered intercept by the mean of its raw design column.
   qi <- info$match_q[1]
-  str_add(out$tpar_comp) <- glue(
-    "  {r_s2z} = sum_to_zero_constrain_brms(z_s2z_{id});\n",
-    "  H_s2z_{id} = rep_vector(0.0, {q});\n",
+  str_add(out$tdata_def) <- glue(
+    "  vector[{q}] H_s2z_{id};\n"
+  )
+  str_add(out$tdata_comp) <- glue(
+    "  H_s2z_{id} = zeros_vector({q});\n",
     "  H_s2z_{id}[{qi}] = 1.0;\n",
     str_if(
       info$center && info$r$coef[1] != "Intercept",
       glue("  H_s2z_{id}[1] = means_X{p}[{qi - 1L}];\n")
     )
+  )
+  str_add(out$tpar_comp) <- glue(
+    "  {r_s2z} = sum_to_zero_constrain_brms(z_s2z_{id});\n"
   )
 
   for (k in seq_len(q)) {
@@ -2459,9 +2883,13 @@ stan_re <- function(bframe, prior, normalize, ...) {
     "  sqrt_D_s2z_{id} = sqrt(D_s2z_{id});\n",
     "  qhat_s2z_{id} = theta_s2z{p} - H_s2z_{id} * ",
     "mhat_s2z_{id};\n",
-    "  white_s2z_{id} = ({r_s2z} + mhat_s2z_{id}) / sd_{id}[1]",
-    str_if(is_student, " ./ group_scale_s2z_{id}"),
-    ";\n"
+    "  {{\n",
+    "    vector[N_{id}] white_s2z = ({r_s2z} + mhat_s2z_{id}) / ",
+    "sd_{id}[1]",
+    str_if(is_student, glue(" ./ group_scale_s2z_{id}")),
+    ";\n",
+    "    group_quad_s2z_{id} = dot_self(white_s2z);\n",
+    "  }}\n"
   )
   str_add(out$pll_args) <- glue(", vector {r_s2z}")
 
@@ -2484,7 +2912,7 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
   }
   str_add(out$tpar_prior) <- glue(
-    "  lprior += -0.5 * dot_self(white_s2z_{id})\n",
+    "  lprior += -0.5 * group_quad_s2z_{id}\n",
     "    - (N_{id} - 1) * log(sd_{id}[1])\n",
     str_if(
       is_student,

--- a/R/stan-predictor.R
+++ b/R/stan-predictor.R
@@ -282,6 +282,16 @@ stan_fe <- function(bframe, prior, stanvars, threads, primitive,
   p <- usc(combine_prefix(px))
   resp <- usc(px$resp)
   lpdf <- stan_lpdf_name(normalize)
+  s2z <- has_re_s2z(bframe)
+
+  if (s2z) {
+    K_s2z <- length(bframe$frame$fe$vars)
+    str_add(out$par) <- glue(
+      "  vector[{K_s2z}] theta_s2z{p};",
+      "  // finite-population coefficients for marginalized S2Z effects\n"
+    )
+    str_add(out$pll_args) <- glue(", vector theta_s2z{p}")
+  }
 
   if (length(fixef)) {
     str_add(out$data) <- glue(
@@ -310,41 +320,43 @@ stan_fe <- function(bframe, prior, stanvars, threads, primitive,
         " = csr_extract_u(X{p});\n"
       )
     }
-    # prepare population-level coefficients
-    b_type <- glue("vector[K{ct}{p}]")
-    has_special_prior <- has_special_prior(prior, bframe, class = "b")
-    if (decomp == "none") {
-      if (has_special_prior) {
-        str_add_list(out) <- stan_prior_non_centered(
-          suffix = p, suffix_K = ct, normalize = normalize
-        )
+    if (!s2z) {
+      # prepare population-level coefficients
+      b_type <- glue("vector[K{ct}{p}]")
+      has_special_prior <- has_special_prior(prior, bframe, class = "b")
+      if (decomp == "none") {
+        if (has_special_prior) {
+          str_add_list(out) <- stan_prior_non_centered(
+            suffix = p, suffix_K = ct, normalize = normalize
+          )
+        } else {
+          str_add_list(out) <- stan_prior(
+            prior, class = "b", coef = fixef, type = b_type,
+            px = px, suffix = p, header_type = "vector",
+            comment = "regression coefficients", normalize = normalize
+          )
+        }
       } else {
-        str_add_list(out) <- stan_prior(
-          prior, class = "b", coef = fixef, type = b_type,
-          px = px, suffix = p, header_type = "vector",
-          comment = "regression coefficients", normalize = normalize
+        stopifnot(decomp == "QR")
+        stopif_prior_bound(prior, class = "b", ls = px)
+        if (has_special_prior) {
+          str_add_list(out) <- stan_prior_non_centered(
+            suffix = p, suffix_class = "Q", suffix_K = ct,
+            normalize = normalize
+          )
+        } else {
+          str_add_list(out) <- stan_prior(
+            prior, class = "b", coef = fixef, type = b_type,
+            px = px, suffix = glue("Q{p}"), header_type = "vector",
+            comment = "regression coefficients on QR scale",
+            normalize = normalize
+          )
+        }
+        str_add(out$gen_def) <- glue(
+          "  // obtain the actual coefficients\n",
+          "  vector[K{ct}{p}] b{p} = XR{p}_inv * bQ{p};\n"
         )
       }
-    } else {
-      stopifnot(decomp == "QR")
-      stopif_prior_bound(prior, class = "b", ls = px)
-      if (has_special_prior) {
-        str_add_list(out) <- stan_prior_non_centered(
-          suffix = p, suffix_class = "Q", suffix_K = ct,
-          normalize = normalize
-        )
-      } else {
-        str_add_list(out) <- stan_prior(
-          prior, class = "b", coef = fixef, type = b_type,
-          px = px, suffix = glue("Q{p}"), header_type = "vector",
-          comment = "regression coefficients on QR scale",
-          normalize = normalize
-        )
-      }
-      str_add(out$gen_def) <- glue(
-        "  // obtain the actual coefficients\n",
-        "  vector[K{ct}{p}] b{p} = XR{p}_inv * bQ{p};\n"
-      )
     }
   }
 
@@ -393,7 +405,9 @@ stan_fe <- function(bframe, prior, stanvars, threads, primitive,
         )
       }
     }
-    if (!is_ordinal(family)) {
+    if (!is_ordinal(family) && s2z) {
+      str_add(out$eta) <- glue(" + theta_s2z{p}[1]")
+    } else if (!is_ordinal(family)) {
       # intercepts of ordinal models are handled in 'stan_thres'
       intercept_type <- "real"
       if (order_intercepts) {
@@ -440,7 +454,16 @@ stan_fe <- function(bframe, prior, stanvars, threads, primitive,
   }
   if (length(fixef) && !primitive) {
     # added in the end such that the intercept comes first in out$eta
-    if (sparse) {
+    if (s2z) {
+      slice <- stan_slice(threads)
+      if (center) {
+        eta_fe <- glue(
+          " + Xc{p}{slice} * tail(theta_s2z{p}, {length(fixef)})"
+        )
+      } else {
+        eta_fe <- glue(" + X{p}{slice} * theta_s2z{p}")
+      }
+    } else if (sparse) {
       stopifnot(!center && decomp == "none")
       csr_args <- sargs(
         paste0(c("rows", "cols"), "(X", p, ")"),
@@ -624,6 +647,13 @@ stan_re <- function(bframe, prior, normalize, ...) {
     }
   }
 
+  if (isTRUE(r$s2z[1])) {
+    return(.stan_re_s2z(
+      id, bframe = bframe, prior = prior, threads = threads,
+      normalize = normalize, out = out
+    ))
+  }
+
   # define group-level coefficients
   dfm <- ""
   tr <- subset_reframe_dist(r, "student")
@@ -775,6 +805,276 @@ stan_re <- function(bframe, prior, normalize, ...) {
     )
   }
   out
+}
+
+# Stan code for one marginalized physical sum-to-zero group-level block.
+# Conditional Gaussian scale mixtures are handled by a group-specific scale,
+# which makes this exact for both Gaussian and Student-t group effects.
+.stan_re_s2z <- function(id, bframe, prior, threads, normalize, out = list()) {
+  lpdf <- stan_lpdf_name(normalize)
+  r <- subset2(bframe$frame$re, id = id)
+  stopifnot(is.reframe(r), has_rows(r), all(r$s2z))
+  bfl <- re_s2z_bframel(bframe, r)
+  info <- re_s2z_info(bfl, prior = prior)
+  q <- length(info$qnames)
+  M <- nrow(r)
+  J <- seq_rows(r)
+  p <- info$p
+  idp <- paste0(r$id, usc(combine_prefix(check_prefix(r))))
+  is_cor <- M > 1L && isTRUE(r$cor[1])
+  is_student <- identical(r$dist[1], "student")
+
+  # Keep brms's existing covariance parameters and priors. Only the
+  # group-effect coordinates and their joint prior are replaced.
+  if (is_cor) {
+    str_add(out$data) <- glue(
+      "  int<lower=1> NC_{id};  // number of group-level correlations\n"
+    )
+    str_add_list(out) <- stan_prior(
+      prior, class = "L", group = r$group[1], suffix = usc(id),
+      type = glue("cholesky_factor_corr[M_{id}]"),
+      comment = "cholesky factor of correlation matrix",
+      normalize = normalize
+    )
+  }
+
+  str_add(out$fun) <- "  #include 'fun_sum_to_zero.stan'\n"
+  str_add(out$par) <- glue(
+    "  array[M_{id}] vector[N_{id} - 1] z_s2z_{id};",
+    "  // physical orthonormal S2Z coordinates\n"
+  )
+
+  # Independent Student-t and Cauchy population priors are represented as
+  # Gaussian scale mixtures, so the omitted group mean remains analytic.
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "student") {
+      str_add(out$par) <- glue(
+        "  real<lower=0> udf_b_s2z{p}_{k};",
+        "  // mixing variable for population coefficient {k}\n"
+      )
+      str_add(out$tpar_prior) <- glue(
+        "  lprior += inv_chi_square_{lpdf}(udf_b_s2z{p}_{k} | ",
+        "{stan_s2z_number(spec$df)});\n"
+      )
+    }
+  }
+
+  str_add(out$tpar_def) <- glue(
+    "  // marginalized physical sum-to-zero group-level effects of ID {id}\n",
+    "  matrix[N_{id}, M_{id}] r_s2z_{id};\n",
+    "  matrix[{q}, M_{id}] H_s2z_{id};\n",
+    "  vector[{q}] prior_mean_s2z_{id};\n",
+    "  vector<lower=0>[{q}] prior_prec_s2z_{id};\n",
+    "  vector<lower=0>[N_{id}] group_scale_s2z_{id};\n",
+    "  vector<lower=0>[N_{id}] group_prec_s2z_{id};\n",
+    "  matrix[M_{id}, M_{id}] L_Sigma_s2z_{id};\n",
+    "  matrix[M_{id}, M_{id}] Q_Sigma_s2z_{id};\n",
+    "  matrix[M_{id}, M_{id}] P_s2z_{id};\n",
+    "  matrix[M_{id}, M_{id}] L_P_s2z_{id};\n",
+    "  vector[M_{id}] mhat_s2z_{id};\n",
+    "  vector[{q}] qhat_s2z_{id};\n",
+    "  matrix[M_{id}, N_{id}] white_s2z_{id};\n",
+    "  // using vectors speeds up indexing in loops\n",
+    cglue("  vector[N_{id}] r_s2z_{idp}_{r$cn};\n")
+  )
+
+  # The mapping H absorbs the omitted raw group mean into brms's population
+  # coordinates. For centered predictors its first row contains the actual
+  # means of every matching raw design column, including interactions.
+  str_add(out$tpar_comp) <- glue(
+    "  H_s2z_{id} = rep_matrix(0.0, {q}, M_{id});\n"
+  )
+  for (j in seq_len(M)) {
+    qi <- info$match_q[j]
+    str_add(out$tpar_comp) <- glue(
+      "  H_s2z_{id}[{qi}, {j}] = 1.0;\n"
+    )
+    if (info$center && info$r$coef[j] != "Intercept") {
+      str_add(out$tpar_comp) <- glue(
+        "  H_s2z_{id}[1, {j}] = means_X{p}[{qi - 1L}];\n"
+      )
+    }
+  }
+  if (is_cor) {
+    str_add(out$tpar_comp) <- glue(
+      "  L_Sigma_s2z_{id} = diag_pre_multiply(sd_{id}, L_{id});\n"
+    )
+  } else {
+    str_add(out$tpar_comp) <- glue(
+      "  L_Sigma_s2z_{id} = diag_matrix(sd_{id});\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  for (k in 1:M_{id}) {{\n",
+    "    r_s2z_{id}[, k] = sum_to_zero_constrain_brms(z_s2z_{id}[k]);\n",
+    "  }}\n"
+  )
+
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    loc <- stan_s2z_number(spec$location)
+    str_add(out$tpar_comp) <- glue(
+      "  prior_mean_s2z_{id}[{k}] = {loc};\n"
+    )
+    if (spec$dist == "flat") {
+      prec <- "0.0"
+    } else if (spec$dist == "normal") {
+      prec <- glue("inv_square({stan_s2z_number(spec$scale)})")
+    } else {
+      prec <- glue(
+        "inv_square({stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k}))"
+      )
+    }
+    str_add(out$tpar_comp) <- glue(
+      "  prior_prec_s2z_{id}[{k}] = {prec};\n"
+    )
+  }
+
+  if (is_student) {
+    tr <- subset_reframe_dist(r, "student")
+    g <- usc(tr$ggn[1])
+    str_add(out$tpar_comp) <- glue(
+      "  group_scale_s2z_{id} = dfm{g};\n"
+    )
+  } else {
+    str_add(out$tpar_comp) <- glue(
+      "  group_scale_s2z_{id} = rep_vector(1.0, N_{id});\n"
+    )
+  }
+  str_add(out$tpar_comp) <- glue(
+    "  group_prec_s2z_{id} = inv_square(group_scale_s2z_{id});\n",
+    "  {{\n",
+    "    matrix[M_{id}, M_{id}] L_inv_s2z = mdivide_left_tri_low(",
+    "L_Sigma_s2z_{id}, diag_matrix(rep_vector(1.0, M_{id})));\n",
+    "    vector[M_{id}] h_s2z;\n",
+    "    Q_Sigma_s2z_{id} = crossprod(L_inv_s2z);\n",
+    "    P_s2z_{id} = crossprod(diag_pre_multiply(",
+    "sqrt(prior_prec_s2z_{id}), H_s2z_{id}))",
+    " + sum(group_prec_s2z_{id}) * Q_Sigma_s2z_{id};\n",
+    "    h_s2z = H_s2z_{id}' * (prior_prec_s2z_{id} .* ",
+    "(theta_s2z{p} - prior_mean_s2z_{id})) - Q_Sigma_s2z_{id} * ",
+    "(r_s2z_{id}' * group_prec_s2z_{id});\n",
+    "    L_P_s2z_{id} = cholesky_decompose(P_s2z_{id});\n",
+    "    mhat_s2z_{id} = mdivide_left_spd(P_s2z_{id}, h_s2z);\n",
+    "    qhat_s2z_{id} = theta_s2z{p} - H_s2z_{id} * mhat_s2z_{id};\n",
+    "    white_s2z_{id} = mdivide_left_tri_low(L_Sigma_s2z_{id}, ",
+    "(r_s2z_{id} + rep_matrix(mhat_s2z_{id}', N_{id}))');\n",
+    "    white_s2z_{id} = white_s2z_{id} .* rep_matrix(",
+    "(1.0 ./ group_scale_s2z_{id})', M_{id});\n",
+    "  }}\n",
+    cglue("  r_s2z_{idp}_{r$cn} = r_s2z_{id}[, {J}];\n")
+  )
+  str_add(out$pll_args) <- cglue(
+    ", vector r_s2z_{idp}_{r$cn}"
+  )
+
+  # Score the original conditional Gaussian hierarchy at its completed-square
+  # mode, followed by the exact Gaussian integration factor. The final log(N)
+  # is the measure correction for the orthonormal contrast coordinates.
+  for (k in seq_len(q)) {
+    spec <- info$prior[[k]]
+    if (spec$dist == "flat") {
+      next
+    }
+    if (spec$dist == "normal") {
+      cond_scale <- stan_s2z_number(spec$scale)
+    } else {
+      cond_scale <- glue(
+        "{stan_s2z_number(spec$scale)} * sqrt(",
+        "{stan_s2z_number(spec$df)} * udf_b_s2z{p}_{k})"
+      )
+    }
+    str_add(out$tpar_prior) <- glue(
+      "  lprior += normal_{lpdf}(qhat_s2z_{id}[{k}] | ",
+      "{stan_s2z_number(spec$location)}, {cond_scale});\n"
+    )
+  }
+  str_add(out$tpar_prior) <- glue(
+    "  lprior += -0.5 * dot_self(to_vector(white_s2z_{id}))\n",
+    "    - N_{id} * sum(log(diagonal(L_Sigma_s2z_{id})))\n",
+    "    - M_{id} * sum(log(group_scale_s2z_{id}))\n",
+    "    - sum(log(diagonal(L_P_s2z_{id})))",
+    str_if(
+      normalize,
+      glue(" - 0.5 * N_{id} * M_{id} * log(2 * pi())",
+           " + 0.5 * M_{id} * log(2 * pi())",
+           " + 0.5 * M_{id} * log(1.0 * N_{id})")
+    ),
+    ";\n"
+  )
+
+  # Recover conventional super-population coefficients and deviations using
+  # one shared conditional draw of the analytically omitted group mean.
+  str_add(out$gen_def) <- glue(
+    "  vector[M_{id}] mean_r_s2z_{id};\n",
+    "  vector[{q}] q_recovered_s2z_{id};\n",
+    "  matrix[N_{id}, M_{id}] r_{id};\n"
+  )
+  if (info$center) {
+    str_add(out$gen_def) <- glue(
+      "  real Intercept{p};\n",
+      str_if(length(info$fixef), glue("  vector[Kc{p}] b{p};\n")),
+      "  real b{p}_Intercept;\n"
+    )
+  } else {
+    str_add(out$gen_def) <- glue("  vector[{q}] b{p};\n")
+  }
+  str_add(out$gen_def) <- cglue(
+    "  vector[N_{id}] r_{idp}_{r$cn};\n"
+  )
+  if (is_cor) {
+    str_add(out$gen_def) <- glue(
+      "  // compute group-level correlations\n",
+      "  corr_matrix[M_{id}] Cor_{id}",
+      " = multiply_lower_tri_self_transpose(L_{id});\n",
+      "  vector<lower=-1,upper=1>[NC_{id}] cor_{id};\n"
+    )
+  }
+
+  str_add(out$gen_comp) <- glue(
+    "  {{\n",
+    "    vector[M_{id}] z_mean_s2z;\n",
+    "    for (k in 1:M_{id}) z_mean_s2z[k] = std_normal_rng();\n",
+    "    mean_r_s2z_{id} = mhat_s2z_{id} + ",
+    "(mdivide_right_tri_low(z_mean_s2z', L_P_s2z_{id}))';\n",
+    "  }}\n",
+    "  q_recovered_s2z_{id} = theta_s2z{p} - H_s2z_{id} * mean_r_s2z_{id};\n",
+    "  r_{id} = r_s2z_{id} + rep_matrix(mean_r_s2z_{id}', N_{id});\n"
+  )
+  if (info$center) {
+    str_add(out$gen_comp) <- glue(
+      "  Intercept{p} = q_recovered_s2z_{id}[1];\n",
+      str_if(
+        length(info$fixef),
+        glue("  b{p} = tail(q_recovered_s2z_{id}, Kc{p});\n",
+             "  b{p}_Intercept = Intercept{p} - dot_product(",
+             "means_X{p}, b{p});\n")
+      ),
+      str_if(
+        !length(info$fixef),
+        glue("  b{p}_Intercept = Intercept{p};\n")
+      )
+    )
+  } else {
+    str_add(out$gen_comp) <- glue("  b{p} = q_recovered_s2z_{id};\n")
+  }
+  str_add(out$gen_comp) <- cglue(
+    "  r_{idp}_{r$cn} = r_{id}[, {J}];\n"
+  )
+  if (is_cor) {
+    str_add(out$gen_comp) <- stan_cor_gen_comp(
+      cor = glue("cor_{id}"), ncol = glue("M_{id}")
+    )
+  }
+  out
+}
+
+# Stable formatting for numeric constants inserted into generated Stan code.
+stan_s2z_number <- function(x) {
+  stopifnot(length(x) == 1L, is.finite(x))
+  trimws(formatC(x, digits = 17, format = "g"))
 }
 
 # Stan code of smooth terms
@@ -2092,18 +2392,19 @@ stan_eta_re <- function(bframe, threads) {
     rpx <- check_prefix(r)
     idp <- paste0(r$id, usc(combine_prefix(rpx)))
     idresp <- paste0(r$id, usc(rpx$resp))
+    rprefix <- str_if(isTRUE(r$s2z[1]), "r_s2z_", "r_")
     if (r$gtype[1] == "mm") {
       ng <- seq_along(r$gcall[[1]]$groups)
       for (i in seq_rows(r)) {
         str_add(eta_re) <- cglue(
           " + W_{idresp[i]}_{ng}{n}",
-          " * r_{idp[i]}_{r$cn[i]}[J_{idresp[i]}_{ng}{n}]",
+          " * {rprefix}{idp[i]}_{r$cn[i]}[J_{idresp[i]}_{ng}{n}]",
           " * Z_{idp[i]}_{r$cn[i]}_{ng}{n}"
         )
       }
     } else {
       str_add(eta_re) <- cglue(
-        " + r_{idp}_{r$cn}[J_{idresp}{n}] * Z_{idp}_{r$cn}{n}"
+        " + {rprefix}{idp}_{r$cn}[J_{idresp}{n}] * Z_{idp}_{r$cn}{n}"
       )
     }
   }

--- a/R/stancode.R
+++ b/R/stancode.R
@@ -118,6 +118,7 @@ stancode.default <- function(object, data, family = gaussian(),
   parse <- as_one_logical(parse)
   backend <- match.arg(backend, backend_choices())
   silent <- as_one_logical(silent)
+  validate_re_s2z(bterms, prior = prior)
   scode_predictor <- stan_predictor(
     bterms, prior = prior, normalize = normalize,
     stanvars = stanvars, threads = threads

--- a/R/stancode.R
+++ b/R/stancode.R
@@ -118,7 +118,7 @@ stancode.default <- function(object, data, family = gaussian(),
   parse <- as_one_logical(parse)
   backend <- match.arg(backend, backend_choices())
   silent <- as_one_logical(silent)
-  validate_re_s2z(bterms, prior = prior)
+  validate_re_s2z_prior_global(bterms, prior = prior)
   scode_predictor <- stan_predictor(
     bterms, prior = prior, normalize = normalize,
     stanvars = stanvars, threads = threads
@@ -249,8 +249,10 @@ stancode.default <- function(object, data, family = gaussian(),
   scode_transformed_data <- paste0(
     "transformed data {\n",
        scode_predictor[["tdata_def"]],
+       scode_re[["tdata_def"]],
        collapse_stanvars(stanvars, "tdata", "start"),
        scode_predictor[["tdata_comp"]],
+       scode_re[["tdata_comp"]],
        collapse_stanvars(stanvars, "tdata", "end"),
     "}\n"
   )

--- a/R/standata.R
+++ b/R/standata.R
@@ -111,7 +111,7 @@ standata.default <- function(object, data, family = gaussian(), prior = NULL,
                       only_response = FALSE, internal = FALSE, ...) {
 
   stopifnot(is.anybrmsframe(bframe))
-  validate_re_s2z(bframe, prior = prior)
+  validate_re_s2z_prior_global(bframe, prior = prior)
   check_response <- as_one_logical(check_response)
   only_response <- as_one_logical(only_response)
   internal <- as_one_logical(internal)

--- a/R/standata.R
+++ b/R/standata.R
@@ -111,6 +111,7 @@ standata.default <- function(object, data, family = gaussian(), prior = NULL,
                       only_response = FALSE, internal = FALSE, ...) {
 
   stopifnot(is.anybrmsframe(bframe))
+  validate_re_s2z(bframe, prior = prior)
   check_response <- as_one_logical(check_response)
   only_response <- as_one_logical(only_response)
   internal <- as_one_logical(internal)

--- a/inst/chunks/fun_sum_to_zero.stan
+++ b/inst/chunks/fun_sum_to_zero.stan
@@ -1,0 +1,13 @@
+  vector sum_to_zero_constrain_brms(vector y) {
+    int N = num_elements(y);
+    vector[N + 1] z = zeros_vector(N + 1);
+    real sum_w = 0;
+    for (ii in 1:N) {
+      int i = N - ii + 1;
+      real w = y[i] * inv_sqrt(i * (i + 1.0));
+      sum_w += w;
+      z[i] += sum_w;
+      z[i + 1] -= i * w;
+    }
+    return z;
+  }

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -27,8 +27,9 @@ must be nested in levels of the \code{by} variable.}
 modelled as correlated.}
 
 \item{s2z}{Logical. If \code{TRUE}, use a physical sum-to-zero
-parameterization and analytically integrate out the omitted common
-group-effect mean vector. This experimental option preserves the usual
+analytically integrate out the omitted common group-effect mean vector of
+each S2Z block, jointly when multiple blocks share a linear predictor.
+This experimental option preserves the usual
 population- and group-level parameter semantics by reconstructing them in
 generated quantities. It is exact for \code{dist = "gaussian"} and for
 \code{dist = "student"} through a Gaussian scale mixture. Every varying
@@ -40,13 +41,18 @@ implementation that also accounts exactly for the shared centered
 intercept prior.
 Usual priors on group-level standard deviations, correlations, and
 Student-t degrees of freedom remain available, including separate
-standard-deviation priors for varying intercepts, slopes, and
-interactions.
+\code{sd} priors for varying intercepts, slopes, and interactions. For
+\code{dist = "student"}, \code{sd} retains its existing \pkg{brms}
+Student-t scale semantics and is not rescaled to a marginal standard
+deviation.
 The physical coordinates are intended for well-informed group
 coefficients and may be slower than the default non-centered
 parameterization when those coefficients are weakly informed.
-Currently, only one such grouping term per linear predictor is supported,
-without the \code{by}, \code{cov}, or \code{pw} arguments.
+Multiple S2Z covariance blocks may be used in the same linear predictor.
+Their omitted group means are integrated and recovered jointly, while each
+block retains its own grouping factor, shared scales, and correlation
+structure.
+The \code{by}, \code{cov}, and \code{pw} arguments remain unsupported.
 Population-level priors must currently be flat, normal, Student-t, or
 Cauchy with numeric constant arguments. Bounds, tags, special priors,
 prior-only sampling, ordinal thresholds, sparse and QR designs, and

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -26,44 +26,9 @@ must be nested in levels of the \code{by} variable.}
 \item{cor}{Logical. If \code{TRUE} (the default), group-level terms will be
 modelled as correlated.}
 
-\item{s2z}{Logical. If \code{TRUE}, use a physical sum-to-zero
-analytically integrate out the omitted common group-effect mean vector of
-each S2Z block, jointly when multiple blocks share a linear predictor.
-This experimental option preserves the usual
-population- and group-level parameter semantics by reconstructing them in
-generated quantities. It is exact for \code{dist = "gaussian"} and for
-\code{dist = "student"} through a Gaussian scale mixture. Every varying
-design column must have an identical population-level design column.
-Blocks with one varying coefficient use a dedicated scalar
-implementation. Blocks with any number of independent coefficients
-(\code{cor = FALSE} or \code{||} syntax) use a component-wise scalar
-implementation that also accounts exactly for the shared centered
-intercept prior.
-Usual priors on group-level standard deviations, correlations, and
-Student-t degrees of freedom remain available, including separate
-\code{sd} priors for varying intercepts, slopes, and interactions. For
-\code{dist = "student"}, \code{sd} retains its existing \pkg{brms}
-Student-t scale semantics and is not rescaled to a marginal standard
-deviation.
-The physical coordinates are intended for well-informed group
-coefficients and may be slower than the default non-centered
-parameterization when those coefficients are weakly informed.
-Multiple S2Z covariance blocks may be used in the same linear predictor.
-Their omitted group means are integrated and recovered jointly, while each
-block retains its own grouping factor, shared scales, and correlation
-structure. When all such blocks are Gaussian, \pkg{brms} uses an
-induced population-coordinate covariance and joint Matheron recovery if
-that system is smaller than the stacked omitted-mean system. Crossed
-varying-intercept models then require only a scalar update, regardless of
-the number of grouping factors. Flat population-level prior coordinates
-are handled exactly rather than approximated by a large finite variance.
-The \code{by}, \code{cov}, and \code{pw} arguments remain unsupported.
-Population-level priors must currently be flat, normal, Student-t, or
-Cauchy with numeric constant arguments. Bounds, tags, special priors,
-prior-only sampling, ordinal thresholds, sparse and QR designs, and
-non-positive fixed group-level standard deviations are not supported.
-Custom Stan code must not use the conventional population- or group-level
-coefficients before they are reconstructed in generated quantities.}
+\item{s2z}{Logical. If \code{TRUE}, use the experimental physical
+sum-to-zero parameterization described in the section
+\dQuote{Physical sum-to-zero effects}. The default is \code{FALSE}.}
 
 \item{id}{Optional character string. All group-level terms across the model
 with the same \code{id} will be modeled as correlated (if \code{cor} is
@@ -90,6 +55,83 @@ The function does not evaluate its arguments --
 it exists purely to help set up a model with grouping terms.
 \code{gr} is called implicitly inside the package
 and there is usually no need to call it directly.
+}
+\section{Physical sum-to-zero effects}{
+
+Setting \code{s2z = TRUE} expresses every coefficient vector in the
+grouping block as a physical deviation whose entries sum exactly to zero
+over the observed grouping levels. The likelihood is evaluated in these
+constrained coordinates. The omitted common group-effect mean is handled
+jointly with the matching population coefficients, and conventional
+population- and group-level draws are reconstructed in generated
+quantities. Thus functions such as \code{fixef}, \code{ranef}, and
+\code{coef} retain their usual interpretation.
+
+Every S2Z varying design column must have a population-level column with the
+same coefficient name and numerically identical values. This applies to
+varying intercepts, numeric and factor slopes, and interaction columns,
+including their contrasts. For example, \code{x * f} must appear on both
+sides of the grouping bar when all of its expanded columns vary. At least
+two grouping levels must be observed.
+
+The current support matrix is:
+
+\tabular{ll}{
+Design \tab Ordinary matched intercepts, slopes, factors, and interactions.\cr
+Group distribution \tab Gaussian or Student-t.\cr
+Covariance \tab Correlated or independent coefficients; one or multiple
+local S2Z blocks.\cr
+Group scales \tab Coefficient-specific \code{sd} parameters shared across
+observed grouping levels.\cr
+Active population priors \tab Flat, \code{normal}, \code{student_t},
+\code{cauchy}, or \code{logistic}, with numeric constant arguments.\cr
+Fixed-only population priors \tab Any otherwise valid \pkg{brms} prior.\cr
+Predictors \tab Separate local S2Z IDs in otherwise eligible location,
+distributional, nonlinear, categorical, multinomial, and multivariate
+predictors.\cr
+Public output \tab Conventional population coefficients and group effects
+reconstructed exactly.\cr
+}
+
+A population coordinate is \emph{S2Z-active} when it is touched by an
+omitted-mean map from at least one local S2Z block. Only active coordinates
+enter the S2Z prior calculation and are subject to the active-prior row of
+the table. Other population coordinates are fixed-only: they retain the
+ordinary \pkg{brms} declaration and prior handling. The \code{logistic}
+case is exact, not a Gaussian approximation. Generated Stan explicitly
+samples standardized omitted block means for a logistic-active system and
+includes their exact density and Jacobian. This supports, among others, the
+default \code{logistic(0, 1)} intercept prior in auxiliary probability
+predictors such as \code{zi}, \code{hu}, \code{zoi}, \code{coi}, mixture
+weights, Wiener \code{bias}, and asym-Laplace \code{quantile}.
+
+Usual priors on shared group-level standard deviations, correlations, and
+Student-t degrees of freedom remain available, including separate
+\code{sd} priors for varying intercepts, slopes, factors, and interactions.
+For \code{dist = "student"}, \code{sd} retains its existing \pkg{brms}
+Student-t scale semantics and is not rescaled to a marginal standard
+deviation. Multiple S2Z blocks in one linear predictor retain separate
+grouping factors, scales, and correlation structures while their omitted
+means are handled jointly. An S2Z \code{id} cannot span linear predictors.
+For categorical, multinomial, and simplex families, omit \code{id} in a
+shared shorthand term so that the generated category predictors receive
+separate internal IDs, or specify the eligible non-reference category
+predictors explicitly and give each a distinct ID. A user-supplied ID that
+spans categories is a cross-predictor ID and is rejected.
+
+This foundation intentionally provides physical S2Z coordinates only.
+Centered, partially centered, and automatically centered modes are deferred;
+there is no S2Z \code{center} argument. Group-level scales that vary across
+grouping levels and priors on realized level-specific scales are also
+deferred. Ordinal location predictors and ordered mixture intercepts are not
+supported. Structural extensions including \code{by}, \code{cov},
+\code{pw}, multi-membership, category-specific or other special group
+coefficients, cross-predictor IDs, and sparse or QR population designs are
+deferred as well. Bounds, tags, and special priors on S2Z-active
+population coordinates, prior-only sampling, and non-positive fixed
+group-level standard deviations are unsupported. Custom Stan code must not
+use conventional population- or group-level coefficients before they are
+reconstructed in generated quantities.
 }
 \examples{
 \dontrun{

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -27,10 +27,10 @@ must be nested in levels of the \code{by} variable.}
 modelled as correlated.}
 
 \item{s2z}{Logical. If \code{TRUE}, use a physical sum-to-zero
-parameterization and analytically marginalize the common group-effect
-mean. This experimental option preserves the usual population- and
-group-level parameter semantics by reconstructing them in generated
-quantities. It is exact for \code{dist = "gaussian"} and for
+parameterization and analytically integrate out the omitted common
+group-effect mean vector. This experimental option preserves the usual
+population- and group-level parameter semantics by reconstructing them in
+generated quantities. It is exact for \code{dist = "gaussian"} and for
 \code{dist = "student"} through a Gaussian scale mixture. Every varying
 design column must have an identical population-level design column.
 Blocks with one varying coefficient use a dedicated scalar
@@ -39,7 +39,7 @@ implementation. Blocks with any number of independent coefficients
 implementation that also accounts exactly for the shared centered
 intercept prior.
 Usual priors on group-level standard deviations, correlations, and
-Student degrees of freedom remain available, including separate
+Student-t degrees of freedom remain available, including separate
 standard-deviation priors for varying intercepts, slopes, and
 interactions.
 The physical coordinates are intended for well-informed group
@@ -100,7 +100,7 @@ fit4 <- brm(count ~ Trt + (1|gr(patient, pw = patient_samp_wgt)),
             data = epilepsy)
 summary(fit4)
 
-# marginalized sum-to-zero varying intercepts, slopes, and interactions
+# physical sum-to-zero varying intercepts, slopes, and interactions
 s2z_prior <- prior(exponential(2), class = "sd", group = "patient",
                    coef = "Intercept") +
   prior(exponential(3), class = "sd", group = "patient", coef = "zAge") +

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -21,7 +21,8 @@ gr(
 \item{by}{An optional factor variable, specifying sub-populations of the
 groups. For each level of the \code{by} variable, a separate
 variance-covariance matrix will be fitted. Levels of the grouping factor
-must be nested in levels of the \code{by} variable.}
+must be nested in levels of the \code{by} variable. This argument is not
+currently supported with \code{s2z = TRUE}.}
 
 \item{cor}{Logical. If \code{TRUE} (the default), group-level terms will be
 modelled as correlated.}
@@ -32,19 +33,24 @@ sum-to-zero parameterization described in the section
 
 \item{id}{Optional character string. All group-level terms across the model
 with the same \code{id} will be modeled as correlated (if \code{cor} is
-\code{TRUE}). See \code{\link{brmsformula}} for more details.}
+\code{TRUE}). With \code{s2z = TRUE}, this sharing is limited to terms in
+one linear predictor: an ID cannot span responses, categories, or
+distributional or nonlinear predictors. See \code{\link{brmsformula}}
+for more details.}
 
 \item{pw}{Optional numeric variable specifying prior weights. They weight the
 contribution of each group to the log-prior of the group-level
 coefficients. Should have one distinct value for each level of the
-grouping variable.}
+grouping variable. This argument is not currently supported with
+\code{s2z = TRUE}.}
 
 \item{cov}{An optional matrix which is proportional to the within-group
 covariance matrix of the group-level effects. All levels of the grouping
 factor should appear as rownames of the corresponding matrix. This argument
 can be used, among others, to model pedigrees and phylogenetic effects. See
 \code{vignette("brms_phylogenetics")} for more details. By default, levels
-of the same grouping factor are modeled as independent of each other.}
+of the same grouping factor are modeled as independent of each other.
+This argument is not currently supported with \code{s2z = TRUE}.}
 
 \item{dist}{Name of the distribution of the group-level effects. Supported
 options are \code{"gaussian"} and \code{"student"}.}
@@ -58,14 +64,15 @@ and there is usually no need to call it directly.
 }
 \section{Physical sum-to-zero effects}{
 
-Setting \code{s2z = TRUE} expresses every coefficient vector in the
-grouping block as a physical deviation whose entries sum exactly to zero
-over the observed grouping levels. The likelihood is evaluated in these
-constrained coordinates. The omitted common group-effect mean is handled
-jointly with the matching population coefficients, and conventional
-population- and group-level draws are reconstructed in generated
-quantities. Thus functions such as \code{fixef}, \code{ranef}, and
-\code{coef} retain their usual interpretation.
+With \code{s2z = TRUE}, \pkg{brms} samples each varying coefficient as
+deviations whose sum is exactly zero over the grouping levels observed in
+the model data. For
+\code{1 + x + (1 + x | gr(g, s2z = TRUE))}, the constraint is applied
+separately to the varying intercepts and the varying \code{x} slopes.
+\pkg{brms} handles each omitted group-effect mean jointly with its matching
+population coefficient, then reconstructs conventional population and
+group effects. Thus \code{fixef}, \code{ranef}, \code{coef}, and prediction
+retain their usual interpretation.
 
 Every S2Z varying design column must have a population-level column with the
 same coefficient name and numerically identical values. This applies to
@@ -74,24 +81,59 @@ including their contrasts. For example, \code{x * f} must appear on both
 sides of the grouping bar when all of its expanded columns vary. At least
 two grouping levels must be observed.
 
-The current support matrix is:
+The main support boundaries are:
 
-\tabular{ll}{
-Design \tab Ordinary matched intercepts, slopes, factors, and interactions.\cr
-Group distribution \tab Gaussian or Student-t.\cr
-Covariance \tab Correlated or independent coefficients; one or multiple
-local S2Z blocks.\cr
-Group scales \tab Coefficient-specific \code{sd} parameters shared across
-observed grouping levels.\cr
-Active population priors \tab Flat, \code{normal}, \code{student_t},
-\code{cauchy}, or \code{logistic}, with numeric constant arguments.\cr
-Fixed-only population priors \tab Any otherwise valid \pkg{brms} prior.\cr
-Predictors \tab Separate local S2Z IDs in otherwise eligible location,
-distributional, nonlinear, categorical, multinomial, and multivariate
-predictors.\cr
-Public output \tab Conventional population coefficients and group effects
-reconstructed exactly.\cr
+\tabular{lll}{
+Feature \tab Supported? \tab Details\cr
+Ordinary designs \tab Yes \tab Matched intercepts, numeric or factor slopes,
+and interactions.\cr
+Group distribution \tab Yes \tab Gaussian or Student-t.\cr
+Coefficient correlation \tab Yes \tab \code{cor = TRUE} or \code{FALSE}
+within one predictor-local ID.\cr
+Multiple blocks \tab Yes \tab One or more local S2Z IDs in a linear
+predictor.\cr
+Multiple predictors \tab Yes \tab Separate S2Z IDs in otherwise eligible
+response, distributional, nonlinear, or category predictors.\cr
+Shared cross-predictor ID \tab No \tab Includes \code{| q |} shared by
+responses in \code{mvbind(...)}.\cr
+Known level covariance \tab No \tab Includes \code{cov = A} for
+phylogenetic or pedigree models.\cr
+Structural extensions \tab No \tab \code{by}, \code{pw},
+multi-membership, and special group coefficients.\cr
+Group scales \tab Yes \tab Coefficient-specific \code{sd} parameters shared
+across observed grouping levels.\cr
+Active population priors \tab Limited \tab Flat, \code{normal},
+\code{student_t}, \code{cauchy}, or \code{logistic}, with numeric constant
+arguments.\cr
+Public output \tab Yes \tab Conventional population coefficients and group
+effects are reconstructed exactly.\cr
 }
+
+A phylogenetic or pedigree covariance supplied through \code{cov} is a
+covariance among grouping levels, not the coefficient correlation selected
+by \code{cor}. It is not yet available with S2Z. In particular,
+\code{gr(phylo, s2z = TRUE)} without \code{cov = A} is an ordinary
+exchangeable grouping effect and does not use \code{A}; it is not a
+substitute for \code{gr(phylo, cov = A)}.
+
+In a multivariate shorthand formula, an ID between the bars is not merely a
+label. For example,
+\code{(1 | q | gr(phylo, s2z = TRUE))} inside
+\code{mvbind(phen, cofactor)} requests one group-effect covariance block
+with ID \code{q} spanning both response predictors. Cross-predictor S2Z IDs
+are not yet supported. Omit \code{q} to request separate response-local S2Z
+blocks:
+\preformatted{
+bf(mvbind(phen, cofactor) ~ 1 +
+     (1 | gr(phylo, s2z = TRUE)))
+}
+Alternatively, write a separate \code{bf()} formula for each response and
+give each block a distinct ID. These response-local blocks do not model a
+cross-response covariance among their group effects. Residual response
+correlation, when supported by the response families, is separate and may
+still be selected with \code{set_rescor(TRUE)}. If cross-response
+group-effect correlation is required, use conventional group effects with
+\code{s2z = FALSE}.
 
 A population coordinate is \emph{S2Z-active} when it is touched by an
 omitted-mean map from at least one local S2Z block. Only active coordinates
@@ -112,12 +154,11 @@ For \code{dist = "student"}, \code{sd} retains its existing \pkg{brms}
 Student-t scale semantics and is not rescaled to a marginal standard
 deviation. Multiple S2Z blocks in one linear predictor retain separate
 grouping factors, scales, and correlation structures while their omitted
-means are handled jointly. An S2Z \code{id} cannot span linear predictors.
-For categorical, multinomial, and simplex families, omit \code{id} in a
-shared shorthand term so that the generated category predictors receive
-separate internal IDs, or specify the eligible non-reference category
-predictors explicitly and give each a distinct ID. A user-supplied ID that
-spans categories is a cross-predictor ID and is rejected.
+means are handled jointly. The same predictor-local ID rule applies to
+categorical, multinomial, and simplex families: omit \code{id} in a shared
+shorthand term so that generated category predictors receive separate
+internal IDs, or specify eligible non-reference category predictors with a
+distinct ID for each one.
 
 This foundation intentionally provides physical S2Z coordinates only.
 Centered, partially centered, and automatically centered modes are deferred;

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -11,7 +11,8 @@ gr(
   id = NA,
   pw = NULL,
   cov = NULL,
-  dist = "gaussian"
+  dist = "gaussian",
+  s2z = FALSE
 )
 }
 \arguments{
@@ -24,6 +25,25 @@ must be nested in levels of the \code{by} variable.}
 
 \item{cor}{Logical. If \code{TRUE} (the default), group-level terms will be
 modelled as correlated.}
+
+\item{s2z}{Logical. If \code{TRUE}, use a physical sum-to-zero
+parameterization and analytically marginalize the common group-effect
+mean. This experimental option preserves the usual population- and
+group-level parameter semantics by reconstructing them in generated
+quantities. It is exact for \code{dist = "gaussian"} and for
+\code{dist = "student"} through a Gaussian scale mixture. Every varying
+design column must have an identical population-level design column.
+The physical coordinates are intended for well-informed group
+coefficients and may be slower than the default non-centered
+parameterization when those coefficients are weakly informed.
+Currently, only one such grouping term per linear predictor is supported,
+without the \code{by}, \code{cov}, or \code{pw} arguments.
+Population-level priors must currently be flat, normal, Student-t, or
+Cauchy with numeric constant arguments. Bounds, tags, special priors,
+prior-only sampling, ordinal thresholds, sparse and QR designs, and
+non-positive fixed group-level standard deviations are not supported.
+Custom Stan code must not use the conventional population- or group-level
+coefficients before they are reconstructed in generated quantities.}
 
 \item{id}{Optional character string. All group-level terms across the model
 with the same \code{id} will be modeled as correlated (if \code{cor} is
@@ -41,8 +61,8 @@ can be used, among others, to model pedigrees and phylogenetic effects. See
 \code{vignette("brms_phylogenetics")} for more details. By default, levels
 of the same grouping factor are modeled as independent of each other.}
 
-\item{dist}{Name of the distribution of the group-level effects.
-Currently \code{"gaussian"} is the only option.}
+\item{dist}{Name of the distribution of the group-level effects. Supported
+options are \code{"gaussian"} and \code{"student"}.}
 }
 \description{
 Function used to set up a basic grouping term in \pkg{brms}.
@@ -70,6 +90,11 @@ epilepsy[['patient_samp_wgt']] <- c(1, rep(c(0.9, 1.1), each = 29))
 fit4 <- brm(count ~ Trt + (1|gr(patient, pw = patient_samp_wgt)),
             data = epilepsy)
 summary(fit4)
+
+# marginalized sum-to-zero varying intercepts, slopes, and interactions
+fit5 <- brm(count ~ zAge * Trt +
+              (1 + zAge * Trt | gr(patient, s2z = TRUE)),
+            data = epilepsy, family = poisson())
 }
 
 }

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -34,7 +34,10 @@ quantities. It is exact for \code{dist = "gaussian"} and for
 \code{dist = "student"} through a Gaussian scale mixture. Every varying
 design column must have an identical population-level design column.
 Blocks with one varying coefficient use a dedicated scalar
-implementation.
+implementation. Blocks with any number of independent coefficients
+(\code{cor = FALSE} or \code{||} syntax) use a component-wise scalar
+implementation that also accounts exactly for the shared centered
+intercept prior.
 Usual priors on group-level standard deviations, correlations, and
 Student degrees of freedom remain available, including separate
 standard-deviation priors for varying intercepts, slopes, and

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -33,6 +33,8 @@ group-level parameter semantics by reconstructing them in generated
 quantities. It is exact for \code{dist = "gaussian"} and for
 \code{dist = "student"} through a Gaussian scale mixture. Every varying
 design column must have an identical population-level design column.
+Blocks with one varying coefficient use a dedicated scalar
+implementation.
 The physical coordinates are intended for well-informed group
 coefficients and may be slower than the default non-centered
 parameterization when those coefficients are weakly informed.

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -35,6 +35,10 @@ quantities. It is exact for \code{dist = "gaussian"} and for
 design column must have an identical population-level design column.
 Blocks with one varying coefficient use a dedicated scalar
 implementation.
+Usual priors on group-level standard deviations, correlations, and
+Student degrees of freedom remain available, including separate
+standard-deviation priors for varying intercepts, slopes, and
+interactions.
 The physical coordinates are intended for well-informed group
 coefficients and may be slower than the default non-centered
 parameterization when those coefficients are weakly informed.
@@ -94,9 +98,13 @@ fit4 <- brm(count ~ Trt + (1|gr(patient, pw = patient_samp_wgt)),
 summary(fit4)
 
 # marginalized sum-to-zero varying intercepts, slopes, and interactions
+s2z_prior <- prior(exponential(2), class = "sd", group = "patient",
+                   coef = "Intercept") +
+  prior(exponential(3), class = "sd", group = "patient", coef = "zAge") +
+  prior(lkj(2), class = "cor", group = "patient")
 fit5 <- brm(count ~ zAge * Trt +
               (1 + zAge * Trt | gr(patient, s2z = TRUE)),
-            data = epilepsy, family = poisson())
+            data = epilepsy, family = poisson(), prior = s2z_prior)
 }
 
 }

--- a/man/gr.Rd
+++ b/man/gr.Rd
@@ -51,7 +51,12 @@ parameterization when those coefficients are weakly informed.
 Multiple S2Z covariance blocks may be used in the same linear predictor.
 Their omitted group means are integrated and recovered jointly, while each
 block retains its own grouping factor, shared scales, and correlation
-structure.
+structure. When all such blocks are Gaussian, \pkg{brms} uses an
+induced population-coordinate covariance and joint Matheron recovery if
+that system is smaller than the stacked omitted-mean system. Crossed
+varying-intercept models then require only a scalar update, regardless of
+the number of grouping factors. Flat population-level prior coordinates
+are handled exactly rather than approximated by a large finite variance.
 The \code{by}, \code{cov}, and \code{pw} arguments remain unsupported.
 Population-level priors must currently be flat, normal, Student-t, or
 Cauchy with numeric constant arguments. Bounds, tags, special priors,

--- a/man/mm.Rd
+++ b/man/mm.Rd
@@ -53,8 +53,8 @@ can be used, among others, to model pedigrees and phylogenetic effects. See
 \code{vignette("brms_phylogenetics")} for more details. By default, levels
 of the same grouping factor are modeled as independent of each other.}
 
-\item{dist}{Name of the distribution of the group-level effects.
-Currently \code{"gaussian"} is the only option.}
+\item{dist}{Name of the distribution of the group-level effects. Supported
+options are \code{"gaussian"} and \code{"student"}.}
 }
 \description{
 Function to set up a multi-membership grouping term in \pkg{brms}.

--- a/tests/local/benchmark-s2z.R
+++ b/tests/local/benchmark-s2z.R
@@ -1,0 +1,450 @@
+# Reproducible benchmark for marginalized sum-to-zero group-level effects.
+#
+# This script compiles the conventional and S2Z programs once, then times only
+# refits that reuse those compiled programs. It does not run as part of the
+# package test suite. A modest default run is
+#
+#   Rscript tests/local/benchmark-s2z.R
+#
+# Scale it up with environment variables, for example
+#
+#   BRMS_S2Z_BENCH_CHAINS=4 \
+#   BRMS_S2Z_BENCH_WARMUP=1000 \
+#   BRMS_S2Z_BENCH_SAMPLING=1000 \
+#   BRMS_S2Z_BENCH_GROUPS=80 \
+#   BRMS_S2Z_BENCH_REPS=3 \
+#   BRMS_S2Z_BENCH_OUT=s2z-benchmark.csv \
+#   Rscript tests/local/benchmark-s2z.R
+#
+# Defaults are deliberately suitable for a local smoke benchmark:
+#
+#   BRMS_S2Z_BENCH_CHAINS=2
+#   BRMS_S2Z_BENCH_WARMUP=400
+#   BRMS_S2Z_BENCH_SAMPLING=400
+#   BRMS_S2Z_BENCH_GROUPS=24
+#   BRMS_S2Z_BENCH_STRONG_N=24       # observations per group
+#   BRMS_S2Z_BENCH_WEAK_N=6
+#   BRMS_S2Z_BENCH_REPS=1
+#   BRMS_S2Z_BENCH_BACKEND=auto
+#   BRMS_S2Z_BENCH_ADAPT_DELTA=0.95
+#   BRMS_S2Z_BENCH_MAX_TREEDEPTH=12
+#
+# `gradient_evals` counts post-warmup leapfrog gradients plus one initial
+# gradient per transition. ESS/gradient is calculated on the same post-warmup
+# transitions. Wall time is elapsed sampling time and excludes the separately
+# reported compile-and-smoke time.
+
+suppressPackageStartupMessages({
+  library(brms)
+  library(posterior)
+})
+
+env_integer <- function(name, default, minimum = 1L) {
+  value <- Sys.getenv(name, unset = "")
+  if (!nzchar(value)) {
+    return(as.integer(default))
+  }
+  out <- suppressWarnings(as.integer(value))
+  if (length(out) != 1L || is.na(out) || out < minimum) {
+    stop(name, " must be an integer >= ", minimum, call. = FALSE)
+  }
+  out
+}
+
+env_number <- function(name, default, minimum = -Inf) {
+  value <- Sys.getenv(name, unset = "")
+  if (!nzchar(value)) {
+    return(as.numeric(default))
+  }
+  out <- suppressWarnings(as.numeric(value))
+  if (length(out) != 1L || !is.finite(out) || out < minimum) {
+    stop(name, " must be a finite number >= ", minimum, call. = FALSE)
+  }
+  out
+}
+
+choose_backend <- function() {
+  requested <- tolower(Sys.getenv(
+    "BRMS_S2Z_BENCH_BACKEND",
+    unset = Sys.getenv("BRMS_S2Z_BACKEND", unset = "auto")
+  ))
+  if (requested %in% c("cmdstanr", "rstan")) {
+    return(requested)
+  }
+  if (!identical(requested, "auto")) {
+    stop("BRMS_S2Z_BENCH_BACKEND must be auto, cmdstanr, or rstan.",
+         call. = FALSE)
+  }
+  cmdstan_ok <- requireNamespace("cmdstanr", quietly = TRUE) &&
+    isTRUE(tryCatch(
+      nzchar(suppressWarnings(cmdstanr::cmdstan_path())),
+      error = function(e) FALSE
+    ))
+  if (cmdstan_ok) {
+    return("cmdstanr")
+  }
+  if (requireNamespace("rstan", quietly = TRUE)) {
+    return("rstan")
+  }
+  stop("Neither a working CmdStan installation nor rstan was found.",
+       call. = FALSE)
+}
+
+chains <- env_integer("BRMS_S2Z_BENCH_CHAINS", 2L, minimum = 2L)
+warmup <- env_integer("BRMS_S2Z_BENCH_WARMUP", 400L)
+sampling <- env_integer("BRMS_S2Z_BENCH_SAMPLING", 400L)
+groups <- env_integer("BRMS_S2Z_BENCH_GROUPS", 24L, minimum = 3L)
+strong_n <- env_integer("BRMS_S2Z_BENCH_STRONG_N", 24L, minimum = 4L)
+weak_n <- env_integer("BRMS_S2Z_BENCH_WEAK_N", 6L, minimum = 4L)
+reps <- env_integer("BRMS_S2Z_BENCH_REPS", 1L)
+base_seed <- env_integer("BRMS_S2Z_BENCH_SEED", 6201L, minimum = 1L)
+adapt_delta <- env_number(
+  "BRMS_S2Z_BENCH_ADAPT_DELTA", 0.95, minimum = 0.5
+)
+max_treedepth <- env_integer("BRMS_S2Z_BENCH_MAX_TREEDEPTH", 12L)
+detected_cores <- parallel::detectCores(logical = FALSE)
+if (is.na(detected_cores)) {
+  detected_cores <- 1L
+}
+cores <- env_integer(
+  "BRMS_S2Z_BENCH_CORES", min(chains, detected_cores), minimum = 1L
+)
+backend <- choose_backend()
+output_file <- Sys.getenv("BRMS_S2Z_BENCH_OUT", unset = "")
+options(mc.cores = cores, width = 180)
+
+backend_version <- if (backend == "cmdstanr") {
+  paste(cmdstanr::cmdstan_version(), collapse = ".")
+} else {
+  as.character(utils::packageVersion("rstan"))
+}
+configuration <- data.frame(
+  brms_version = as.character(utils::packageVersion("brms")),
+  backend = backend,
+  backend_version = backend_version,
+  chains = chains,
+  warmup = warmup,
+  sampling = sampling,
+  groups = groups,
+  strong_n = strong_n,
+  weak_n = weak_n,
+  reps = reps,
+  adapt_delta = adapt_delta,
+  max_treedepth = max_treedepth,
+  stringsAsFactors = FALSE
+)
+cat("S2Z benchmark configuration\n")
+print(configuration, row.names = FALSE)
+
+rmvn_rows <- function(n, sigma) {
+  matrix(stats::rnorm(n * nrow(sigma)), nrow = n) %*% chol(sigma)
+}
+
+simulate_benchmark_data <- function(identification, seed, groups,
+                                    observations_per_group) {
+  identification <- match.arg(identification, c("strong", "weak"))
+  set.seed(seed)
+  g_levels <- sprintf("g%03d", seq_len(groups))
+  pieces <- lapply(seq_len(groups), function(j) {
+    n <- observations_per_group
+    if (identification == "strong") {
+      grid <- expand.grid(x = c(-1, 1), z = c(-1, 1))
+      grid <- grid[rep(seq_len(nrow(grid)), length.out = n), ]
+      x <- grid$x + stats::rnorm(n, sd = 0.08)
+      z <- grid$z + stats::rnorm(n, sd = 0.08)
+    } else {
+      latent <- stats::rnorm(n)
+      x <- latent + stats::rnorm(n, sd = 0.08)
+      z <- 0.95 * latent + stats::rnorm(n, sd = 0.16)
+    }
+    data.frame(g = g_levels[j], x = x, z = z)
+  })
+  dat <- do.call(rbind, pieces)
+  rownames(dat) <- NULL
+  dat$g <- factor(dat$g, levels = g_levels)
+
+  X <- stats::model.matrix(~ x * z, dat)
+  beta <- c(0.35, 0.70, -0.45, 0.30)
+  re_sd <- c(0.75, 0.50, 0.45, 0.35)
+  re_cor <- outer(seq_along(re_sd), seq_along(re_sd), function(i, j) {
+    0.25^abs(i - j)
+  })
+  sigma_re <- diag(re_sd) %*% re_cor %*% diag(re_sd)
+  u <- rmvn_rows(groups, sigma_re)
+  eta <- drop(X %*% beta) + rowSums(X * u[as.integer(dat$g), ])
+  residual_sd <- if (identification == "strong") 0.35 else 1.40
+  dat$y <- stats::rnorm(nrow(dat), eta, residual_sd)
+  dat
+}
+
+benchmark_data <- list(
+  strong = simulate_benchmark_data(
+    "strong", seed = base_seed + 10L, groups = groups,
+    observations_per_group = strong_n
+  ),
+  weak = simulate_benchmark_data(
+    "weak", seed = base_seed + 20L, groups = groups,
+    observations_per_group = weak_n
+  )
+)
+
+benchmark_prior <- prior(normal(0, 2), class = "b") +
+  prior(normal(0, 2), class = "Intercept") +
+  prior(exponential(1), class = "sd") +
+  prior(lkj(2), class = "cor") +
+  prior(exponential(1), class = "sigma")
+
+benchmark_formula <- list(
+  conventional = bf(y ~ x * z + (1 + x * z | g)),
+  s2z = bf(y ~ x * z + (1 + x * z | gr(g, s2z = TRUE)))
+)
+
+compile_template <- function(formula, data, parameterization) {
+  cat("Compiling and smoke-running ", parameterization, " model ...\n",
+      sep = "")
+  timing <- system.time({
+    fit <- brm(
+      formula = formula,
+      data = data,
+      family = gaussian(),
+      prior = benchmark_prior,
+      backend = backend,
+      chains = 1,
+      cores = 1,
+      iter = 2,
+      warmup = 1,
+      seed = base_seed + if (parameterization == "s2z") 2L else 1L,
+      refresh = 0,
+      silent = 1,
+      save_pars = save_pars(all = TRUE),
+      control = list(adapt_delta = 0.8, max_treedepth = 5)
+    )
+  })
+  list(fit = fit, seconds = unname(timing[["elapsed"]]))
+}
+
+templates <- lapply(names(benchmark_formula), function(parameterization) {
+  compile_template(
+    benchmark_formula[[parameterization]], benchmark_data$strong,
+    parameterization
+  )
+})
+names(templates) <- names(benchmark_formula)
+
+public_benchmark_variables <- function(fit) {
+  out <- grep(
+    "^(b_|sd_g__|cor_g__|sigma$|r_g\\[)",
+    variables(fit), value = TRUE
+  )
+  out[!grepl("^theta_s2z(\\[|$)", out)]
+}
+
+ebfmi_by_chain <- function(nuts) {
+  energy <- nuts[nuts$Parameter == "energy__", , drop = FALSE]
+  split_energy <- split(energy, energy$Chain)
+  vapply(split_energy, function(x) {
+    x <- x[order(x$Iteration), , drop = FALSE]
+    value <- x$Value
+    variance <- stats::var(value)
+    if (length(value) < 3L || !is.finite(variance) || variance <= 0) {
+      return(NA_real_)
+    }
+    mean(diff(value)^2) / variance
+  }, numeric(1))
+}
+
+sampler_report <- function(fit) {
+  monitored <- public_benchmark_variables(fit)
+  summaries <- posterior::summarise_draws(
+    as_draws_array(fit, variable = monitored),
+    rhat = posterior::rhat,
+    ess_bulk = posterior::ess_bulk,
+    ess_tail = posterior::ess_tail
+  )
+  nuts <- nuts_params(fit)
+  leapfrog <- nuts$Value[nuts$Parameter == "n_leapfrog__"]
+  if (!length(leapfrog)) {
+    stop("n_leapfrog__ was not available from nuts_params().", call. = FALSE)
+  }
+  gradient_evals <- sum(leapfrog + 1)
+  divergences <- sum(nuts$Value[nuts$Parameter == "divergent__"])
+  treedepth <- nuts$Value[nuts$Parameter == "treedepth__"]
+  ebfmi <- ebfmi_by_chain(nuts)
+  finite_rhat <- summaries$rhat[is.finite(summaries$rhat)]
+  finite_bulk <- summaries$ess_bulk[is.finite(summaries$ess_bulk)]
+  finite_tail <- summaries$ess_tail[is.finite(summaries$ess_tail)]
+  if (!length(finite_rhat) || !length(finite_bulk) || !length(finite_tail)) {
+    stop("Posterior diagnostics were not finite.", call. = FALSE)
+  }
+  data.frame(
+    monitored_parameters = nrow(summaries),
+    postwarmup_transitions = length(leapfrog),
+    gradient_evals = gradient_evals,
+    mean_leapfrog_steps = mean(leapfrog),
+    median_bulk_ess = stats::median(finite_bulk),
+    min_bulk_ess = min(finite_bulk),
+    median_tail_ess = stats::median(finite_tail),
+    min_tail_ess = min(finite_tail),
+    median_bulk_ess_per_gradient =
+      stats::median(finite_bulk) / gradient_evals,
+    median_tail_ess_per_gradient =
+      stats::median(finite_tail) / gradient_evals,
+    median_bulk_ess_per_1000_gradients =
+      1000 * stats::median(finite_bulk) / gradient_evals,
+    median_tail_ess_per_1000_gradients =
+      1000 * stats::median(finite_tail) / gradient_evals,
+    divergences = divergences,
+    treedepth_hits = sum(treedepth >= max_treedepth),
+    min_ebfmi = if (all(is.na(ebfmi))) NA_real_ else min(ebfmi, na.rm = TRUE),
+    max_rhat = max(finite_rhat),
+    stringsAsFactors = FALSE
+  )
+}
+
+sample_job <- function(template, data, seed) {
+  timing <- system.time({
+    fit <- update(
+      template,
+      newdata = data,
+      recompile = FALSE,
+      algorithm = "sampling",
+      chains = chains,
+      cores = cores,
+      iter = warmup + sampling,
+      warmup = warmup,
+      seed = seed,
+      refresh = 0,
+      silent = 1,
+      control = list(
+        adapt_delta = adapt_delta,
+        max_treedepth = max_treedepth
+      )
+    )
+  })
+  report <- sampler_report(fit)
+  report$wall_seconds <- unname(timing[["elapsed"]])
+  report$median_bulk_ess_per_second <-
+    report$median_bulk_ess / report$wall_seconds
+  report$median_tail_ess_per_second <-
+    report$median_tail_ess / report$wall_seconds
+  report
+}
+
+jobs <- expand.grid(
+  identification = names(benchmark_data),
+  parameterization = names(benchmark_formula),
+  replicate = seq_len(reps),
+  stringsAsFactors = FALSE
+)
+# Deterministic randomization reduces systematic thermal/order effects while
+# keeping every run exactly reproducible from BRMS_S2Z_BENCH_SEED.
+set.seed(base_seed + 100L)
+jobs <- jobs[sample(seq_len(nrow(jobs))), , drop = FALSE]
+
+rows <- vector("list", nrow(jobs))
+for (i in seq_len(nrow(jobs))) {
+  job <- jobs[i, ]
+  identification_id <- match(job$identification, c("strong", "weak"))
+  parameterization_id <- match(
+    job$parameterization, c("conventional", "s2z")
+  )
+  job_seed <- base_seed + 1000L * job$replicate +
+    100L * identification_id + 10L * parameterization_id
+  cat(
+    sprintf(
+      "Benchmarking %s identification, %s parameterization, replicate %d (seed %d) ...\n",
+      job$identification, job$parameterization, job$replicate, job_seed
+    )
+  )
+  report <- sample_job(
+    templates[[job$parameterization]]$fit,
+    benchmark_data[[job$identification]],
+    seed = job_seed
+  )
+  rows[[i]] <- cbind(
+    data.frame(
+      identification = job$identification,
+      parameterization = job$parameterization,
+      replicate = job$replicate,
+      seed = job_seed,
+      observations = nrow(benchmark_data[[job$identification]]),
+      groups = groups,
+      coefficients_per_group = 4L,
+      compile_and_smoke_seconds =
+        templates[[job$parameterization]]$seconds,
+      stringsAsFactors = FALSE
+    ),
+    report
+  )
+  print(rows[[i]], row.names = FALSE, digits = 4)
+  invisible(gc())
+}
+
+benchmark_results <- do.call(rbind, rows)
+benchmark_results <- benchmark_results[
+  order(
+    match(benchmark_results$identification, c("strong", "weak")),
+    benchmark_results$replicate,
+    match(benchmark_results$parameterization, c("conventional", "s2z"))
+  ),
+]
+rownames(benchmark_results) <- NULL
+
+conventional <- subset(
+  benchmark_results, parameterization == "conventional",
+  select = -parameterization
+)
+s2z <- subset(
+  benchmark_results, parameterization == "s2z",
+  select = -parameterization
+)
+paired <- merge(
+  conventional, s2z,
+  by = c("identification", "replicate", "observations", "groups",
+         "coefficients_per_group"),
+  suffixes = c("_conventional", "_s2z"), sort = FALSE
+)
+paired_results <- data.frame(
+  identification = paired$identification,
+  replicate = paired$replicate,
+  wall_time_speedup_conventional_over_s2z =
+    paired$wall_seconds_conventional / paired$wall_seconds_s2z,
+  gradient_reduction_conventional_over_s2z =
+    paired$gradient_evals_conventional / paired$gradient_evals_s2z,
+  bulk_ess_per_gradient_gain_s2z_over_conventional =
+    paired$median_bulk_ess_per_gradient_s2z /
+      paired$median_bulk_ess_per_gradient_conventional,
+  tail_ess_per_gradient_gain_s2z_over_conventional =
+    paired$median_tail_ess_per_gradient_s2z /
+      paired$median_tail_ess_per_gradient_conventional,
+  bulk_ess_per_second_gain_s2z_over_conventional =
+    paired$median_bulk_ess_per_second_s2z /
+      paired$median_bulk_ess_per_second_conventional,
+  stringsAsFactors = FALSE
+)
+paired_results <- paired_results[
+  order(match(paired_results$identification, c("strong", "weak")),
+        paired_results$replicate),
+]
+rownames(paired_results) <- NULL
+
+cat("\nFull benchmark results\n")
+print(benchmark_results, row.names = FALSE, digits = 5)
+cat("\nPaired conventional/S2Z efficiency ratios (> 1 favors S2Z)\n")
+print(paired_results, row.names = FALSE, digits = 5)
+
+if (nzchar(output_file)) {
+  output_dir <- dirname(output_file)
+  if (!identical(output_dir, ".")) {
+    dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  }
+  utils::write.csv(benchmark_results, output_file, row.names = FALSE)
+  paired_file <- if (grepl("\\.csv$", output_file, ignore.case = TRUE)) {
+    sub("\\.csv$", "-paired.csv", output_file, ignore.case = TRUE)
+  } else {
+    paste0(output_file, "-paired.csv")
+  }
+  utils::write.csv(paired_results, paired_file, row.names = FALSE)
+  cat("\nWrote ", normalizePath(output_file, mustWork = FALSE),
+      " and ", normalizePath(paired_file, mustWork = FALSE), ".\n", sep = "")
+}

--- a/tests/local/benchmark-s2z.R
+++ b/tests/local/benchmark-s2z.R
@@ -12,7 +12,9 @@
 #   BRMS_S2Z_BENCH_WARMUP=1000 \
 #   BRMS_S2Z_BENCH_SAMPLING=1000 \
 #   BRMS_S2Z_BENCH_GROUPS=80 \
-#   BRMS_S2Z_BENCH_MODEL=scalar-intercept \
+#   BRMS_S2Z_BENCH_MODEL=orthogonal \
+#   BRMS_S2Z_BENCH_K=10 \
+#   BRMS_S2Z_BENCH_COVARIANCE=independent \
 #   BRMS_S2Z_BENCH_REPS=3 \
 #   BRMS_S2Z_BENCH_OUT=s2z-benchmark.csv \
 #   Rscript tests/local/benchmark-s2z.R
@@ -23,7 +25,12 @@
 #   BRMS_S2Z_BENCH_WARMUP=400
 #   BRMS_S2Z_BENCH_SAMPLING=400
 #   BRMS_S2Z_BENCH_GROUPS=24
-#   BRMS_S2Z_BENCH_MODEL=interaction  # or scalar-intercept/scalar-slope
+#   BRMS_S2Z_BENCH_MODEL=interaction  # also scalar-*, orthogonal
+#   BRMS_S2Z_BENCH_K=10               # orthogonal model only
+#   BRMS_S2Z_BENCH_COVARIANCE=independent  # or correlated; orthogonal only
+#   BRMS_S2Z_BENCH_GROUP_DIST=gaussian     # or student
+#   BRMS_S2Z_BENCH_IDENTIFICATION=both     # or strong/weak
+#   BRMS_S2Z_BENCH_SIGMA=0.08         # orthogonal residual SD
 #   BRMS_S2Z_BENCH_STRONG_N=24       # observations per group
 #   BRMS_S2Z_BENCH_WEAK_N=6
 #   BRMS_S2Z_BENCH_REPS=1
@@ -31,10 +38,14 @@
 #   BRMS_S2Z_BENCH_ADAPT_DELTA=0.95
 #   BRMS_S2Z_BENCH_MAX_TREEDEPTH=12
 #
+# The orthogonal/independent setting exercises the component-wise (scalar)
+# marginal algebra with any K; "scalar" does not imply K = 1.
+#
 # `gradient_evals` counts post-warmup leapfrog gradients plus one initial
 # gradient per transition. ESS/gradient is calculated on the same post-warmup
-# transitions. Wall time is elapsed sampling time and excludes the separately
-# reported compile-and-smoke time.
+# transitions. Wall time is end-to-end refit time: it includes warmup,
+# sampling, process/CSV overhead, and brms fit construction, but excludes the
+# separately reported compile-and-smoke time.
 
 suppressPackageStartupMessages({
   library(brms)
@@ -107,7 +118,33 @@ sampling <- env_integer("BRMS_S2Z_BENCH_SAMPLING", 400L)
 groups <- env_integer("BRMS_S2Z_BENCH_GROUPS", 24L, minimum = 3L)
 benchmark_model <- env_choice(
   "BRMS_S2Z_BENCH_MODEL", "interaction",
-  c("interaction", "scalar-intercept", "scalar-slope")
+  c("interaction", "scalar-intercept", "scalar-slope", "orthogonal")
+)
+orthogonal_k <- env_integer("BRMS_S2Z_BENCH_K", 10L)
+benchmark_covariance <- if (benchmark_model == "orthogonal") {
+  env_choice(
+    "BRMS_S2Z_BENCH_COVARIANCE", "independent",
+    c("independent", "correlated")
+  )
+} else if (benchmark_model == "interaction") {
+  "correlated"
+} else {
+  "independent"
+}
+group_dist <- env_choice(
+  "BRMS_S2Z_BENCH_GROUP_DIST", "gaussian", c("gaussian", "student")
+)
+identification <- env_choice(
+  "BRMS_S2Z_BENCH_IDENTIFICATION", "both",
+  c("strong", "weak", "both")
+)
+identification_levels <- if (identification == "both") {
+  c("strong", "weak")
+} else {
+  identification
+}
+orthogonal_sigma <- env_number(
+  "BRMS_S2Z_BENCH_SIGMA", 0.08, minimum = .Machine$double.eps
 )
 strong_n <- env_integer("BRMS_S2Z_BENCH_STRONG_N", 24L, minimum = 4L)
 weak_n <- env_integer("BRMS_S2Z_BENCH_WEAK_N", 6L, minimum = 4L)
@@ -128,6 +165,21 @@ backend <- choose_backend()
 output_file <- Sys.getenv("BRMS_S2Z_BENCH_OUT", unset = "")
 options(mc.cores = cores, width = 180)
 
+benchmark_k <- switch(
+  benchmark_model,
+  interaction = 4L,
+  `scalar-intercept` = 1L,
+  `scalar-slope` = 1L,
+  orthogonal = orthogonal_k
+)
+if (benchmark_model == "orthogonal" &&
+    "strong" %in% identification_levels && strong_n < benchmark_k) {
+  stop(
+    "BRMS_S2Z_BENCH_STRONG_N must be at least BRMS_S2Z_BENCH_K ",
+    "for the exact orthogonal design.", call. = FALSE
+  )
+}
+
 backend_version <- if (backend == "cmdstanr") {
   paste(cmdstanr::cmdstan_version(), collapse = ".")
 } else {
@@ -141,9 +193,14 @@ configuration <- data.frame(
   warmup = warmup,
   sampling = sampling,
   model = benchmark_model,
+  k = benchmark_k,
+  covariance = benchmark_covariance,
+  group_dist = group_dist,
+  identification = identification,
   groups = groups,
   strong_n = strong_n,
   weak_n = weak_n,
+  orthogonal_sigma = orthogonal_sigma,
   reps = reps,
   adapt_delta = adapt_delta,
   max_treedepth = max_treedepth,
@@ -156,14 +213,51 @@ rmvn_rows <- function(n, sigma) {
   matrix(stats::rnorm(n * nrow(sigma)), nrow = n) %*% chol(sigma)
 }
 
+draw_group_effects <- function(n, sigma, dist, df = 5) {
+  out <- rmvn_rows(n, sigma)
+  if (dist == "student") {
+    # One scale per group gives an elliptically symmetric multivariate t.
+    out <- out * sqrt(df / stats::rchisq(n, df = df))
+  }
+  out
+}
+
+dense_benchmark_design <- function(n, k, identification) {
+  if (identification == "strong") {
+    if (n < k) {
+      stop("The strong orthogonal design requires n >= k.", call. = FALSE)
+    }
+    q <- qr.Q(qr(matrix(stats::rnorm(n * k), nrow = n)))
+    out <- sqrt(n) * q[, seq_len(k), drop = FALSE]
+    target <- diag(n, nrow = k, ncol = k)
+    if (max(abs(crossprod(out) - target)) > 1e-8 * n) {
+      stop("Failed to construct an orthogonal benchmark design.",
+           call. = FALSE)
+    }
+  } else {
+    weak_cor <- outer(seq_len(k), seq_len(k), function(i, j) {
+      0.97^abs(i - j)
+    })
+    out <- matrix(stats::rnorm(n * k), nrow = n) %*% chol(weak_cor)
+    out <- sweep(out, 2, sqrt(colMeans(out^2)), "/")
+  }
+  colnames(out) <- paste0("x", seq_len(k))
+  out
+}
+
 simulate_benchmark_data <- function(identification, seed, groups,
-                                    observations_per_group, model) {
+                                    observations_per_group, model, k,
+                                    covariance, group_dist,
+                                    orthogonal_sigma) {
   identification <- match.arg(identification, c("strong", "weak"))
   set.seed(seed)
   g_levels <- sprintf("g%03d", seq_len(groups))
   pieces <- lapply(seq_len(groups), function(j) {
     n <- observations_per_group
-    if (identification == "strong") {
+    if (model == "orthogonal") {
+      design <- dense_benchmark_design(n, k, identification)
+      return(data.frame(g = g_levels[j], design, check.names = FALSE))
+    } else if (identification == "strong") {
       grid <- expand.grid(x = c(-1, 1), z = c(-1, 1))
       grid <- grid[rep(seq_len(nrow(grid)), length.out = n), ]
       x <- grid$x + stats::rnorm(n, sd = 0.08)
@@ -181,12 +275,25 @@ simulate_benchmark_data <- function(identification, seed, groups,
 
   if (model == "scalar-intercept") {
     beta <- 0.35
-    u <- stats::rnorm(groups, sd = 0.75)
-    eta <- beta + u[as.integer(dat$g)]
+    u <- draw_group_effects(groups, matrix(0.75^2), group_dist)
+    eta <- beta + u[as.integer(dat$g), 1]
   } else if (model == "scalar-slope") {
     beta <- 0.70
-    u <- stats::rnorm(groups, sd = 0.50)
-    eta <- dat$x * (beta + u[as.integer(dat$g)])
+    u <- draw_group_effects(groups, matrix(0.50^2), group_dist)
+    eta <- dat$x * (beta + u[as.integer(dat$g), 1])
+  } else if (model == "orthogonal") {
+    x_names <- paste0("x", seq_len(k))
+    X <- as.matrix(dat[x_names])
+    beta <- seq(0.20, 0.80, length.out = k) * (-1)^(seq_len(k) - 1L)
+    re_sd <- seq(0.35, 0.80, length.out = k)
+    re_cor <- if (covariance == "independent") {
+      diag(k)
+    } else {
+      outer(seq_len(k), seq_len(k), function(i, j) 0.25^abs(i - j))
+    }
+    sigma_re <- diag(re_sd) %*% re_cor %*% diag(re_sd)
+    u <- draw_group_effects(groups, sigma_re, group_dist)
+    eta <- drop(X %*% beta) + rowSums(X * u[as.integer(dat$g), ])
   } else {
     X <- stats::model.matrix(~ x * z, dat)
     beta <- c(0.35, 0.70, -0.45, 0.30)
@@ -195,58 +302,122 @@ simulate_benchmark_data <- function(identification, seed, groups,
       0.25^abs(i - j)
     })
     sigma_re <- diag(re_sd) %*% re_cor %*% diag(re_sd)
-    u <- rmvn_rows(groups, sigma_re)
+    u <- draw_group_effects(groups, sigma_re, group_dist)
     eta <- drop(X %*% beta) + rowSums(X * u[as.integer(dat$g), ])
   }
-  residual_sd <- if (identification == "strong") 0.35 else 1.40
+  residual_sd <- if (model == "orthogonal") {
+    orthogonal_sigma
+  } else if (identification == "strong") {
+    0.35
+  } else {
+    1.40
+  }
   dat$y <- stats::rnorm(nrow(dat), eta, residual_sd)
   dat
 }
 
-benchmark_data <- list(
-  strong = simulate_benchmark_data(
-    "strong", seed = base_seed + 10L, groups = groups,
-    observations_per_group = strong_n, model = benchmark_model
-  ),
-  weak = simulate_benchmark_data(
-    "weak", seed = base_seed + 20L, groups = groups,
-    observations_per_group = weak_n, model = benchmark_model
+benchmark_data <- lapply(identification_levels, function(level) {
+  simulate_benchmark_data(
+    level,
+    seed = base_seed + if (level == "strong") 10L else 20L,
+    groups = groups,
+    observations_per_group = if (level == "strong") strong_n else weak_n,
+    model = benchmark_model,
+    k = benchmark_k,
+    covariance = benchmark_covariance,
+    group_dist = group_dist,
+    orthogonal_sigma = orthogonal_sigma
   )
-)
+})
+names(benchmark_data) <- identification_levels
 
 benchmark_prior <- if (benchmark_model == "scalar-intercept") {
-  prior(normal(0, 2), class = "Intercept") +
-    prior(exponential(1), class = "sd") +
-    prior(exponential(1), class = "sigma")
-} else if (benchmark_model == "scalar-slope") {
-  prior(normal(0, 2), class = "b") +
-    prior(exponential(1), class = "sd") +
-    prior(exponential(1), class = "sigma")
+  prior(normal(0, 2), class = "Intercept")
+} else if (benchmark_model %in% c("scalar-slope", "orthogonal")) {
+  prior(normal(0, 2), class = "b")
 } else {
   prior(normal(0, 2), class = "b") +
-    prior(normal(0, 2), class = "Intercept") +
-    prior(exponential(1), class = "sd") +
-    prior(lkj(2), class = "cor") +
-    prior(exponential(1), class = "sigma")
+    prior(normal(0, 2), class = "Intercept")
 }
+benchmark_prior <- benchmark_prior +
+  prior(exponential(1), class = "sd") +
+  prior(exponential(1), class = "sigma")
+if (benchmark_covariance == "correlated" && benchmark_k > 1L) {
+  benchmark_prior <- benchmark_prior + prior(lkj(2), class = "cor")
+}
+if (group_dist == "student") {
+  benchmark_prior <- benchmark_prior +
+    prior(gamma(2, 0.2), class = "df", group = "g")
+}
+
+group_expression <- function(s2z, explicit_cor = NULL) {
+  args <- "g"
+  if (!is.null(explicit_cor)) {
+    args <- c(args, paste0("cor = ", as.character(explicit_cor)))
+  }
+  if (group_dist == "student") {
+    args <- c(args, 'dist = "student"')
+  }
+  if (s2z) {
+    args <- c(args, "s2z = TRUE")
+  }
+  if (length(args) == 1L) {
+    return(args)
+  }
+  paste0("gr(", paste(args, collapse = ", "), ")")
+}
+
+orthogonal_cor <- identical(benchmark_covariance, "correlated")
+conventional_group <- group_expression(
+  FALSE,
+  explicit_cor = if (benchmark_model == "orthogonal") orthogonal_cor else NULL
+)
+s2z_group <- group_expression(
+  TRUE,
+  explicit_cor = if (benchmark_model == "orthogonal") orthogonal_cor else NULL
+)
 
 benchmark_formula <- if (benchmark_model == "scalar-intercept") {
   list(
-    conventional = bf(y ~ 1 + (1 | g)),
-    s2z = bf(y ~ 1 + (1 | gr(g, s2z = TRUE)))
+    conventional = bf(stats::as.formula(paste0(
+      "y ~ 1 + (1 | ", conventional_group, ")"
+    ))),
+    s2z = bf(stats::as.formula(paste0(
+      "y ~ 1 + (1 | ", s2z_group, ")"
+    )))
   )
 } else if (benchmark_model == "scalar-slope") {
   list(
-    conventional = bf(y ~ 0 + x + (0 + x | g)),
-    s2z = bf(y ~ 0 + x + (0 + x | gr(g, s2z = TRUE)))
+    conventional = bf(stats::as.formula(paste0(
+      "y ~ 0 + x + (0 + x | ", conventional_group, ")"
+    ))),
+    s2z = bf(stats::as.formula(paste0(
+      "y ~ 0 + x + (0 + x | ", s2z_group, ")"
+    )))
+  )
+} else if (benchmark_model == "orthogonal") {
+  x_terms <- paste0("x", seq_len(benchmark_k), collapse = " + ")
+  list(
+    conventional = bf(stats::as.formula(paste0(
+      "y ~ 0 + ", x_terms, " + (0 + ", x_terms, " | ",
+      conventional_group, ")"
+    ))),
+    s2z = bf(stats::as.formula(paste0(
+      "y ~ 0 + ", x_terms, " + (0 + ", x_terms, " | ",
+      s2z_group, ")"
+    )))
   )
 } else {
   list(
-    conventional = bf(y ~ x * z + (1 + x * z | g)),
-    s2z = bf(y ~ x * z + (1 + x * z | gr(g, s2z = TRUE)))
+    conventional = bf(stats::as.formula(paste0(
+      "y ~ x * z + (1 + x * z | ", conventional_group, ")"
+    ))),
+    s2z = bf(stats::as.formula(paste0(
+      "y ~ x * z + (1 + x * z | ", s2z_group, ")"
+    )))
   )
 }
-coefficients_per_group <- if (benchmark_model == "interaction") 4L else 1L
+coefficients_per_group <- benchmark_k
 
 compile_template <- function(formula, data, parameterization) {
   cat("Compiling and smoke-running ", parameterization, " model ...\n",
@@ -274,7 +445,7 @@ compile_template <- function(formula, data, parameterization) {
 
 templates <- lapply(names(benchmark_formula), function(parameterization) {
   compile_template(
-    benchmark_formula[[parameterization]], benchmark_data$strong,
+    benchmark_formula[[parameterization]], benchmark_data[[1]],
     parameterization
   )
 })
@@ -282,7 +453,7 @@ names(templates) <- names(benchmark_formula)
 
 public_benchmark_variables <- function(fit) {
   out <- grep(
-    "^(b_|sd_g__|cor_g__|sigma$|r_g\\[)",
+    "^(b_|sd_g__|cor_g__|df_g($|__)|sigma$|r_g\\[)",
     variables(fit), value = TRUE
   )
   out[!grepl("^theta_s2z(\\[|$)", out)]
@@ -414,6 +585,9 @@ for (i in seq_len(nrow(jobs))) {
     data.frame(
       identification = job$identification,
       model = benchmark_model,
+      k = benchmark_k,
+      covariance = benchmark_covariance,
+      group_dist = group_dist,
       parameterization = job$parameterization,
       replicate = job$replicate,
       seed = job_seed,
@@ -451,14 +625,17 @@ s2z <- subset(
 paired <- merge(
   conventional, s2z,
   by = c(
-    "identification", "model", "replicate", "observations", "groups",
-    "coefficients_per_group"
+    "identification", "model", "k", "covariance", "group_dist",
+    "replicate", "observations", "groups", "coefficients_per_group"
   ),
   suffixes = c("_conventional", "_s2z"), sort = FALSE
 )
 paired_results <- data.frame(
   identification = paired$identification,
   model = paired$model,
+  k = paired$k,
+  covariance = paired$covariance,
+  group_dist = paired$group_dist,
   replicate = paired$replicate,
   wall_time_speedup_conventional_over_s2z =
     paired$wall_seconds_conventional / paired$wall_seconds_s2z,

--- a/tests/local/benchmark-s2z.R
+++ b/tests/local/benchmark-s2z.R
@@ -12,6 +12,7 @@
 #   BRMS_S2Z_BENCH_WARMUP=1000 \
 #   BRMS_S2Z_BENCH_SAMPLING=1000 \
 #   BRMS_S2Z_BENCH_GROUPS=80 \
+#   BRMS_S2Z_BENCH_MODEL=scalar-intercept \
 #   BRMS_S2Z_BENCH_REPS=3 \
 #   BRMS_S2Z_BENCH_OUT=s2z-benchmark.csv \
 #   Rscript tests/local/benchmark-s2z.R
@@ -22,6 +23,7 @@
 #   BRMS_S2Z_BENCH_WARMUP=400
 #   BRMS_S2Z_BENCH_SAMPLING=400
 #   BRMS_S2Z_BENCH_GROUPS=24
+#   BRMS_S2Z_BENCH_MODEL=interaction  # or scalar-intercept/scalar-slope
 #   BRMS_S2Z_BENCH_STRONG_N=24       # observations per group
 #   BRMS_S2Z_BENCH_WEAK_N=6
 #   BRMS_S2Z_BENCH_REPS=1
@@ -63,6 +65,15 @@ env_number <- function(name, default, minimum = -Inf) {
   out
 }
 
+env_choice <- function(name, default, choices) {
+  value <- Sys.getenv(name, unset = default)
+  if (!value %in% choices) {
+    stop(name, " must be one of: ", paste(choices, collapse = ", "), ".",
+         call. = FALSE)
+  }
+  value
+}
+
 choose_backend <- function() {
   requested <- tolower(Sys.getenv(
     "BRMS_S2Z_BENCH_BACKEND",
@@ -94,6 +105,10 @@ chains <- env_integer("BRMS_S2Z_BENCH_CHAINS", 2L, minimum = 2L)
 warmup <- env_integer("BRMS_S2Z_BENCH_WARMUP", 400L)
 sampling <- env_integer("BRMS_S2Z_BENCH_SAMPLING", 400L)
 groups <- env_integer("BRMS_S2Z_BENCH_GROUPS", 24L, minimum = 3L)
+benchmark_model <- env_choice(
+  "BRMS_S2Z_BENCH_MODEL", "interaction",
+  c("interaction", "scalar-intercept", "scalar-slope")
+)
 strong_n <- env_integer("BRMS_S2Z_BENCH_STRONG_N", 24L, minimum = 4L)
 weak_n <- env_integer("BRMS_S2Z_BENCH_WEAK_N", 6L, minimum = 4L)
 reps <- env_integer("BRMS_S2Z_BENCH_REPS", 1L)
@@ -125,6 +140,7 @@ configuration <- data.frame(
   chains = chains,
   warmup = warmup,
   sampling = sampling,
+  model = benchmark_model,
   groups = groups,
   strong_n = strong_n,
   weak_n = weak_n,
@@ -141,7 +157,7 @@ rmvn_rows <- function(n, sigma) {
 }
 
 simulate_benchmark_data <- function(identification, seed, groups,
-                                    observations_per_group) {
+                                    observations_per_group, model) {
   identification <- match.arg(identification, c("strong", "weak"))
   set.seed(seed)
   g_levels <- sprintf("g%03d", seq_len(groups))
@@ -163,15 +179,25 @@ simulate_benchmark_data <- function(identification, seed, groups,
   rownames(dat) <- NULL
   dat$g <- factor(dat$g, levels = g_levels)
 
-  X <- stats::model.matrix(~ x * z, dat)
-  beta <- c(0.35, 0.70, -0.45, 0.30)
-  re_sd <- c(0.75, 0.50, 0.45, 0.35)
-  re_cor <- outer(seq_along(re_sd), seq_along(re_sd), function(i, j) {
-    0.25^abs(i - j)
-  })
-  sigma_re <- diag(re_sd) %*% re_cor %*% diag(re_sd)
-  u <- rmvn_rows(groups, sigma_re)
-  eta <- drop(X %*% beta) + rowSums(X * u[as.integer(dat$g), ])
+  if (model == "scalar-intercept") {
+    beta <- 0.35
+    u <- stats::rnorm(groups, sd = 0.75)
+    eta <- beta + u[as.integer(dat$g)]
+  } else if (model == "scalar-slope") {
+    beta <- 0.70
+    u <- stats::rnorm(groups, sd = 0.50)
+    eta <- dat$x * (beta + u[as.integer(dat$g)])
+  } else {
+    X <- stats::model.matrix(~ x * z, dat)
+    beta <- c(0.35, 0.70, -0.45, 0.30)
+    re_sd <- c(0.75, 0.50, 0.45, 0.35)
+    re_cor <- outer(seq_along(re_sd), seq_along(re_sd), function(i, j) {
+      0.25^abs(i - j)
+    })
+    sigma_re <- diag(re_sd) %*% re_cor %*% diag(re_sd)
+    u <- rmvn_rows(groups, sigma_re)
+    eta <- drop(X %*% beta) + rowSums(X * u[as.integer(dat$g), ])
+  }
   residual_sd <- if (identification == "strong") 0.35 else 1.40
   dat$y <- stats::rnorm(nrow(dat), eta, residual_sd)
   dat
@@ -180,24 +206,47 @@ simulate_benchmark_data <- function(identification, seed, groups,
 benchmark_data <- list(
   strong = simulate_benchmark_data(
     "strong", seed = base_seed + 10L, groups = groups,
-    observations_per_group = strong_n
+    observations_per_group = strong_n, model = benchmark_model
   ),
   weak = simulate_benchmark_data(
     "weak", seed = base_seed + 20L, groups = groups,
-    observations_per_group = weak_n
+    observations_per_group = weak_n, model = benchmark_model
   )
 )
 
-benchmark_prior <- prior(normal(0, 2), class = "b") +
+benchmark_prior <- if (benchmark_model == "scalar-intercept") {
   prior(normal(0, 2), class = "Intercept") +
-  prior(exponential(1), class = "sd") +
-  prior(lkj(2), class = "cor") +
-  prior(exponential(1), class = "sigma")
+    prior(exponential(1), class = "sd") +
+    prior(exponential(1), class = "sigma")
+} else if (benchmark_model == "scalar-slope") {
+  prior(normal(0, 2), class = "b") +
+    prior(exponential(1), class = "sd") +
+    prior(exponential(1), class = "sigma")
+} else {
+  prior(normal(0, 2), class = "b") +
+    prior(normal(0, 2), class = "Intercept") +
+    prior(exponential(1), class = "sd") +
+    prior(lkj(2), class = "cor") +
+    prior(exponential(1), class = "sigma")
+}
 
-benchmark_formula <- list(
-  conventional = bf(y ~ x * z + (1 + x * z | g)),
-  s2z = bf(y ~ x * z + (1 + x * z | gr(g, s2z = TRUE)))
-)
+benchmark_formula <- if (benchmark_model == "scalar-intercept") {
+  list(
+    conventional = bf(y ~ 1 + (1 | g)),
+    s2z = bf(y ~ 1 + (1 | gr(g, s2z = TRUE)))
+  )
+} else if (benchmark_model == "scalar-slope") {
+  list(
+    conventional = bf(y ~ 0 + x + (0 + x | g)),
+    s2z = bf(y ~ 0 + x + (0 + x | gr(g, s2z = TRUE)))
+  )
+} else {
+  list(
+    conventional = bf(y ~ x * z + (1 + x * z | g)),
+    s2z = bf(y ~ x * z + (1 + x * z | gr(g, s2z = TRUE)))
+  )
+}
+coefficients_per_group <- if (benchmark_model == "interaction") 4L else 1L
 
 compile_template <- function(formula, data, parameterization) {
   cat("Compiling and smoke-running ", parameterization, " model ...\n",
@@ -364,12 +413,13 @@ for (i in seq_len(nrow(jobs))) {
   rows[[i]] <- cbind(
     data.frame(
       identification = job$identification,
+      model = benchmark_model,
       parameterization = job$parameterization,
       replicate = job$replicate,
       seed = job_seed,
       observations = nrow(benchmark_data[[job$identification]]),
       groups = groups,
-      coefficients_per_group = 4L,
+      coefficients_per_group = coefficients_per_group,
       compile_and_smoke_seconds =
         templates[[job$parameterization]]$seconds,
       stringsAsFactors = FALSE
@@ -400,12 +450,15 @@ s2z <- subset(
 )
 paired <- merge(
   conventional, s2z,
-  by = c("identification", "replicate", "observations", "groups",
-         "coefficients_per_group"),
+  by = c(
+    "identification", "model", "replicate", "observations", "groups",
+    "coefficients_per_group"
+  ),
   suffixes = c("_conventional", "_s2z"), sort = FALSE
 )
 paired_results <- data.frame(
   identification = paired$identification,
+  model = paired$model,
   replicate = paired$replicate,
   wall_time_speedup_conventional_over_s2z =
     paired$wall_seconds_conventional / paired$wall_seconds_s2z,

--- a/tests/local/benchmark-s2z.R
+++ b/tests/local/benchmark-s2z.R
@@ -1,4 +1,4 @@
-# Reproducible benchmark for marginalized sum-to-zero group-level effects.
+# Reproducible benchmark for physical sum-to-zero group-level effects.
 #
 # This script compiles the conventional and S2Z programs once, then times only
 # refits that reuse those compiled programs. It does not run as part of the
@@ -39,7 +39,7 @@
 #   BRMS_S2Z_BENCH_MAX_TREEDEPTH=12
 #
 # The orthogonal/independent setting exercises the component-wise (scalar)
-# marginal algebra with any K; "scalar" does not imply K = 1.
+# component-wise S2Z algebra with any K; "scalar" does not imply K = 1.
 #
 # `gradient_evals` counts post-warmup leapfrog gradients plus one initial
 # gradient per transition. ESS/gradient is calculated on the same post-warmup

--- a/tests/local/s2z-foundation-provenance.md
+++ b/tests/local/s2z-foundation-provenance.md
@@ -2,20 +2,22 @@
 
 This manifest records how the combined development branch preserved at
 `archive/s2z-combined-20260825` was reduced to the physical/shared-scale
-foundation on `feature/s2z-foundation`. The extraction base is
-`29ccd2384776b2bfc13bf749659528911743a92b`.
+foundation on `feature/s2z-foundation`. The original extraction base was
+`29ccd2384776b2bfc13bf749659528911743a92b`; the resulting series was then
+rebased onto `origin/master` at
+`4f91054353436f5814cd4ccf6da61f14b2d0e45d`.
 
 | Combined commit | Foundation treatment |
 |---|---|
-| `112e2fce` Add marginalized sum-to-zero group effects | Replayed as `85ce52c8`. |
-| `fd3b08b3` Specialize scalar sum-to-zero effects | Replayed as `aff8582c`. |
-| `1835a8a5` Document varying-effect prior support | Replayed as `79de4c28`; this describes coefficient-specific scales shared across levels. |
-| `4b36a563` Specialize independent sum-to-zero effects | Replayed as `e4acf030`. |
-| `601e792c` Clarify physical sum-to-zero terminology | Replayed as `b946ebfa`. |
+| `112e2fce` Add marginalized sum-to-zero group effects | Replayed as `562a969f`. |
+| `fd3b08b3` Specialize scalar sum-to-zero effects | Replayed as `a7449e20`. |
+| `1835a8a5` Document varying-effect prior support | Replayed as `003ea1e4`; this describes coefficient-specific scales shared across levels. |
+| `4b36a563` Specialize independent sum-to-zero effects | Replayed as `c1afad55`. |
+| `601e792c` Clarify physical sum-to-zero terminology | Replayed as `2a99dc40`. |
 | `5f692168` Add group-varying S2Z scales | Deferred to PLAN-04; no public API or state retained. |
 | `2a4eeb11` Add partial centering for sum-to-zero effects | Deferred to PLAN-03; no `center`, `rho_s2z`, or automatic-centering state retained. |
-| `ca59f007` Support multiple sum-to-zero grouping blocks | Replayed as `aa1f6d40` after removing dependencies on deferred modes. |
-| `4c95250a` Add fast Matheron path for Gaussian S2Z blocks | Replayed as `92561314` after removing dependencies on deferred modes. |
+| `ca59f007` Support multiple sum-to-zero grouping blocks | Replayed as `48169204` after removing dependencies on deferred modes. |
+| `4c95250a` Add fast Matheron path for Gaussian S2Z blocks | Replayed as `e1381595` after removing dependencies on deferred modes. |
 | `50ec7242` Allow priors on realized group-level scales | Deferred to PLAN-04; no realized-scale API or level-specific scale state retained. |
 | `ddf913c5` Reduce Stan allocations for S2Z effects | PR-1-safe allocation changes were rewritten onto the reduced physical paths. |
 | `ce57b03b` Vectorize S2Z scale priors | Shared-scale vectorization was rewritten where applicable; varying-level-scale hunks were deferred to PLAN-04. |

--- a/tests/local/s2z-foundation-provenance.md
+++ b/tests/local/s2z-foundation-provenance.md
@@ -1,0 +1,32 @@
+# PLAN-01 S2Z foundation provenance
+
+This manifest records how the combined development branch preserved at
+`archive/s2z-combined-20260825` was reduced to the physical/shared-scale
+foundation on `feature/s2z-foundation`. The extraction base is
+`29ccd2384776b2bfc13bf749659528911743a92b`.
+
+| Combined commit | Foundation treatment |
+|---|---|
+| `112e2fce` Add marginalized sum-to-zero group effects | Replayed as `85ce52c8`. |
+| `fd3b08b3` Specialize scalar sum-to-zero effects | Replayed as `aff8582c`. |
+| `1835a8a5` Document varying-effect prior support | Replayed as `79de4c28`; this describes coefficient-specific scales shared across levels. |
+| `4b36a563` Specialize independent sum-to-zero effects | Replayed as `e4acf030`. |
+| `601e792c` Clarify physical sum-to-zero terminology | Replayed as `b946ebfa`. |
+| `5f692168` Add group-varying S2Z scales | Deferred to PLAN-04; no public API or state retained. |
+| `2a4eeb11` Add partial centering for sum-to-zero effects | Deferred to PLAN-03; no `center`, `rho_s2z`, or automatic-centering state retained. |
+| `ca59f007` Support multiple sum-to-zero grouping blocks | Replayed as `aa1f6d40` after removing dependencies on deferred modes. |
+| `4c95250a` Add fast Matheron path for Gaussian S2Z blocks | Replayed as `92561314` after removing dependencies on deferred modes. |
+| `50ec7242` Allow priors on realized group-level scales | Deferred to PLAN-04; no realized-scale API or level-specific scale state retained. |
+| `ddf913c5` Reduce Stan allocations for S2Z effects | PR-1-safe allocation changes were rewritten onto the reduced physical paths. |
+| `ce57b03b` Vectorize S2Z scale priors | Shared-scale vectorization was rewritten where applicable; varying-level-scale hunks were deferred to PLAN-04. |
+| `9d76772e` Vectorize additional S2Z operations | PR-1-safe vectorization was rewritten; its varying-scale fixture was not retained. |
+| `7aed341b` Add automatic Fisher centering for S2Z effects | Deferred to PLAN-03; no Fisher-centering API or generated state retained. |
+
+PLAN-01 also adds work that postdates the combined branch: exact logistic
+population priors, phased structure/design/prior validation, contextual
+diagnostics, active versus fixed-only population coordinates, a semantic
+capability matrix, and posterior-equivalence fixtures.
+
+The mechanical forbidden-feature audit lives in
+`tests/testthat/tests.s2z-capabilities.R`. The combined branch and its pushed
+copy (`feature/s2z-group-effects`) remain unchanged and recoverable.

--- a/tests/local/tests.models-s2z-families.R
+++ b/tests/local/tests.models-s2z-families.R
@@ -1,0 +1,809 @@
+# Sampling validation for physical sum-to-zero effects in non-Gaussian
+# families and distributional parameters.
+#
+# This local test complements tests.models-s2z.R. It fits conventional and
+# exactly equivalent S2Z versions of five small, deterministically simulated
+# models: Bernoulli, Poisson, zero-inflated Poisson with S2Z in zi, hurdle
+# Poisson with S2Z in hu, and a two-component Poisson mixture with S2Z in
+# theta1. Run it against an installed development build of brms, for example
+# with
+#
+#   R_LIBS=/tmp/brms-foundation-lib \
+#     Rscript tests/local/tests.models-s2z-families.R
+#
+# Useful controls (shown with their defaults) are
+#
+#   BRMS_S2Z_CHAINS=2
+#   BRMS_S2Z_WARMUP=400
+#   BRMS_S2Z_SAMPLING=400
+#   BRMS_S2Z_CORES=min(chains, parallel::detectCores())
+#   BRMS_S2Z_BACKEND=auto
+#   BRMS_S2Z_ADAPT_DELTA=0.97
+#   BRMS_S2Z_MAX_TREEDEPTH=12
+#   BRMS_S2Z_EQUIV_Z=7
+#   BRMS_S2Z_MAX_RHAT=1.10
+#   BRMS_S2Z_MAX_DIVERGENCES=0
+#   BRMS_S2Z_MAX_TREEDEPTH_HITS=0
+#   BRMS_S2Z_MIN_EBFMI=0.20
+#   BRMS_S2Z_INVARIANT_TOL=1e-6
+#   BRMS_S2Z_REPORT_ROWS=30
+#   BRMS_S2Z_CACHE_DIR=
+#
+# Posterior equivalence is tested for means and standard deviations. For each
+# independently sampled pair, the acceptance threshold is fixed in advance at
+# BRMS_S2Z_EQUIV_Z times
+#
+#   sqrt(mcse_conventional^2 + mcse_s2z^2).
+
+suppressPackageStartupMessages({
+  library(brms)
+  library(posterior)
+})
+
+env_integer <- function(name, default, minimum = 1L) {
+  value <- Sys.getenv(name, unset = "")
+  if (!nzchar(value)) {
+    return(as.integer(default))
+  }
+  out <- suppressWarnings(as.integer(value))
+  if (length(out) != 1L || is.na(out) || out < minimum) {
+    stop(name, " must be an integer >= ", minimum, call. = FALSE)
+  }
+  out
+}
+
+env_number <- function(name, default, minimum = -Inf) {
+  value <- Sys.getenv(name, unset = "")
+  if (!nzchar(value)) {
+    return(as.numeric(default))
+  }
+  out <- suppressWarnings(as.numeric(value))
+  if (length(out) != 1L || !is.finite(out) || out < minimum) {
+    stop(name, " must be a finite number >= ", minimum, call. = FALSE)
+  }
+  out
+}
+
+choose_backend <- function() {
+  requested <- tolower(Sys.getenv("BRMS_S2Z_BACKEND", unset = "auto"))
+  if (requested %in% c("cmdstanr", "rstan")) {
+    return(requested)
+  }
+  if (!identical(requested, "auto")) {
+    stop("BRMS_S2Z_BACKEND must be auto, cmdstanr, or rstan.",
+         call. = FALSE)
+  }
+  cmdstan_ok <- requireNamespace("cmdstanr", quietly = TRUE) &&
+    isTRUE(tryCatch(
+      nzchar(suppressWarnings(cmdstanr::cmdstan_path())),
+      error = function(e) FALSE
+    ))
+  if (cmdstan_ok) {
+    return("cmdstanr")
+  }
+  if (requireNamespace("rstan", quietly = TRUE)) {
+    return("rstan")
+  }
+  stop("Neither a working CmdStan installation nor rstan was found.",
+       call. = FALSE)
+}
+
+chains <- env_integer("BRMS_S2Z_CHAINS", 2L, minimum = 2L)
+warmup <- env_integer("BRMS_S2Z_WARMUP", 400L)
+sampling <- env_integer("BRMS_S2Z_SAMPLING", 400L)
+detected_cores <- parallel::detectCores(logical = FALSE)
+if (is.na(detected_cores)) {
+  detected_cores <- 1L
+}
+cores <- env_integer(
+  "BRMS_S2Z_CORES", min(chains, detected_cores), minimum = 1L
+)
+backend <- choose_backend()
+adapt_delta <- env_number("BRMS_S2Z_ADAPT_DELTA", 0.97, minimum = 0.5)
+max_treedepth <- env_integer("BRMS_S2Z_MAX_TREEDEPTH", 12L)
+equiv_z <- env_number("BRMS_S2Z_EQUIV_Z", 7, minimum = 1)
+max_rhat <- env_number("BRMS_S2Z_MAX_RHAT", 1.10, minimum = 1)
+max_divergences <- env_integer(
+  "BRMS_S2Z_MAX_DIVERGENCES", 0L, minimum = 0L
+)
+max_treedepth_hits <- env_integer(
+  "BRMS_S2Z_MAX_TREEDEPTH_HITS", 0L, minimum = 0L
+)
+min_ebfmi <- env_number("BRMS_S2Z_MIN_EBFMI", 0.20, minimum = 0)
+invariant_tolerance <- env_number(
+  # CmdStan's default CSV precision introduces errors around 1e-7 when
+  # generated quantities are read back into R.
+  "BRMS_S2Z_INVARIANT_TOL", 1e-6, minimum = 0
+)
+report_rows <- env_integer("BRMS_S2Z_REPORT_ROWS", 30L)
+cache_dir <- Sys.getenv("BRMS_S2Z_CACHE_DIR", unset = "")
+
+options(mc.cores = cores, width = 150)
+
+configuration <- data.frame(
+  brms_version = as.character(utils::packageVersion("brms")),
+  backend = backend,
+  chains = chains,
+  warmup = warmup,
+  sampling = sampling,
+  cores = cores,
+  adapt_delta = adapt_delta,
+  max_treedepth = max_treedepth,
+  equiv_z = equiv_z,
+  stringsAsFactors = FALSE
+)
+cat("S2Z non-Gaussian sampling-equivalence configuration\n")
+print(configuration, row.names = FALSE)
+
+group_frame <- function(groups, per_group) {
+  levels <- sprintf("g%02d", seq_len(groups))
+  data.frame(
+    g = factor(rep(levels, each = per_group), levels = levels),
+    within = rep(seq(-1, 1, length.out = per_group), groups)
+  )
+}
+
+simulate_bernoulli <- function(seed = 6201L, groups = 10L,
+                               per_group = 16L) {
+  set.seed(seed)
+  dat <- group_frame(groups, per_group)
+  # Keep the group scale away from the weakly identified boundary so this
+  # equivalence test diagnoses the transformation rather than a generic
+  # near-zero hierarchical funnel.
+  u <- 1.4 * sin(seq(0, 2 * pi, length.out = groups + 1L)[-1L])
+  eta <- -0.15 + u[as.integer(dat$g)]
+  dat$y <- stats::rbinom(nrow(dat), size = 1L, prob = plogis(eta))
+  dat[, c("y", "g")]
+}
+
+simulate_poisson <- function(seed = 6202L, groups = 10L,
+                             per_group = 10L) {
+  set.seed(seed)
+  dat <- group_frame(groups, per_group)
+  u <- seq(-0.55, 0.55, length.out = groups)
+  lambda <- exp(0.55 + u[as.integer(dat$g)])
+  dat$y <- stats::rpois(nrow(dat), lambda)
+  dat[, c("y", "g")]
+}
+
+simulate_zero_process <- function(type = c("zi", "hu"), seed = 6203L,
+                                  groups = 10L, per_group = 14L) {
+  type <- match.arg(type)
+  set.seed(seed)
+  dat <- group_frame(groups, per_group)
+  u_limit <- if (type == "zi") 1.5 else 1.05
+  u <- seq(-u_limit, u_limit, length.out = groups)
+  pzero <- plogis(-0.65 + u[as.integer(dat$g)])
+  # A higher ZIP rate separates structural from sampling zeros and makes the
+  # zi group scale a well-identified test quantity.
+  lambda <- rep(if (type == "zi") 4 else 2.4, nrow(dat))
+  is_zero <- stats::rbinom(nrow(dat), size = 1L, prob = pzero) == 1L
+  if (type == "zi") {
+    dat$y <- ifelse(is_zero, 0L, stats::rpois(nrow(dat), lambda))
+  } else {
+    p0 <- exp(-lambda)
+    positive <- stats::qpois(
+      p0 + stats::runif(nrow(dat)) * (1 - p0), lambda = lambda
+    )
+    dat$y <- ifelse(is_zero, 0L, positive)
+  }
+  dat[, c("y", "g")]
+}
+
+simulate_poisson_mixture <- function(seed = 6205L, groups = 10L,
+                                     per_group = 16L) {
+  set.seed(seed)
+  dat <- group_frame(groups, per_group)
+  u <- seq(-1.2, 1.2, length.out = groups)
+  theta1 <- plogis(0.15 + u[as.integer(dat$g)])
+  component1 <- stats::rbinom(nrow(dat), size = 1L, prob = theta1) == 1L
+  lambda <- ifelse(component1, 1.25, 6.0)
+  dat$y <- stats::rpois(nrow(dat), lambda)
+  dat[, c("y", "g")]
+}
+
+cache_file <- function(label) {
+  if (!nzchar(cache_dir)) {
+    return(NULL)
+  }
+  dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+  suffix <- paste(backend, chains, warmup, sampling, sep = "-")
+  file.path(cache_dir, paste0(label, "-", suffix, ".rds"))
+}
+
+sample_model <- function(case, parameterization) {
+  label <- paste(case$name, parameterization, sep = "-")
+  cat("Sampling ", label, " ...\n", sep = "")
+  formula <- case[[paste0(parameterization, "_formula")]]
+  args <- list(
+    formula = formula,
+    data = case$data,
+    family = case$family,
+    prior = case$prior,
+    backend = backend,
+    chains = chains,
+    cores = cores,
+    iter = warmup + sampling,
+    warmup = warmup,
+    seed = case$seed + identical(parameterization, "s2z"),
+    refresh = 0,
+    silent = 1,
+    save_pars = save_pars(all = TRUE),
+    control = list(
+      adapt_delta = adapt_delta,
+      max_treedepth = max_treedepth
+    )
+  )
+  file <- cache_file(label)
+  if (!is.null(file)) {
+    args$file <- file
+    args$file_refit <- "on_change"
+  }
+  do.call(brm, args)
+}
+
+exact_draw_matrix <- function(fit, variable) {
+  missing <- setdiff(variable, variables(fit))
+  if (length(missing)) {
+    stop("Required saved variables are missing: ",
+         paste(missing, collapse = ", "), call. = FALSE)
+  }
+  as.matrix(as_draws_matrix(fit, variable = variable))
+}
+
+selected_observations <- function(n) {
+  unique(round(seq(1, n, length.out = min(5L, n))))
+}
+
+append_matrix_samples <- function(out, value, prefix) {
+  selected <- selected_observations(ncol(value))
+  for (i in selected) {
+    out[[sprintf("%s:observation[%d]", prefix, i)]] <- value[, i]
+  }
+  out[[paste0(prefix, ":observation-average")]] <- rowMeans(value)
+  out
+}
+
+public_samples <- function(fit, case) {
+  fe <- as.matrix(fixef(fit, summary = FALSE))
+  if (any(grepl("s2z", colnames(fe), fixed = TRUE))) {
+    stop("An internal S2Z coefficient leaked through fixef().", call. = FALSE)
+  }
+  out <- setNames(
+    lapply(seq_len(ncol(fe)), function(k) fe[, k]),
+    paste0("b:", colnames(fe))
+  )
+
+  re <- ranef(fit, summary = FALSE)$g
+  if (is.null(re) || !case$re_coef %in% dimnames(re)[[3L]]) {
+    stop("No public group-level draws found for ", case$re_coef,
+         call. = FALSE)
+  }
+  for (j in seq_len(dim(re)[2L])) {
+    label <- paste(dimnames(re)[[2L]][j], case$re_coef, sep = ",")
+    out[[paste0("r:[", label, "]")]] <- re[, j, case$re_coef]
+  }
+
+  hyper_name <- paste0("sd_g__", case$re_coef)
+  hyper <- exact_draw_matrix(fit, hyper_name)
+  out[[paste0("parameter:", hyper_name)]] <- hyper[, 1L]
+
+  for (dpar in case$prediction_dpars) {
+    eta <- posterior_linpred(fit, dpar = dpar, transform = FALSE)
+    out <- append_matrix_samples(out, eta, paste0("eta:", dpar))
+    response_dpar <- posterior_epred(fit, dpar = dpar)
+    out <- append_matrix_samples(
+      out, response_dpar, paste0("dpar-response:", dpar)
+    )
+  }
+  epred <- posterior_epred(fit)
+  append_matrix_samples(out, epred, "epred")
+}
+
+safe_mcse <- function(x, metric) {
+  ans <- switch(
+    metric,
+    mean = posterior::mcse_mean(x),
+    sd = posterior::mcse_sd(x),
+    stop("Unknown comparison metric.", call. = FALSE)
+  )
+  if (!is.finite(ans)) {
+    stop("Could not estimate MCSE for a sampled public quantity.",
+         call. = FALSE)
+  }
+  ans
+}
+
+compare_public_posteriors <- function(conventional, s2z, case) {
+  if (!setequal(names(conventional), names(s2z))) {
+    stop("Public quantities differ between conventional and S2Z fits.\n",
+         "Only conventional: ",
+         paste(setdiff(names(conventional), names(s2z)), collapse = ", "),
+         "\nOnly S2Z: ",
+         paste(setdiff(names(s2z), names(conventional)), collapse = ", "),
+         call. = FALSE)
+  }
+  quantity <- sort(names(conventional))
+  rows <- vector("list", 2L * length(quantity))
+  row <- 0L
+  for (name in quantity) {
+    x <- conventional[[name]]
+    y <- s2z[[name]]
+    for (metric in c("mean", "sd")) {
+      row <- row + 1L
+      estimate_x <- switch(metric, mean = mean(x), sd = stats::sd(x))
+      estimate_y <- switch(metric, mean = mean(y), sd = stats::sd(y))
+      mcse_x <- safe_mcse(x, metric)
+      mcse_y <- safe_mcse(y, metric)
+      mcse_difference <- sqrt(mcse_x^2 + mcse_y^2)
+      threshold <- equiv_z * mcse_difference
+      difference <- estimate_y - estimate_x
+      z_score <- if (mcse_difference > 0) {
+        abs(difference) / mcse_difference
+      } else if (identical(estimate_x, estimate_y)) {
+        0
+      } else {
+        Inf
+      }
+      rows[[row]] <- data.frame(
+        case = case,
+        quantity = name,
+        metric = metric,
+        conventional = estimate_x,
+        s2z = estimate_y,
+        difference = difference,
+        propagated_mcse = mcse_difference,
+        threshold = threshold,
+        z_score = z_score,
+        pass = abs(difference) <= threshold,
+        stringsAsFactors = FALSE
+      )
+    }
+  }
+  out <- do.call(rbind, rows)
+  out[order(out$z_score, decreasing = TRUE), ]
+}
+
+inverse_link <- function(eta, dpar) {
+  if (dpar %in% c("mu_bernoulli", "zi", "hu", "theta1")) {
+    return(plogis(eta))
+  }
+  if (dpar %in% c("mu_poisson", "mu", "mu1", "mu2")) {
+    return(exp(eta))
+  }
+  stop("No inverse-link identity registered for ", dpar, call. = FALSE)
+}
+
+response_mean_identity <- function(fit, case) {
+  epred <- posterior_epred(fit)
+  expected <- switch(
+    case$mean_identity,
+    bernoulli = posterior_epred(fit, dpar = "mu"),
+    poisson = posterior_epred(fit, dpar = "mu"),
+    zero_inflated_poisson = {
+      mu <- posterior_epred(fit, dpar = "mu")
+      zi <- posterior_epred(fit, dpar = "zi")
+      (1 - zi) * mu
+    },
+    hurdle_poisson = {
+      mu <- posterior_epred(fit, dpar = "mu")
+      hu <- posterior_epred(fit, dpar = "hu")
+      (1 - hu) * mu / (-expm1(-mu))
+    },
+    poisson_mixture = {
+      mu1 <- posterior_epred(fit, dpar = "mu1")
+      mu2 <- posterior_epred(fit, dpar = "mu2")
+      theta1 <- posterior_epred(fit, dpar = "theta1")
+      theta1 * mu1 + (1 - theta1) * mu2
+    },
+    stop("Unknown response-mean identity.", call. = FALSE)
+  )
+  max(abs(epred - expected))
+}
+
+public_prediction_invariants <- function(fit, case, parameterization) {
+  fe <- as.matrix(fixef(fit, summary = FALSE))
+  re <- ranef(fit, summary = FALSE)$g
+  levels <- levels(case$data$g)
+  group_index <- as.integer(case$data$g)
+  eta <- posterior_linpred(
+    fit, dpar = case$active_dpar, transform = FALSE
+  )
+  eta_public <- sweep(
+    matrix(re[, levels, case$re_coef], nrow = nrow(fe)),
+    1L, fe[, case$fe_coef], "+"
+  )[, group_index, drop = FALSE]
+  transformed <- posterior_epred(fit, dpar = case$active_dpar)
+  dpar_link_name <- if (case$name == "bernoulli") {
+    "mu_bernoulli"
+  } else {
+    case$active_dpar
+  }
+  expected_transformed <- inverse_link(eta, dpar_link_name)
+
+  public_r_names <- if (identical(case$active_dpar, "mu")) {
+    sprintf("r_g[%s,%s]", levels, case$re_coef)
+  } else {
+    sprintf("r_g__%s[%s,Intercept]", case$active_dpar, levels)
+  }
+  expected_public <- c(
+    paste0("b_", case$fe_coef), public_r_names,
+    paste0("sd_g__", case$re_coef)
+  )
+  public_names_ok <- all(expected_public %in% variables(fit))
+  no_internal_fixef <- !any(grepl("s2z", colnames(fe), fixed = TRUE))
+  rows <- data.frame(
+    case = case$name,
+    parameterization = parameterization,
+    check = c(
+      "saved public b/r/sd names use conventional API",
+      "fixef excludes internal S2Z coordinates",
+      "active dpar predictor equals public b+r",
+      "active dpar inverse link is exact",
+      "response-scale posterior mean identity is exact"
+    ),
+    max_abs_error = c(
+      if (public_names_ok) 0 else Inf,
+      if (no_internal_fixef) 0 else Inf,
+      max(abs(eta - eta_public)),
+      max(abs(transformed - expected_transformed)),
+      response_mean_identity(fit, case)
+    ),
+    tolerance = invariant_tolerance,
+    stringsAsFactors = FALSE
+  )
+  rows$pass <- rows$max_abs_error <= rows$tolerance
+  rows
+}
+
+s2z_internal_invariants <- function(fit, case) {
+  n_group <- nlevels(case$data$g)
+  theta <- exact_draw_matrix(fit, case$internal_theta)[, 1L]
+  internal_names <- sprintf(case$internal_re, seq_len(n_group))
+  internal_re <- exact_draw_matrix(fit, internal_names)
+  fe <- as.matrix(fixef(fit, summary = FALSE))[, case$fe_coef]
+  re <- ranef(fit, summary = FALSE)$g[, levels(case$data$g), case$re_coef]
+  public_finite <- sweep(matrix(re, nrow = length(fe)), 1L, fe, "+")
+  internal_finite <- sweep(internal_re, 1L, theta, "+")
+  rows <- data.frame(
+    case = case$name,
+    parameterization = "s2z",
+    check = c(
+      "internal physical group effects sum to zero",
+      "public b+r equals internal finite coefficient"
+    ),
+    max_abs_error = c(
+      max(abs(rowSums(internal_re))),
+      max(abs(public_finite - internal_finite))
+    ),
+    tolerance = invariant_tolerance,
+    stringsAsFactors = FALSE
+  )
+  rows$pass <- rows$max_abs_error <= rows$tolerance
+  rows
+}
+
+chain_ebfmi <- function(nuts) {
+  energy <- nuts[nuts$Parameter == "energy__", c("Chain", "Value")]
+  split_energy <- split(energy$Value, energy$Chain)
+  vapply(split_energy, function(x) {
+    if (length(x) < 3L || !is.finite(stats::var(x)) || stats::var(x) == 0) {
+      return(NA_real_)
+    }
+    mean(diff(x)^2) / stats::var(x)
+  }, numeric(1L))
+}
+
+fit_quality <- function(fit, case, parameterization) {
+  public <- grep(
+    "^(b_|sd_g__|cor_g__|r_g\\[)", variables(fit), value = TRUE
+  )
+  draws <- as_draws_array(fit, variable = public)
+  summary <- posterior::summarise_draws(
+    draws,
+    rhat = posterior::rhat,
+    ess_bulk = posterior::ess_bulk,
+    ess_tail = posterior::ess_tail
+  )
+  nuts <- nuts_params(fit)
+  divergences <- sum(nuts$Value[nuts$Parameter == "divergent__"])
+  treedepth_hits <- sum(
+    nuts$Value[nuts$Parameter == "treedepth__"] >= max_treedepth
+  )
+  ebfmi <- chain_ebfmi(nuts)
+  observed_max_rhat <- max(summary$rhat, na.rm = TRUE)
+  observed_min_ebfmi <- min(ebfmi, na.rm = TRUE)
+  data.frame(
+    case = case,
+    parameterization = parameterization,
+    max_rhat = observed_max_rhat,
+    min_bulk_ess = min(summary$ess_bulk, na.rm = TRUE),
+    min_tail_ess = min(summary$ess_tail, na.rm = TRUE),
+    divergences = divergences,
+    treedepth_hits = treedepth_hits,
+    min_ebfmi = observed_min_ebfmi,
+    pass = observed_max_rhat <= max_rhat &&
+      divergences <= max_divergences &&
+      treedepth_hits <= max_treedepth_hits &&
+      observed_min_ebfmi >= min_ebfmi,
+    stringsAsFactors = FALSE
+  )
+}
+
+representative_api_checks <- function(fit, case) {
+  fe <- as.matrix(fixef(fit, summary = FALSE))
+  re <- ranef(fit, summary = FALSE)$g
+  co <- coef(fit, summary = FALSE)$g
+  expected_coef <- sweep(
+    matrix(re[, , case$re_coef], nrow = nrow(fe)),
+    1L, fe[, case$fe_coef], "+"
+  )
+  coef_error <- max(abs(co[, , case$re_coef] - expected_coef))
+
+  vc <- VarCorr(fit, summary = FALSE)$g
+  sd_draws <- exact_draw_matrix(
+    fit, paste0("sd_g__", case$re_coef)
+  )[, 1L]
+  varcorr_error <- max(abs(vc$sd[, case$re_coef] - sd_draws))
+
+  observed <- posterior_epred(fit)
+  first_level <- levels(case$data$g)[1L]
+  newdata <- data.frame(g = c(first_level, "new-group"))
+  set.seed(7211L)
+  new_epred <- posterior_epred(
+    fit, newdata = newdata, allow_new_levels = TRUE,
+    sample_new_levels = "gaussian"
+  )
+  known_prediction_error <- max(abs(new_epred[, 1L] - observed[, 1L]))
+  new_prediction_valid <- all(is.finite(new_epred)) &&
+    all(new_epred >= 0) && all(new_epred <= 1)
+
+  serialization_file <- tempfile(fileext = ".rds")
+  saveRDS(fit, serialization_file)
+  restored <- readRDS(serialization_file)
+  unlink(serialization_file)
+  serialization_error <- max(
+    abs(as.matrix(fixef(restored, summary = FALSE)) - fe),
+    abs(ranef(restored, summary = FALSE)$g - re),
+    abs(posterior_epred(restored) - observed)
+  )
+
+  updated <- update(
+    fit, newdata = case$data, recompile = FALSE,
+    testmode = TRUE, silent = 2
+  )
+  update_ok <- inherits(updated, "brmsfit") &&
+    isTRUE(all.equal(updated$formula, fit$formula)) &&
+    identical(nrow(updated$data), nrow(case$data)) &&
+    all(case$data$g == updated$data$g)
+
+  rows <- data.frame(
+    case = case$name,
+    check = c(
+      "fixef exposes the expected public coefficient",
+      "ranef exposes the expected public group effect",
+      "coef equals fixef plus ranef",
+      "VarCorr sd equals the saved public sd",
+      "observed-level newdata prediction is unchanged",
+      "new-level predictions are finite probabilities",
+      "serialized fit preserves public draws and predictions",
+      "update validation path preserves S2Z formula and data"
+    ),
+    max_abs_error = c(
+      if (case$fe_coef %in% colnames(fe)) 0 else Inf,
+      if (case$re_coef %in% dimnames(re)[[3L]]) 0 else Inf,
+      coef_error,
+      varcorr_error,
+      known_prediction_error,
+      if (new_prediction_valid) 0 else Inf,
+      serialization_error,
+      if (update_ok) 0 else Inf
+    ),
+    tolerance = invariant_tolerance,
+    stringsAsFactors = FALSE
+  )
+  rows$pass <- rows$max_abs_error <= rows$tolerance
+  rows
+}
+
+run_case <- function(case) {
+  conventional <- sample_model(case, "conventional")
+  s2z <- sample_model(case, "s2z")
+  comparison <- compare_public_posteriors(
+    public_samples(conventional, case),
+    public_samples(s2z, case),
+    case = case$name
+  )
+  invariants <- rbind(
+    public_prediction_invariants(conventional, case, "conventional"),
+    public_prediction_invariants(s2z, case, "s2z"),
+    s2z_internal_invariants(s2z, case)
+  )
+  quality <- rbind(
+    fit_quality(conventional, case$name, "conventional"),
+    fit_quality(s2z, case$name, "s2z")
+  )
+  list(
+    conventional = conventional,
+    s2z = s2z,
+    comparison = comparison,
+    invariants = invariants,
+    quality = quality
+  )
+}
+
+cases <- list(
+  list(
+    name = "bernoulli",
+    data = simulate_bernoulli(),
+    family = bernoulli(),
+    conventional_formula = bf(y ~ 1 + (1 | gr(g, id = "binary"))),
+    s2z_formula = bf(
+      y ~ 1 + (1 | gr(g, id = "binary", s2z = TRUE))
+    ),
+    prior = prior(logistic(0, 1), class = "Intercept") +
+      prior(exponential(1.5), class = "sd", group = "g"),
+    seed = 7201L,
+    active_dpar = "mu",
+    prediction_dpars = "mu",
+    fe_coef = "Intercept",
+    re_coef = "Intercept",
+    internal_theta = "theta_s2z[1]",
+    internal_re = "r_s2z_1_1[%d]",
+    mean_identity = "bernoulli"
+  ),
+  list(
+    name = "poisson",
+    data = simulate_poisson(),
+    family = poisson(),
+    conventional_formula = bf(y ~ 1 + (1 | gr(g, id = "count"))),
+    s2z_formula = bf(
+      y ~ 1 + (1 | gr(g, id = "count", s2z = TRUE))
+    ),
+    prior = prior(normal(0, 1.2), class = "Intercept") +
+      prior(exponential(1.5), class = "sd", group = "g"),
+    seed = 7202L,
+    active_dpar = "mu",
+    prediction_dpars = "mu",
+    fe_coef = "Intercept",
+    re_coef = "Intercept",
+    internal_theta = "theta_s2z[1]",
+    internal_re = "r_s2z_1_1[%d]",
+    mean_identity = "poisson"
+  ),
+  list(
+    name = "zero-inflated-poisson-zi",
+    data = simulate_zero_process(
+      "zi", seed = 6203L, per_group = 20L
+    ),
+    family = zero_inflated_poisson(),
+    conventional_formula = bf(
+      y ~ 1, zi ~ 1 + (1 | gr(g, id = "zero"))
+    ),
+    s2z_formula = bf(
+      y ~ 1,
+      zi ~ 1 + (1 | gr(g, id = "zero", s2z = TRUE))
+    ),
+    prior = prior(normal(log(4), 0.6), class = "Intercept") +
+      prior(logistic(0, 1), class = "Intercept", dpar = "zi") +
+      prior(
+        exponential(1.5), class = "sd", group = "g", dpar = "zi"
+      ),
+    seed = 7203L,
+    active_dpar = "zi",
+    prediction_dpars = c("mu", "zi"),
+    fe_coef = "zi_Intercept",
+    re_coef = "zi_Intercept",
+    internal_theta = "theta_s2z_zi[1]",
+    internal_re = "r_s2z_1_zi_1[%d]",
+    mean_identity = "zero_inflated_poisson"
+  ),
+  list(
+    name = "hurdle-poisson-hu",
+    data = simulate_zero_process("hu", seed = 6204L),
+    family = hurdle_poisson(),
+    conventional_formula = bf(
+      y ~ 1, hu ~ 1 + (1 | gr(g, id = "hurdle"))
+    ),
+    s2z_formula = bf(
+      y ~ 1,
+      hu ~ 1 + (1 | gr(g, id = "hurdle", s2z = TRUE))
+    ),
+    prior = prior(normal(log(2.4), 0.6), class = "Intercept") +
+      prior(logistic(0, 1), class = "Intercept", dpar = "hu") +
+      prior(
+        exponential(1.5), class = "sd", group = "g", dpar = "hu"
+      ),
+    seed = 7204L,
+    active_dpar = "hu",
+    prediction_dpars = c("mu", "hu"),
+    fe_coef = "hu_Intercept",
+    re_coef = "hu_Intercept",
+    internal_theta = "theta_s2z_hu[1]",
+    internal_re = "r_s2z_1_hu_1[%d]",
+    mean_identity = "hurdle_poisson"
+  ),
+  list(
+    name = "poisson-mixture-theta1",
+    data = simulate_poisson_mixture(),
+    # Ordering the component locations makes this a single-mode validation
+    # fixture rather than a test of mixture label switching.
+    family = mixture(poisson, poisson, order = "mu"),
+    conventional_formula = bf(
+      y ~ 1, mu2 ~ 1,
+      theta1 ~ 1 + (1 | gr(g, id = "mixture"))
+    ),
+    s2z_formula = bf(
+      y ~ 1, mu2 ~ 1,
+      theta1 ~ 1 + (1 | gr(g, id = "mixture", s2z = TRUE))
+    ),
+    prior = prior(
+      normal(log(1.25), 0.35), class = "Intercept", dpar = "mu1"
+    ) +
+      prior(
+        normal(log(6), 0.35), class = "Intercept", dpar = "mu2"
+      ) +
+      prior(logistic(0, 1), class = "Intercept", dpar = "theta1") +
+      prior(
+        exponential(1.5), class = "sd", group = "g", dpar = "theta1"
+      ),
+    seed = 7205L,
+    active_dpar = "theta1",
+    prediction_dpars = c("mu1", "mu2", "theta1"),
+    fe_coef = "theta1_Intercept",
+    re_coef = "theta1_Intercept",
+    internal_theta = "theta_s2z_theta1[1]",
+    internal_re = "r_s2z_1_theta1_1[%d]",
+    mean_identity = "poisson_mixture"
+  )
+)
+
+results <- lapply(cases, run_case)
+comparison_results <- do.call(rbind, lapply(results, `[[`, "comparison"))
+invariant_results <- do.call(rbind, lapply(results, `[[`, "invariants"))
+quality_results <- do.call(rbind, lapply(results, `[[`, "quality"))
+api_results <- representative_api_checks(results[[1L]]$s2z, cases[[1L]])
+
+cat("\nMCSE-aware conventional-vs-S2Z comparisons (largest z-scores first)\n")
+comparison_results <- comparison_results[
+  order(comparison_results$z_score, decreasing = TRUE),
+]
+print(
+  utils::head(comparison_results, report_rows),
+  row.names = FALSE, digits = 4
+)
+if (nrow(comparison_results) > report_rows) {
+  cat("... ", nrow(comparison_results) - report_rows,
+      " additional passing-or-failing comparisons retained for assertions.\n",
+      sep = "")
+}
+cat("\nExact public prediction and S2Z coordinate invariants\n")
+print(invariant_results, row.names = FALSE, digits = 4)
+cat("\nSampling quality\n")
+print(quality_results, row.names = FALSE, digits = 4)
+cat("\nRepresentative public API checks\n")
+print(api_results, row.names = FALSE, digits = 4)
+
+failed_comparisons <- subset(comparison_results, !pass)
+failed_invariants <- subset(invariant_results, !pass)
+failed_quality <- subset(quality_results, !pass)
+failed_api <- subset(api_results, !pass)
+if (nrow(failed_comparisons) || nrow(failed_invariants) ||
+    nrow(failed_quality) || nrow(failed_api)) {
+  stop(
+    "S2Z non-Gaussian sampling validation failed: ",
+    nrow(failed_comparisons), " MCSE comparisons, ",
+    nrow(failed_invariants), " exact invariants, ",
+    nrow(failed_quality), " sampling-quality checks, and ",
+    nrow(failed_api), " public API checks failed.",
+    call. = FALSE
+  )
+}
+
+cat(
+  "\nPASS: all five conventional and S2Z posteriors agree within the ",
+  "prespecified propagated-MCSE thresholds; dpar/public-coordinate ",
+  "identities, sampler diagnostics, and representative public API ",
+  "checks all pass.\n",
+  sep = ""
+)

--- a/tests/local/tests.models-s2z.R
+++ b/tests/local/tests.models-s2z.R
@@ -1,7 +1,8 @@
 # Sampling validation for marginalized sum-to-zero group-level effects.
 #
-# This is intentionally a local test: it compiles and samples eight Stan
-# models, including both dedicated scalar paths.
+# This is intentionally a local test: it compiles and samples twelve Stan
+# models, including literal-scalar, independent-component, and correlated
+# paths.
 # Run it against an installed development build of brms, for example with
 #
 #   Rscript tests/local/tests.models-s2z.R
@@ -214,12 +215,14 @@ simulate_scalar_student_slope <- function(seed = 4104L, groups = 14L,
   dat
 }
 
-model_prior <- function(student_group = FALSE) {
+model_prior <- function(student_group = FALSE, correlated = TRUE) {
   out <- prior(normal(0, 1.5), class = "b") +
     prior(normal(0, 1.5), class = "Intercept") +
     prior(exponential(1), class = "sd") +
-    prior(lkj(2), class = "cor") +
     prior(exponential(1), class = "sigma")
+  if (correlated) {
+    out <- out + prior(lkj(2), class = "cor")
+  }
   if (student_group) {
     out <- out + prior(gamma(2, 0.2), class = "df", group = "g")
   }
@@ -415,8 +418,10 @@ s2z_coordinate_invariants <- function(fit, formula, data, prior,
   for (k in seq_len(n_coef)) {
     r_names <- if (n_coef == 1L) {
       sprintf("r_s2z_1_1[%d]", seq_len(n_group))
-    } else {
+    } else if (sprintf("r_s2z_1[1,%d]", k) %in% variables(fit)) {
       sprintf("r_s2z_1[%d,%d]", seq_len(n_group), k)
+    } else {
+      sprintf("r_s2z_1_%d[%d]", k, seq_len(n_group))
     }
     r_s2z[, , k] <- exact_draw_matrix(fit, r_names)
   }
@@ -594,6 +599,33 @@ student_result <- run_case(
   seed = 5102L
 )
 
+diagonal_gaussian_result <- run_case(
+  case = "independent-gaussian-interaction",
+  data = gaussian_data,
+  conventional_formula = bf(y ~ x * z + (1 + x * z || g)),
+  s2z_formula = bf(
+    y ~ x * z + (1 + x * z || gr(g, s2z = TRUE))
+  ),
+  prior = model_prior(correlated = FALSE),
+  fixed_formula = ~ x * z,
+  seed = 5105L
+)
+
+diagonal_student_result <- run_case(
+  case = "independent-student-intercept-slope",
+  data = student_data,
+  conventional_formula = bf(
+    y ~ x + (1 + x || gr(g, dist = "student"))
+  ),
+  s2z_formula = bf(
+    y ~ x +
+      (1 + x || gr(g, dist = "student", s2z = TRUE))
+  ),
+  prior = model_prior(student_group = TRUE, correlated = FALSE),
+  fixed_formula = ~ x,
+  seed = 5106L
+)
+
 scalar_intercept_data <- simulate_scalar_intercept()
 scalar_intercept_result <- run_case(
   case = "scalar-gaussian-intercept",
@@ -624,18 +656,24 @@ scalar_student_result <- run_case(
 comparison_results <- rbind(
   gaussian_result$comparison,
   student_result$comparison,
+  diagonal_gaussian_result$comparison,
+  diagonal_student_result$comparison,
   scalar_intercept_result$comparison,
   scalar_student_result$comparison
 )
 invariant_results <- rbind(
   gaussian_result$invariants,
   student_result$invariants,
+  diagonal_gaussian_result$invariants,
+  diagonal_student_result$invariants,
   scalar_intercept_result$invariants,
   scalar_student_result$invariants
 )
 quality_results <- rbind(
   gaussian_result$quality,
   student_result$quality,
+  diagonal_gaussian_result$quality,
+  diagonal_student_result$quality,
   scalar_intercept_result$quality,
   scalar_student_result$quality
 )

--- a/tests/local/tests.models-s2z.R
+++ b/tests/local/tests.models-s2z.R
@@ -1,6 +1,7 @@
 # Sampling validation for marginalized sum-to-zero group-level effects.
 #
-# This is intentionally a local test: it compiles and samples four Stan models.
+# This is intentionally a local test: it compiles and samples eight Stan
+# models, including both dedicated scalar paths.
 # Run it against an installed development build of brms, for example with
 #
 #   Rscript tests/local/tests.models-s2z.R
@@ -177,11 +178,61 @@ simulate_student_group <- function(seed = 4102L, groups = 12L,
   dat
 }
 
+simulate_scalar_intercept <- function(seed = 4103L, groups = 14L,
+                                      per_group = 10L) {
+  set.seed(seed)
+  g_levels <- sprintf("g%02d", seq_len(groups))
+  dat <- data.frame(
+    g = factor(
+      rep(g_levels, each = per_group), levels = g_levels
+    )
+  )
+  group_effect <- stats::rnorm(groups, sd = 0.75)
+  eta <- 0.4 + group_effect[as.integer(dat$g)]
+  dat$y <- stats::rnorm(nrow(dat), eta, 0.45)
+  dat
+}
+
+simulate_scalar_student_slope <- function(seed = 4104L, groups = 14L,
+                                          per_group = 10L,
+                                          group_df = 5) {
+  set.seed(seed)
+  g_levels <- sprintf("g%02d", seq_len(groups))
+  dat <- do.call(rbind, lapply(seq_len(groups), function(j) {
+    data.frame(
+      g = g_levels[j],
+      x = seq(-1.5, 1.5, length.out = per_group) +
+        stats::rnorm(per_group, sd = 0.08)
+    )
+  }))
+  rownames(dat) <- NULL
+  dat$g <- factor(dat$g, levels = g_levels)
+  group_effect <- stats::rnorm(groups, sd = 0.55) *
+    sqrt(group_df / stats::rchisq(groups, df = group_df))
+  eta <- dat$x * (0.8 + group_effect[as.integer(dat$g)])
+  dat$y <- stats::rnorm(nrow(dat), eta, 0.5)
+  dat
+}
+
 model_prior <- function(student_group = FALSE) {
   out <- prior(normal(0, 1.5), class = "b") +
     prior(normal(0, 1.5), class = "Intercept") +
     prior(exponential(1), class = "sd") +
     prior(lkj(2), class = "cor") +
+    prior(exponential(1), class = "sigma")
+  if (student_group) {
+    out <- out + prior(gamma(2, 0.2), class = "df", group = "g")
+  }
+  out
+}
+
+scalar_prior <- function(intercept = TRUE, student_group = FALSE) {
+  out <- if (intercept) {
+    prior(normal(0, 1.5), class = "Intercept")
+  } else {
+    prior(normal(0, 1.5), class = "b", coef = "x")
+  }
+  out <- out + prior(exponential(1), class = "sd") +
     prior(exponential(1), class = "sigma")
   if (student_group) {
     out <- out + prior(gamma(2, 0.2), class = "df", group = "g")
@@ -362,7 +413,11 @@ s2z_coordinate_invariants <- function(fit, formula, data, prior,
   n_draw <- nrow(b_s2z)
   r_s2z <- array(NA_real_, dim = c(n_draw, n_group, n_coef))
   for (k in seq_len(n_coef)) {
-    r_names <- sprintf("r_s2z_1[%d,%d]", seq_len(n_group), k)
+    r_names <- if (n_coef == 1L) {
+      sprintf("r_s2z_1_1[%d]", seq_len(n_group))
+    } else {
+      sprintf("r_s2z_1[%d,%d]", seq_len(n_group), k)
+    }
     r_s2z[, , k] <- exact_draw_matrix(fit, r_names)
   }
 
@@ -539,17 +594,50 @@ student_result <- run_case(
   seed = 5102L
 )
 
+scalar_intercept_data <- simulate_scalar_intercept()
+scalar_intercept_result <- run_case(
+  case = "scalar-gaussian-intercept",
+  data = scalar_intercept_data,
+  conventional_formula = bf(y ~ 1 + (1 | g)),
+  s2z_formula = bf(y ~ 1 + (1 | gr(g, s2z = TRUE))),
+  prior = scalar_prior(intercept = TRUE),
+  fixed_formula = ~ 1,
+  seed = 5103L
+)
+
+scalar_student_data <- simulate_scalar_student_slope()
+scalar_student_result <- run_case(
+  case = "scalar-student-slope-no-intercept",
+  data = scalar_student_data,
+  conventional_formula = bf(
+    y ~ 0 + x + (0 + x | gr(g, dist = "student"))
+  ),
+  s2z_formula = bf(
+    y ~ 0 + x +
+      (0 + x | gr(g, dist = "student", s2z = TRUE))
+  ),
+  prior = scalar_prior(intercept = FALSE, student_group = TRUE),
+  fixed_formula = ~ 0 + x,
+  seed = 5104L
+)
+
 comparison_results <- rbind(
   gaussian_result$comparison,
-  student_result$comparison
+  student_result$comparison,
+  scalar_intercept_result$comparison,
+  scalar_student_result$comparison
 )
 invariant_results <- rbind(
   gaussian_result$invariants,
-  student_result$invariants
+  student_result$invariants,
+  scalar_intercept_result$invariants,
+  scalar_student_result$invariants
 )
 quality_results <- rbind(
   gaussian_result$quality,
-  student_result$quality
+  student_result$quality,
+  scalar_intercept_result$quality,
+  scalar_student_result$quality
 )
 
 cat("\nMCSE-aware conventional-vs-S2Z comparisons (largest z-scores first)\n")

--- a/tests/local/tests.models-s2z.R
+++ b/tests/local/tests.models-s2z.R
@@ -1,4 +1,4 @@
-# Sampling validation for marginalized sum-to-zero group-level effects.
+# Sampling validation for physical sum-to-zero group-level effects.
 #
 # This is intentionally a local test: it compiles and samples twelve Stan
 # models, including literal-scalar, independent-component, and correlated

--- a/tests/local/tests.models-s2z.R
+++ b/tests/local/tests.models-s2z.R
@@ -1,0 +1,578 @@
+# Sampling validation for marginalized sum-to-zero group-level effects.
+#
+# This is intentionally a local test: it compiles and samples four Stan models.
+# Run it against an installed development build of brms, for example with
+#
+#   Rscript tests/local/tests.models-s2z.R
+#
+# Useful controls (shown with their defaults) are
+#
+#   BRMS_S2Z_CHAINS=2
+#   BRMS_S2Z_WARMUP=500
+#   BRMS_S2Z_SAMPLING=500
+#   BRMS_S2Z_CORES=min(chains, parallel::detectCores())
+#   BRMS_S2Z_BACKEND=auto
+#   BRMS_S2Z_ADAPT_DELTA=0.97
+#   BRMS_S2Z_MAX_TREEDEPTH=12
+#   BRMS_S2Z_EQUIV_Z=7
+#   BRMS_S2Z_MAX_RHAT=1.10
+#   BRMS_S2Z_MAX_DIVERGENCES=0
+#   BRMS_S2Z_INVARIANT_TOL=1e-6
+#   BRMS_S2Z_CACHE_DIR=
+#
+# Equivalence is assessed on both posterior means and posterior standard
+# deviations. The Monte Carlo standard error from each independent fit is
+# propagated as sqrt(mcse_conventional^2 + mcse_s2z^2).
+
+suppressPackageStartupMessages({
+  library(brms)
+  library(posterior)
+})
+
+env_integer <- function(name, default, minimum = 1L) {
+  value <- Sys.getenv(name, unset = "")
+  if (!nzchar(value)) {
+    return(as.integer(default))
+  }
+  out <- suppressWarnings(as.integer(value))
+  if (length(out) != 1L || is.na(out) || out < minimum) {
+    stop(name, " must be an integer >= ", minimum, call. = FALSE)
+  }
+  out
+}
+
+env_number <- function(name, default, minimum = -Inf) {
+  value <- Sys.getenv(name, unset = "")
+  if (!nzchar(value)) {
+    return(as.numeric(default))
+  }
+  out <- suppressWarnings(as.numeric(value))
+  if (length(out) != 1L || !is.finite(out) || out < minimum) {
+    stop(name, " must be a finite number >= ", minimum, call. = FALSE)
+  }
+  out
+}
+
+choose_backend <- function() {
+  requested <- tolower(Sys.getenv("BRMS_S2Z_BACKEND", unset = "auto"))
+  if (requested %in% c("cmdstanr", "rstan")) {
+    return(requested)
+  }
+  if (!identical(requested, "auto")) {
+    stop("BRMS_S2Z_BACKEND must be auto, cmdstanr, or rstan.", call. = FALSE)
+  }
+  cmdstan_ok <- requireNamespace("cmdstanr", quietly = TRUE) &&
+    isTRUE(tryCatch(
+      nzchar(suppressWarnings(cmdstanr::cmdstan_path())),
+      error = function(e) FALSE
+    ))
+  if (cmdstan_ok) {
+    return("cmdstanr")
+  }
+  if (requireNamespace("rstan", quietly = TRUE)) {
+    return("rstan")
+  }
+  stop("Neither a working CmdStan installation nor rstan was found.",
+       call. = FALSE)
+}
+
+chains <- env_integer("BRMS_S2Z_CHAINS", 2L, minimum = 2L)
+warmup <- env_integer("BRMS_S2Z_WARMUP", 500L)
+sampling <- env_integer("BRMS_S2Z_SAMPLING", 500L)
+detected_cores <- parallel::detectCores(logical = FALSE)
+if (is.na(detected_cores)) {
+  detected_cores <- 1L
+}
+cores <- env_integer(
+  "BRMS_S2Z_CORES", min(chains, detected_cores), minimum = 1L
+)
+backend <- choose_backend()
+adapt_delta <- env_number("BRMS_S2Z_ADAPT_DELTA", 0.97, minimum = 0.5)
+max_treedepth <- env_integer("BRMS_S2Z_MAX_TREEDEPTH", 12L)
+equiv_z <- env_number("BRMS_S2Z_EQUIV_Z", 7, minimum = 1)
+max_rhat <- env_number("BRMS_S2Z_MAX_RHAT", 1.10, minimum = 1)
+max_divergences <- env_integer(
+  "BRMS_S2Z_MAX_DIVERGENCES", 0L, minimum = 0L
+)
+invariant_tolerance <- env_number(
+  # CmdStan's default CSV precision introduces errors around 1e-7 when the
+  # exactly equivalent generated quantities are read back into R.
+  "BRMS_S2Z_INVARIANT_TOL", 1e-6, minimum = 0
+)
+cache_dir <- Sys.getenv("BRMS_S2Z_CACHE_DIR", unset = "")
+
+options(mc.cores = cores, width = 140)
+
+configuration <- data.frame(
+  brms_version = as.character(utils::packageVersion("brms")),
+  backend = backend,
+  chains = chains,
+  warmup = warmup,
+  sampling = sampling,
+  cores = cores,
+  adapt_delta = adapt_delta,
+  max_treedepth = max_treedepth,
+  equiv_z = equiv_z,
+  stringsAsFactors = FALSE
+)
+cat("S2Z sampling-equivalence configuration\n")
+print(configuration, row.names = FALSE)
+
+rmvn_rows <- function(n, sigma) {
+  matrix(stats::rnorm(n * nrow(sigma)), nrow = n) %*% chol(sigma)
+}
+
+simulate_gaussian_interaction <- function(seed = 4101L, groups = 10L,
+                                          per_group = 12L) {
+  set.seed(seed)
+  g_levels <- sprintf("g%02d", seq_len(groups))
+  factorial_grid <- expand.grid(x = c(-1, 1), z = c(-1, 1))
+  dat <- do.call(rbind, lapply(seq_len(groups), function(j) {
+    grid <- factorial_grid[rep(seq_len(nrow(factorial_grid)),
+                              length.out = per_group), ]
+    data.frame(
+      g = g_levels[j],
+      x = grid$x + stats::rnorm(per_group, sd = 0.12),
+      z = grid$z + stats::rnorm(per_group, sd = 0.12)
+    )
+  }))
+  rownames(dat) <- NULL
+  dat$g <- factor(dat$g, levels = g_levels)
+  X <- stats::model.matrix(~ x * z, dat)
+  beta <- c(0.45, 0.80, -0.55, 0.40)
+  re_sd <- c(0.70, 0.45, 0.40, 0.30)
+  re_cor <- outer(seq_along(re_sd), seq_along(re_sd), function(i, j) {
+    0.30^abs(i - j)
+  })
+  sigma_re <- diag(re_sd) %*% re_cor %*% diag(re_sd)
+  u <- rmvn_rows(groups, sigma_re)
+  eta <- drop(X %*% beta) + rowSums(X * u[as.integer(dat$g), ])
+  dat$y <- stats::rnorm(nrow(dat), eta, 0.45)
+  dat
+}
+
+simulate_student_group <- function(seed = 4102L, groups = 12L,
+                                   per_group = 10L, group_df = 5) {
+  set.seed(seed)
+  g_levels <- sprintf("g%02d", seq_len(groups))
+  dat <- do.call(rbind, lapply(seq_len(groups), function(j) {
+    data.frame(
+      g = g_levels[j],
+      x = seq(-1.25, 1.25, length.out = per_group) +
+        stats::rnorm(per_group, sd = 0.08)
+    )
+  }))
+  rownames(dat) <- NULL
+  dat$g <- factor(dat$g, levels = g_levels)
+  X <- stats::model.matrix(~ x, dat)
+  beta <- c(-0.25, 0.75)
+  re_sd <- c(0.80, 0.50)
+  re_cor <- matrix(c(1, -0.25, -0.25, 1), nrow = 2L)
+  sigma_re <- diag(re_sd) %*% re_cor %*% diag(re_sd)
+  # One mixing scale per group gives a multivariate Student-t effect.
+  u <- rmvn_rows(groups, sigma_re)
+  u <- u * sqrt(group_df / stats::rchisq(groups, df = group_df))
+  eta <- drop(X %*% beta) + rowSums(X * u[as.integer(dat$g), ])
+  dat$y <- stats::rnorm(nrow(dat), eta, 0.55)
+  dat
+}
+
+model_prior <- function(student_group = FALSE) {
+  out <- prior(normal(0, 1.5), class = "b") +
+    prior(normal(0, 1.5), class = "Intercept") +
+    prior(exponential(1), class = "sd") +
+    prior(lkj(2), class = "cor") +
+    prior(exponential(1), class = "sigma")
+  if (student_group) {
+    out <- out + prior(gamma(2, 0.2), class = "df", group = "g")
+  }
+  out
+}
+
+cache_file <- function(label) {
+  if (!nzchar(cache_dir)) {
+    return(NULL)
+  }
+  dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+  suffix <- paste(backend, chains, warmup, sampling, sep = "-")
+  file.path(cache_dir, paste0(label, "-", suffix, ".rds"))
+}
+
+sample_model <- function(formula, data, prior, seed, label) {
+  cat("Sampling ", label, " ...\n", sep = "")
+  args <- list(
+    formula = formula,
+    data = data,
+    family = gaussian(),
+    prior = prior,
+    backend = backend,
+    chains = chains,
+    cores = cores,
+    iter = warmup + sampling,
+    warmup = warmup,
+    seed = seed,
+    refresh = 0,
+    silent = 1,
+    save_pars = save_pars(all = TRUE),
+    control = list(
+      adapt_delta = adapt_delta,
+      max_treedepth = max_treedepth
+    )
+  )
+  file <- cache_file(label)
+  if (!is.null(file)) {
+    args$file <- file
+    args$file_refit <- "on_change"
+  }
+  do.call(brm, args)
+}
+
+exact_draw_matrix <- function(fit, variable) {
+  missing <- setdiff(variable, variables(fit))
+  if (length(missing)) {
+    stop("Required saved variables are missing: ",
+         paste(missing, collapse = ", "), call. = FALSE)
+  }
+  as.matrix(as_draws_matrix(fit, variable = variable))
+}
+
+public_fixef_draws <- function(fit) {
+  out <- as.matrix(fixef(fit, summary = FALSE))
+  # Keep downstream comparisons interpretable even when this test detects that
+  # an internal finite-population vector has accidentally leaked through
+  # fixef().
+  out[, !grepl("^s2z(\\[|$)", colnames(out)), drop = FALSE]
+}
+
+public_samples <- function(fit, data, group = "g") {
+  fe <- public_fixef_draws(fit)
+  re <- ranef(fit, summary = FALSE)[[group]]
+  if (is.null(re)) {
+    stop("No public group-level draws found for ", group, call. = FALSE)
+  }
+  out <- setNames(lapply(seq_len(ncol(fe)), function(k) fe[, k]),
+                  paste0("b:", colnames(fe)))
+
+  public_hyper <- grep(
+    paste0("^(sd_", group, "__|cor_", group, "__|df_", group,
+           "$|sigma$)"),
+    variables(fit), value = TRUE
+  )
+  if (length(public_hyper)) {
+    hyper <- exact_draw_matrix(fit, public_hyper)
+    for (name in colnames(hyper)) {
+      out[[paste0("parameter:", name)]] <- hyper[, name]
+    }
+  }
+
+  selected_levels <- unique(c(1L, dim(re)[2L]))
+  selected_coef <- unique(c(1L, dim(re)[3L]))
+  for (j in selected_levels) {
+    for (k in selected_coef) {
+      label <- paste(dimnames(re)[[2L]][j], dimnames(re)[[3L]][k], sep = ",")
+      out[[paste0("r:[", label, "]")]] <- re[, j, k]
+      out[[paste0("b+r:[", label, "]")]] <- fe[, k] + re[, j, k]
+    }
+  }
+
+  eta <- posterior_linpred(fit, transform = FALSE)
+  selected_obs <- unique(round(seq(1, ncol(eta), length.out = 5L)))
+  for (i in selected_obs) {
+    out[[sprintf("eta:observation[%d]", i)]] <- eta[, i]
+  }
+  out[["eta:observation-average"]] <- rowMeans(eta)
+  out
+}
+
+safe_mcse <- function(x, metric) {
+  ans <- switch(
+    metric,
+    mean = posterior::mcse_mean(x),
+    sd = posterior::mcse_sd(x),
+    stop("Unknown comparison metric.", call. = FALSE)
+  )
+  if (!is.finite(ans)) {
+    stop("Could not estimate MCSE for a sampled public quantity.",
+         call. = FALSE)
+  }
+  ans
+}
+
+compare_public_posteriors <- function(conventional, s2z, case) {
+  if (!setequal(names(conventional), names(s2z))) {
+    stop("Public quantities differ between conventional and S2Z fits.\n",
+         "Only conventional: ",
+         paste(setdiff(names(conventional), names(s2z)), collapse = ", "),
+         "\nOnly S2Z: ",
+         paste(setdiff(names(s2z), names(conventional)), collapse = ", "),
+         call. = FALSE)
+  }
+  quantity <- sort(names(conventional))
+  rows <- vector("list", 2L * length(quantity))
+  row <- 0L
+  for (name in quantity) {
+    x <- conventional[[name]]
+    y <- s2z[[name]]
+    for (metric in c("mean", "sd")) {
+      row <- row + 1L
+      estimate_x <- switch(metric, mean = mean(x), sd = stats::sd(x))
+      estimate_y <- switch(metric, mean = mean(y), sd = stats::sd(y))
+      mcse_x <- safe_mcse(x, metric)
+      mcse_y <- safe_mcse(y, metric)
+      mcse_difference <- sqrt(mcse_x^2 + mcse_y^2)
+      difference <- estimate_y - estimate_x
+      z_score <- if (mcse_difference > 0) {
+        abs(difference) / mcse_difference
+      } else if (identical(estimate_x, estimate_y)) {
+        0
+      } else {
+        Inf
+      }
+      rows[[row]] <- data.frame(
+        case = case,
+        quantity = name,
+        metric = metric,
+        conventional = estimate_x,
+        s2z = estimate_y,
+        difference = difference,
+        mcse_difference = mcse_difference,
+        z_score = z_score,
+        pass = z_score <= equiv_z,
+        stringsAsFactors = FALSE
+      )
+    }
+  }
+  out <- do.call(rbind, rows)
+  out[order(out$z_score, decreasing = TRUE), ]
+}
+
+s2z_coordinate_invariants <- function(fit, formula, data, prior,
+                                      fixed_formula, case) {
+  sdata <- standata(
+    formula, data = data, family = gaussian(), prior = prior
+  )
+  X <- stats::model.matrix(fixed_formula, data)
+  coef_names <- sub("^\\(Intercept\\)$", "Intercept", colnames(X))
+  n_coef <- ncol(X)
+  n_group <- sdata$N_1
+  group_index <- as.integer(sdata$J_1)
+
+  b_names <- sprintf("theta_s2z[%d]", seq_len(n_coef))
+  b_s2z <- exact_draw_matrix(fit, b_names)
+  n_draw <- nrow(b_s2z)
+  r_s2z <- array(NA_real_, dim = c(n_draw, n_group, n_coef))
+  for (k in seq_len(n_coef)) {
+    r_names <- sprintf("r_s2z_1[%d,%d]", seq_len(n_group), k)
+    r_s2z[, , k] <- exact_draw_matrix(fit, r_names)
+  }
+
+  # Convert Stan's centered intercept coordinate to the raw model-matrix
+  # intercept. Slopes and interaction coefficients are already raw.
+  b_s2z_raw <- b_s2z
+  if (n_coef > 1L) {
+    means_X <- colMeans(X[, -1L, drop = FALSE])
+    b_s2z_raw[, 1L] <- b_s2z[, 1L] -
+      drop(b_s2z[, -1L, drop = FALSE] %*% means_X)
+  }
+
+  all_fe <- as.matrix(fixef(fit, summary = FALSE))
+  fe <- public_fixef_draws(fit)
+  re <- ranef(fit, summary = FALSE)$g
+  if (!all(coef_names %in% colnames(fe)) ||
+      !all(coef_names %in% dimnames(re)[[3L]])) {
+    stop("Could not align public fixed/group coefficient names.",
+         call. = FALSE)
+  }
+  fe <- fe[, coef_names, drop = FALSE]
+  expected_levels <- levels(data$g)
+  if (!all(expected_levels %in% dimnames(re)[[2L]])) {
+    stop("Could not align public group levels with Stan group indices.",
+         call. = FALSE)
+  }
+  re <- re[, expected_levels, coef_names, drop = FALSE]
+  if (nrow(fe) != n_draw) {
+    stop("Internal and public draw counts differ.", call. = FALSE)
+  }
+
+  eta_internal <- matrix(0, nrow = n_draw, ncol = nrow(X))
+  eta_public <- matrix(0, nrow = n_draw, ncol = nrow(X))
+  max_finite_error <- 0
+  max_sum_to_zero_error <- 0
+  for (k in seq_len(n_coef)) {
+    internal_re <- matrix(r_s2z[, , k], nrow = n_draw, ncol = n_group)
+    public_re <- matrix(re[, , k], nrow = n_draw, ncol = n_group)
+    internal_finite <- sweep(internal_re, 1L, b_s2z_raw[, k], "+")
+    public_finite <- sweep(public_re, 1L, fe[, k], "+")
+    max_finite_error <- max(
+      max_finite_error, max(abs(internal_finite - public_finite))
+    )
+    max_sum_to_zero_error <- max(
+      max_sum_to_zero_error, max(abs(rowSums(internal_re)))
+    )
+    eta_internal <- eta_internal +
+      sweep(internal_finite[, group_index, drop = FALSE],
+            2L, X[, k], "*")
+    eta_public <- eta_public +
+      sweep(public_finite[, group_index, drop = FALSE],
+            2L, X[, k], "*")
+  }
+  eta_brms <- posterior_linpred(fit, transform = FALSE)
+
+  expected_public <- c(
+    paste0("b_", coef_names),
+    as.vector(outer(
+      expected_levels, coef_names,
+      function(level, coef) sprintf("r_g[%s,%s]", level, coef)
+    ))
+  )
+  public_names_ok <- all(expected_public %in% variables(fit))
+  fixef_names_ok <- setequal(colnames(all_fe), coef_names)
+  out <- data.frame(
+    case = case,
+    check = c(
+      "saved public b/r names use conventional API",
+      "fixef exposes only public coefficient names",
+      "internal group effects sum to zero",
+      "public b+r equals internal finite coefficient",
+      "posterior_linpred equals public b+r predictor",
+      "posterior_linpred equals internal S2Z predictor"
+    ),
+    max_abs_error = c(
+      if (public_names_ok) 0 else Inf,
+      if (fixef_names_ok) 0 else Inf,
+      max_sum_to_zero_error,
+      max_finite_error,
+      max(abs(eta_brms - eta_public)),
+      max(abs(eta_brms - eta_internal))
+    ),
+    tolerance = invariant_tolerance,
+    stringsAsFactors = FALSE
+  )
+  out$pass <- out$max_abs_error <= out$tolerance
+  out
+}
+
+fit_quality <- function(fit, case, parameterization) {
+  public <- grep(
+    "^(b_|sd_g__|cor_g__|df_g$|sigma$|r_g\\[)",
+    variables(fit), value = TRUE
+  )
+  public <- public[!grepl("^theta_s2z(\\[|$)", public)]
+  draws <- as_draws_array(fit, variable = public)
+  summary <- posterior::summarise_draws(
+    draws,
+    rhat = posterior::rhat,
+    ess_bulk = posterior::ess_bulk,
+    ess_tail = posterior::ess_tail
+  )
+  np <- nuts_params(fit)
+  divergences <- sum(np$Value[np$Parameter == "divergent__"])
+  data.frame(
+    case = case,
+    parameterization = parameterization,
+    max_rhat = max(summary$rhat, na.rm = TRUE),
+    min_bulk_ess = min(summary$ess_bulk, na.rm = TRUE),
+    min_tail_ess = min(summary$ess_tail, na.rm = TRUE),
+    divergences = divergences,
+    pass = max(summary$rhat, na.rm = TRUE) <= max_rhat &&
+      divergences <= max_divergences,
+    stringsAsFactors = FALSE
+  )
+}
+
+run_case <- function(case, data, conventional_formula, s2z_formula, prior,
+                     fixed_formula, seed) {
+  conventional <- sample_model(
+    conventional_formula, data, prior, seed,
+    paste0(case, "-conventional")
+  )
+  s2z <- sample_model(
+    s2z_formula, data, prior, seed + 1L,
+    paste0(case, "-s2z")
+  )
+  comparison <- compare_public_posteriors(
+    public_samples(conventional, data),
+    public_samples(s2z, data),
+    case = case
+  )
+  invariants <- s2z_coordinate_invariants(
+    s2z, s2z_formula, data, prior, fixed_formula, case
+  )
+  quality <- rbind(
+    fit_quality(conventional, case, "conventional"),
+    fit_quality(s2z, case, "s2z")
+  )
+  list(
+    conventional = conventional,
+    s2z = s2z,
+    comparison = comparison,
+    invariants = invariants,
+    quality = quality
+  )
+}
+
+gaussian_data <- simulate_gaussian_interaction()
+gaussian_prior <- model_prior()
+gaussian_result <- run_case(
+  case = "gaussian-interaction",
+  data = gaussian_data,
+  conventional_formula = bf(y ~ x * z + (1 + x * z | g)),
+  s2z_formula = bf(y ~ x * z + (1 + x * z | gr(g, s2z = TRUE))),
+  prior = gaussian_prior,
+  fixed_formula = ~ x * z,
+  seed = 5101L
+)
+
+student_data <- simulate_student_group()
+student_prior <- model_prior(student_group = TRUE)
+student_result <- run_case(
+  case = "student-group-effects",
+  data = student_data,
+  conventional_formula = bf(
+    y ~ x + (1 + x | gr(g, dist = "student"))
+  ),
+  s2z_formula = bf(
+    y ~ x + (1 + x | gr(g, dist = "student", s2z = TRUE))
+  ),
+  prior = student_prior,
+  fixed_formula = ~ x,
+  seed = 5102L
+)
+
+comparison_results <- rbind(
+  gaussian_result$comparison,
+  student_result$comparison
+)
+invariant_results <- rbind(
+  gaussian_result$invariants,
+  student_result$invariants
+)
+quality_results <- rbind(
+  gaussian_result$quality,
+  student_result$quality
+)
+
+cat("\nMCSE-aware conventional-vs-S2Z comparisons (largest z-scores first)\n")
+print(comparison_results, row.names = FALSE, digits = 4)
+cat("\nExact public/internal coordinate invariants\n")
+print(invariant_results, row.names = FALSE, digits = 4)
+cat("\nSampling quality\n")
+print(quality_results, row.names = FALSE, digits = 4)
+
+failed_comparisons <- subset(comparison_results, !pass)
+failed_invariants <- subset(invariant_results, !pass)
+failed_quality <- subset(quality_results, !pass)
+if (nrow(failed_comparisons) || nrow(failed_invariants) ||
+    nrow(failed_quality)) {
+  stop(
+    "S2Z sampling validation failed: ",
+    nrow(failed_comparisons), " MCSE comparisons, ",
+    nrow(failed_invariants), " coordinate invariants, and ",
+    nrow(failed_quality), " sampling-quality checks failed.",
+    call. = FALSE
+  )
+}
+
+cat("\nPASS: conventional and S2Z posterior draws agree within propagated ",
+    "MCSE, public b/r/predictor identities hold draw by draw, and all fits ",
+    "meet the configured sampler checks.\n", sep = "")

--- a/tests/testthat/tests.brmsterms.R
+++ b/tests/testthat/tests.brmsterms.R
@@ -18,6 +18,34 @@ test_that("brmsterms handles very long RE terms", {
   expect_equal(bterms$dpars$mu$re$group, "id")
 })
 
+test_that("brmsterms retains the sum-to-zero grouping option", {
+  default <- brmsterms(y ~ x + (1 + x | gr(g)))
+  s2z <- brmsterms(y ~ x + (1 + x | gr(g, s2z = TRUE)))
+
+  expect_false(default$dpars$mu$re$gcall[[1]]$s2z)
+  expect_true(s2z$dpars$mu$re$gcall[[1]]$s2z)
+
+  data <- data.frame(y = rnorm(6), x = rnorm(6), g = rep(1:3, each = 2))
+  reframe <- frame_re(s2z, data)
+  expect_true(all(reframe$s2z))
+  expect_equal(reframe$coef, c("Intercept", "x"))
+
+  mm_terms <- brmsterms(y ~ (1 | mm(g, h)))
+  mm_data <- transform(data, h = rep(3:1, each = 2))
+  expect_false(any(frame_re(mm_terms, mm_data)$s2z))
+})
+
+test_that("gr validates the sum-to-zero grouping option", {
+  expect_error(
+    gr(g, s2z = NA),
+    "Cannot coerce 's2z' to a single logical value"
+  )
+  expect_error(
+    gr(g, s2z = c(TRUE, FALSE)),
+    "Cannot coerce 's2z' to a single logical value"
+  )
+})
+
 test_that("brmsterms correctly handles auxiliary parameter 'mu'", {
   bterms1 <- brmsterms(y ~ x + (x|g))
   bterms2 <- brmsterms(bf(y ~ 1, mu ~ x + (x|g)))

--- a/tests/testthat/tests.s2z-capabilities.R
+++ b/tests/testthat/tests.s2z-capabilities.R
@@ -1,0 +1,553 @@
+context("Capability matrix for physical sum-to-zero group-level effects")
+
+expect_match2 <- brms:::expect_match2
+
+s2z_cap_count_fixed <- function(x, pattern) {
+  unname(lengths(regmatches(
+    x, gregexpr(pattern, x, fixed = TRUE)
+  )))
+}
+
+s2z_cap_error <- function(expr) {
+  error <- tryCatch(expr, error = identity)
+  expect_s3_class(error, "error")
+  conditionMessage(error)
+}
+
+s2z_cap_code <- function(case, normalize = TRUE) {
+  args <- list(
+    object = case$formula, data = s2z_cap_dat,
+    normalize = normalize, parse = TRUE
+  )
+  if (!is.null(case$family)) {
+    args$family <- case$family
+  }
+  if (!is.null(case$prior)) {
+    args$prior <- case$prior
+  }
+  do.call(stancode, args)
+}
+
+s2z_cap_dat <- local({
+  n <- 36L
+  i <- seq_len(n)
+  out <- data.frame(
+    y = sin(i / 4) + cos(i / 9),
+    y2 = cos(i / 5) - sin(i / 11),
+    y_binary = as.integer(i %% 3L == 0L),
+    y_count = i %% 5L,
+    y_cat = factor(rep(1:3, length.out = n)),
+    y_beta = rep(c(0, 1, 0.2, 0.65), length.out = n),
+    rt = 0.4 + i / n,
+    decision = i %% 2L,
+    x = seq(-1.4, 1.6, length.out = n),
+    z = cos(i / 6),
+    w = sin(i / 7),
+    g = factor(rep(seq_len(6L), each = 6L)),
+    h = factor(rep(seq_len(4L), each = 9L))
+  )
+
+  ymulti <- cbind(
+    ymulti1 = 1L + i %% 3L,
+    ymulti2 = 1L + (i + 1L) %% 4L,
+    ymulti3 = 1L + (i + 2L) %% 5L
+  )
+  out$ymulti <- ymulti
+  out$multi_size <- rowSums(ymulti)
+
+  ysimplex <- cbind(
+    ysimplex1 = 1 + i %% 4L,
+    ysimplex2 = 2 + (i + 1L) %% 5L,
+    ysimplex3 = 3 + (i + 2L) %% 6L
+  )
+  out$ysimplex <- ysimplex / rowSums(ysimplex)
+  out
+})
+
+test_that("S2Z Stan parses across core likelihood capabilities", {
+  skip_if_not_installed("rstan")
+
+  cases <- list(
+    Gaussian = list(
+      formula = y ~ x + (1 + x | gr(g, id = "gauss", s2z = TRUE)),
+      family = gaussian(), prior = NULL, marker = "normal_id_glm"
+    ),
+    Bernoulli = list(
+      formula = y_binary ~ x +
+        (1 + x | gr(g, id = "bern", s2z = TRUE)),
+      family = bernoulli(), prior = NULL, marker = "bernoulli_logit"
+    ),
+    Poisson = list(
+      formula = y_count ~ x +
+        (1 + x | gr(g, id = "pois", s2z = TRUE)),
+      family = poisson(), prior = NULL, marker = "poisson_log"
+    ),
+    categorical = list(
+      formula = bf(
+        y_cat ~ 1,
+        mu2 ~ x + (1 + x | gr(g, id = "cat-two", s2z = TRUE)),
+        mu3 ~ x + (1 + x | gr(h, id = "cat-three", s2z = TRUE))
+      ),
+      family = categorical(), prior = NULL, marker = "categorical_logit"
+    ),
+    multinomial = list(
+      formula = bf(
+        ymulti | trials(multi_size) ~ 1,
+        muymulti2 ~ x +
+          (1 + x | gr(g, id = "multi-two", s2z = TRUE)),
+        muymulti3 ~ x +
+          (1 + x | gr(h, id = "multi-three", s2z = TRUE))
+      ),
+      family = multinomial(), prior = NULL, marker = "multinomial_logit2"
+    ),
+    simplex = list(
+      formula = bf(
+        ysimplex ~ 1,
+        muysimplex2 ~ x +
+          (1 + x | gr(g, id = "simplex-two", s2z = TRUE)),
+        muysimplex3 ~ x +
+          (1 + x | gr(h, id = "simplex-three", s2z = TRUE))
+      ),
+      family = dirichlet(), prior = NULL, marker = "dirichlet_logit"
+    ),
+    distributional = list(
+      formula = bf(
+        y ~ x,
+        sigma ~ x + (1 + x | gr(g, id = "sigma", s2z = TRUE))
+      ),
+      family = gaussian(), prior = NULL, marker = "theta_s2z_sigma"
+    ),
+    nonlinear = list(
+      formula = bf(
+        y ~ a,
+        a ~ 1 + x + (1 + x | gr(g, id = "nla", s2z = TRUE)),
+        nl = TRUE
+      ),
+      family = gaussian(),
+      prior = prior(normal(0, 1), nlpar = a), marker = "theta_s2z_a"
+    ),
+    multivariate = list(
+      formula = bf(
+        y ~ x + (1 + x | gr(g, id = "response-one", s2z = TRUE))
+      ) +
+        bf(
+          y2 ~ x +
+            (1 + x | gr(h, id = "response-two", s2z = TRUE))
+        ) +
+        set_rescor(FALSE),
+      family = NULL, prior = NULL, marker = "theta_s2z_y2"
+    )
+  )
+
+  for (name in names(cases)) {
+    code <- s2z_cap_code(cases[[name]])
+    expect_s3_class(code, "brmsmodel")
+    expect_match2(code, "sum_to_zero_constrain_brms", info = name)
+    expect_match2(code, "q_recovered_s2z_", info = name)
+    expect_match2(code, cases[[name]]$marker, info = name)
+  }
+})
+
+test_that("categorical shorthand allocates separate local S2Z IDs", {
+  skip_if_not_installed("rstan")
+
+  code <- stancode(
+    y_cat ~ x + (1 + x | gr(g, s2z = TRUE)),
+    data = s2z_cap_dat, family = categorical(), parse = TRUE
+  )
+  expect_equal(
+    s2z_cap_count_fixed(code, "// physical sum-to-zero group-level effects"),
+    2L
+  )
+  expect_match2(code, "q_recovered_s2z_1")
+  expect_match2(code, "q_recovered_s2z_2")
+  expect_match2(code, "b_mu2_Intercept")
+  expect_match2(code, "b_mu3_Intercept")
+
+  msg <- s2z_cap_error(stancode(
+    y_cat ~ x + (1 + x | gr(g, id = "shared", s2z = TRUE)),
+    data = s2z_cap_dat, family = categorical()
+  ))
+  expect_match(msg, "S2Z capability 'cross_predictor_id'", fixed = TRUE)
+  expect_match(msg, "response 'y_cat'", fixed = TRUE)
+  expect_match(msg, "family 'categorical'", fixed = TRUE)
+  expect_match(msg, "ID 'shared'", fixed = TRUE)
+  expect_match(msg, "Remedy:", fixed = TRUE)
+})
+
+test_that("default probability predictors use exact logistic S2Z means", {
+  skip_if_not_installed("rstan")
+
+  cases <- list(
+    zi = list(
+      formula = bf(
+        y_count ~ 1,
+        zi ~ 1 + (1 | gr(g, id = "zi", s2z = TRUE))
+      ),
+      family = zero_inflated_poisson(), prior = NULL,
+      marker = "theta_s2z_zi", nlogistic = 1L
+    ),
+    hu = list(
+      formula = bf(
+        y_count ~ 1,
+        hu ~ 1 + (1 | gr(g, id = "hu", s2z = TRUE))
+      ),
+      family = hurdle_poisson(), prior = NULL,
+      marker = "theta_s2z_hu", nlogistic = 1L
+    ),
+    zoi_coi = list(
+      formula = bf(
+        y_beta ~ 1,
+        zoi ~ 1 + (1 | gr(g, id = "zoi", s2z = TRUE)),
+        coi ~ 1 + (1 | gr(h, id = "coi", s2z = TRUE))
+      ),
+      family = zero_one_inflated_beta(), prior = NULL,
+      marker = "theta_s2z_coi", nlogistic = 2L
+    ),
+    mixture_theta = list(
+      formula = bf(
+        y ~ 1,
+        theta1 ~ 1 + (1 | gr(g, id = "mixture", s2z = TRUE))
+      ),
+      family = mixture(gaussian, gaussian, order = "none"), prior = NULL,
+      marker = "theta_s2z_theta1", nlogistic = 1L
+    ),
+    wiener_bias = list(
+      formula = bf(
+        rt | dec(decision) ~ 1,
+        bias ~ 1 + (1 | gr(g, id = "bias", s2z = TRUE))
+      ),
+      family = wiener(), prior = NULL,
+      marker = "theta_s2z_bias", nlogistic = 1L
+    ),
+    asym_laplace_quantile = list(
+      formula = bf(
+        y ~ 1,
+        quantile ~ 1 + (1 | gr(g, id = "quantile", s2z = TRUE))
+      ),
+      family = asym_laplace(), prior = NULL,
+      marker = "theta_s2z_quantile", nlogistic = 1L
+    )
+  )
+
+  for (name in names(cases)) {
+    code <- s2z_cap_code(cases[[name]])
+    expect_s3_class(code, "brmsmodel")
+    expect_match2(code, cases[[name]]$marker, info = name)
+    expect_match2(code, "z_mean_s2z_", info = name)
+    expect_match2(code, "q_explicit_s2z_", info = name)
+    expect_equal(
+      s2z_cap_count_fixed(
+        code, "lprior += logistic_lpdf(q_explicit_s2z_"
+      ),
+      cases[[name]]$nlogistic,
+      info = name
+    )
+  }
+})
+
+test_that("exact logistic means cover every physical S2Z kernel shape", {
+  skip_if_not_installed("rstan")
+
+  population_prior <- prior(logistic(-1, 2), class = Intercept) +
+    prior(normal(0, 1), class = b, coef = x)
+  cases <- list(
+    scalar = list(
+      formula = y ~ 1 + (1 | gr(g, id = "scalar", s2z = TRUE)),
+      family = gaussian(),
+      prior = prior(logistic(-1, 2), class = Intercept), nblocks = 1L
+    ),
+    independent = list(
+      formula = y ~ x +
+        (1 + x || gr(g, id = "independent", s2z = TRUE)),
+      family = gaussian(), prior = population_prior, nblocks = 1L
+    ),
+    correlated = list(
+      formula = y ~ x +
+        (1 + x | gr(g, id = "correlated", s2z = TRUE)),
+      family = gaussian(), prior = population_prior, nblocks = 1L
+    ),
+    Student = list(
+      formula = y ~ x +
+        (1 + x | gr(
+          g, id = "student", dist = "student", s2z = TRUE
+        )),
+      family = gaussian(), prior = population_prior, nblocks = 1L
+    ),
+    multiblock = list(
+      formula = y ~ x +
+        (1 + x | gr(g, id = "first", s2z = TRUE)) +
+        (1 | gr(
+          h, id = "second", dist = "student", s2z = TRUE
+        )),
+      family = gaussian(), prior = population_prior, nblocks = 2L
+    )
+  )
+
+  code <- lapply(cases, s2z_cap_code)
+  for (name in names(code)) {
+    expect_s3_class(code[[name]], "brmsmodel")
+    expect_equal(
+      s2z_cap_count_fixed(code[[name]], "// exact explicit-mean S2Z block"),
+      cases[[name]]$nblocks,
+      info = name
+    )
+    expect_equal(
+      s2z_cap_count_fixed(code[[name]], "-0.5 * group_quad_s2z_"),
+      cases[[name]]$nblocks,
+      info = name
+    )
+    expect_equal(
+      s2z_cap_count_fixed(code[[name]], "- 0.5 * N_"),
+      cases[[name]]$nblocks,
+      info = paste(name, "normalizing constants")
+    )
+    expect_equal(
+      s2z_cap_count_fixed(
+        code[[name]], "sum(log(diagonal(L_Sigma_s2z_"
+      ),
+      cases[[name]]$nblocks,
+      info = paste(name, "restricted Jacobians")
+    )
+    expect_match2(
+      code[[name]], "lprior += logistic_lpdf(q_explicit_s2z_", info = name
+    )
+    expect_match2(
+      code[[name]], "z_mean_s2z_", info = paste(name, "omitted mean")
+    )
+    expect_match2(code[[name]], "q_recovered_s2z_", info = name)
+  }
+
+  expect_match2(
+    code$independent, "L_Sigma_s2z_1 = diag_matrix(sd_1);"
+  )
+  expect_match2(
+    code$correlated,
+    "L_Sigma_s2z_1 = diag_pre_multiply(sd_1, L_1);"
+  )
+  expect_match2(code$Student, "group_scale_s2z_1 = dfm_1;")
+  expect_match2(
+    code$Student, "- M_1 * sum(log(group_scale_s2z_1))"
+  )
+  expect_match2(code$multiblock, "z_mean_s2z_1")
+  expect_match2(code$multiblock, "z_mean_s2z_2")
+  expect_equal(
+    s2z_cap_count_fixed(
+      code$multiblock, "q_explicit_s2z_1 -= H_s2z_"
+    ),
+    2L
+  )
+
+  unnormalized <- s2z_cap_code(cases$scalar, normalize = FALSE)
+  expect_match2(
+    unnormalized, "lprior += logistic_lupdf(q_explicit_s2z_1[1] | -1, 2);"
+  )
+  expect_false(grepl(
+    "lprior += logistic_lpdf(q_explicit_s2z_1", unnormalized, fixed = TRUE
+  ))
+  expect_false(grepl(
+    "- 0.5 * N_1 * M_1 * log(2 * pi())", unnormalized, fixed = TRUE
+  ))
+  expect_match2(
+    unnormalized,
+    "- (N_1 - 1) * sum(log(diagonal(L_Sigma_s2z_1)))"
+  )
+})
+
+test_that("fixed-only coordinates keep arbitrary ordinary brms priors", {
+  skip_if_not_installed("rstan")
+
+  case <- list(
+    formula = y ~ x + z + w +
+      (1 + x | gr(g, id = "active", s2z = TRUE)),
+    family = gaussian(),
+    prior = prior(logistic(0, 1), class = Intercept) +
+      prior(normal(0.2, 0.8), class = b, coef = x) +
+      prior(
+        double_exponential(0, 1.3), class = b, coef = z,
+        tag = "fixedonly"
+      ) +
+      prior(constant(0.4), class = b, coef = w)
+  )
+  code <- s2z_cap_code(case)
+
+  expect_match2(
+    code,
+    "vector[2] theta_s2z_active;  // S2Z-active finite-population coefficients"
+  )
+  expect_match2(
+    code,
+    "vector[2] fixed_s2z;  // S2Z-inactive regression coefficients"
+  )
+  expect_match2(code, "real par_fixed_s2z_1;")
+  expect_match2(code, "fixed_s2z[2] = 0.4;")
+  expect_match2(code, "theta_s2z[3] = fixed_s2z[1];")
+  expect_match2(code, "theta_s2z[4] = fixed_s2z[2];")
+  expect_match2(
+    code,
+    paste0(
+      "lprior_fixedonly += double_exponential_lpdf(",
+      "fixed_s2z[1] | 0, 1.3);"
+    )
+  )
+  expect_match2(
+    code, "lprior += logistic_lpdf(q_explicit_s2z_1[1] | 0, 1);"
+  )
+  expect_match2(
+    code,
+    paste0(
+      "lprior += normal_lpdf(q_explicit_s2z_1[2] | ",
+      "0.20000000000000001, 0.80000000000000004);"
+    )
+  )
+  expect_false(grepl("q_explicit_s2z_1[3]", code, fixed = TRUE))
+  expect_false(grepl("q_explicit_s2z_1[4]", code, fixed = TRUE))
+  expect_false(grepl("b_s2z_inactive", code, fixed = TRUE))
+})
+
+test_that("additional S2Z gates reject in the intended phase with context", {
+  structural <- list(
+    sparse = bf(
+      y ~ x + (1 + x + z | gr(g, id = "sparse", s2z = TRUE)),
+      sparse = TRUE
+    ),
+    qr = bf(
+      y ~ x + (1 + x + z | gr(g, id = "qr", s2z = TRUE)),
+      decomp = "QR"
+    )
+  )
+  for (capability in names(structural)) {
+    msg <- s2z_cap_error(stancode(
+      structural[[capability]], data = s2z_cap_dat
+    ))
+    expect_match(
+      msg, paste0("S2Z capability '", capability, "'"), fixed = TRUE
+    )
+    expect_match(msg, "response 'y'", fixed = TRUE)
+    expect_match(msg, paste0("ID '", capability, "'"), fixed = TRUE)
+    expect_match(msg, "Remedy:", fixed = TRUE)
+    expect_false(grepl("matching population-level", msg, fixed = TRUE))
+  }
+
+  active_priors <- list(
+    active_prior_distribution = prior(
+      double_exponential(0, 1), class = b, coef = x
+    ),
+    active_prior_tag = prior(
+      normal(0, 1), class = b, coef = x, tag = "active"
+    )
+  )
+  for (capability in names(active_priors)) {
+    msg <- s2z_cap_error(stancode(
+      y ~ x + (1 + x | gr(g, id = "prior", s2z = TRUE)),
+      data = s2z_cap_dat, prior = active_priors[[capability]]
+    ))
+    expect_match(
+      msg, paste0("S2Z capability '", capability, "'"), fixed = TRUE
+    )
+    expect_match(msg, "coefficient(s) 'x'", fixed = TRUE)
+    expect_match(msg, "group 'g'", fixed = TRUE)
+    expect_match(msg, "ID 'prior'", fixed = TRUE)
+    expect_match(msg, "Remedy:", fixed = TRUE)
+  }
+
+  one_level <- transform(s2z_cap_dat, g = factor("only"))
+  msg <- s2z_cap_error(stancode(
+    y ~ x + (1 + x | gr(g, id = "one-level", s2z = TRUE)),
+    data = one_level
+  ))
+  expect_match(msg, "S2Z capability 'minimum_levels'", fixed = TRUE)
+  expect_match(msg, "ID 'one-level'", fixed = TRUE)
+  expect_match(msg, "Remedy:", fixed = TRUE)
+
+  retained_one_level <- transform(
+    s2z_cap_dat, g = factor("used", levels = c("used", "unused"))
+  )
+  msg <- s2z_cap_error(standata(
+    y ~ x + (1 + x | gr(g, id = "retained-one", s2z = TRUE)),
+    data = retained_one_level, drop_unused_levels = FALSE
+  ))
+  expect_match(msg, "S2Z capability 'minimum_levels'", fixed = TRUE)
+  expect_match(msg, "at least two observed grouping levels", fixed = TRUE)
+
+  retained_unused <- transform(
+    s2z_cap_dat,
+    g = factor(
+      rep(c("first", "second"), length.out = nrow(s2z_cap_dat)),
+      levels = c("first", "second", "unused")
+    )
+  )
+  msg <- s2z_cap_error(standata(
+    y ~ x + (1 + x | gr(g, id = "retained-unused", s2z = TRUE)),
+    data = retained_unused, drop_unused_levels = FALSE
+  ))
+  expect_match(msg, "S2Z capability 'unused_levels'", fixed = TRUE)
+  expect_match(msg, "unused", fixed = TRUE)
+  expect_match(msg, "drop_unused_levels = TRUE", fixed = TRUE)
+})
+
+test_that("foundation code contains no later S2Z APIs or state", {
+  public_arguments <- names(formals(gr))
+  expect_false("center" %in% public_arguments)
+  expect_false("scale" %in% public_arguments)
+  expect_error(
+    gr(g, s2z = TRUE, center = "auto"),
+    "expects only a single grouping term"
+  )
+  expect_error(
+    gr(g, s2z = TRUE, scale = "varying"),
+    "expects only a single grouping term"
+  )
+
+  code <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)),
+    data = s2z_cap_dat, parse = FALSE
+  )
+  forbidden <- c(
+    "s2z_center", "s2z_center_auto", "rho_s2z", "mean_rho_s2z",
+    "sdlog_s2z", "sd_level", "z_sd_s2z"
+  )
+  for (term in forbidden) {
+    expect_false(grepl(term, code, fixed = TRUE), info = term)
+  }
+
+  # Audit the production and user-facing files that define this feature, not
+  # only one representative Stan program. Construct the symbol names in
+  # pieces so this test does not satisfy its own forbidden patterns.
+  test_root <- normalizePath(
+    file.path(testthat::test_path(), "..", ".."), mustWork = TRUE
+  )
+  root_candidates <- c(
+    test_root, file.path(test_root, "00_pkg_src", "brms")
+  )
+  is_source_root <- file.exists(file.path(root_candidates, "R/re-s2z.R"))
+  expect_true(any(is_source_root))
+  package_root <- root_candidates[which(is_source_root)[1L]]
+  audit_files <- file.path(package_root, c(
+    "R/brmsframe.R", "R/exclude_pars.R", "R/formula-re.R",
+    "R/priors.R", "R/re-s2z.R", "R/stan-likelihood.R",
+    "R/stan-predictor.R", "R/stancode.R", "R/standata.R",
+    "inst/chunks/fun_sum_to_zero.stan", "NEWS.md", "man/gr.Rd",
+    "man/mm.Rd", "tests/testthat/tests.brmsterms.R",
+    "tests/testthat/tests.s2z-code.R", "tests/testthat/tests.s2z.R",
+    "tests/testthat/tests.s2z-optimizations.R",
+    "tests/testthat/tests.s2z-validation.R"
+  ))
+  audit_text <- unlist(lapply(audit_files, readLines, warn = FALSE))
+  forbidden_patterns <- c(
+    paste0("s2z", "_center"),
+    paste0("s2z", "_center_auto"),
+    paste0("rho", "_s2z"),
+    paste0("mean_rho", "_s2z"),
+    paste0("sdlog", "_s2z"),
+    paste0("sd", "_level"),
+    paste0("z_sd", "_s2z"),
+    paste0("relative_sd", "_s2z"),
+    paste0("reference_sd", "_s2z"),
+    "center[[:space:]]*=[[:space:]]*['\"](auto|fisher)['\"]",
+    "scale[[:space:]]*=[[:space:]]*['\"]varying['\"]"
+  )
+  for (pattern in forbidden_patterns) {
+    expect_false(any(grepl(pattern, audit_text)), info = pattern)
+  }
+})

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -593,6 +593,198 @@ test_that("an S2Z ID cannot span linear predictors in either term order", {
   }
 })
 
+test_that("large crossed scalar Gaussian systems use one-dimensional Matheron work", {
+  n <- 120L
+  many_data <- data.frame(y = sin(seq_len(n) * 0.07))
+  n_factor <- 10L
+  for (k in seq_len(n_factor)) {
+    many_data[[paste0("g", k)]] <- factor(
+      (seq_len(n) - 1L) %% (k + 1L) + 1L
+    )
+  }
+  terms <- sprintf(
+    "(1 | gr(g%s, s2z = TRUE))",
+    seq_len(n_factor)
+  )
+  form <- stats::as.formula(paste("y ~ 1 +", paste(terms, collapse = "+")))
+  scode <- stancode(
+    form, data = many_data,
+    prior = prior(normal(0, 1.4), class = Intercept)
+  )
+
+  expect_match2(scode, "// fast Gaussian Matheron system for S2Z blocks")
+  expect_match2(scode, "real<lower=0> W_matheron_s2z_1;")
+  expect_match2(scode, "real<lower=0> sqrt_W_matheron_s2z_1;")
+  expect_equal(
+    s2z_count_fixed(scode, "W_matheron_s2z_1 += dot_self("),
+    n_factor
+  )
+  expect_equal(
+    s2z_count_fixed(scode, "theta_star_s2z[1] += dot_product("),
+    n_factor
+  )
+  expect_equal(s2z_count_fixed(scode, "cholesky_decompose("), 0L)
+  expect_false(grepl("matrix[10, 10] P_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("L_P_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("P_group_s2z_", scode, fixed = TRUE))
+  expect_match2(
+    scode,
+    "delta_s2z[1] = (theta_s2z[1] - theta_star_s2z[1]) / "
+  )
+  expect_match2(scode, "q_recovered_s2z_1 = theta_s2z;")
+})
+
+test_that("Matheron supports overlapping physical S2Z blocks", {
+  form <- y ~ x * z +
+    (1 + x | gr(g, s2z = TRUE)) +
+    (1 + x * z || gr(h, s2z = TRUE)) +
+    (1 | gr(f, s2z = TRUE))
+  bprior <- prior(normal(0, 2), class = Intercept) +
+    prior(normal(0, 1), class = b)
+  scode <- stancode(form, data = s2z_dat, prior = bprior)
+
+  for (term in c(
+    "// fast Gaussian Matheron system for S2Z blocks 1, 2, 3",
+    "matrix[4, 4] W_matheron_s2z_1;",
+    "matrix[4, 4] L_W_matheron_s2z_1;",
+    "- (N_1 - 1) * sum(log(diagonal(L_Sigma_s2z_1)))",
+    "- (N_2 - 1) * sum(log(diagonal(L_Sigma_s2z_2)))",
+    "- (N_3 - 1) * sum(log(diagonal(L_Sigma_s2z_3)))",
+    "- 0.5 * (N_1 - 1) * M_1 * log(2 * pi())",
+    "- 0.5 * (N_2 - 1) * M_2 * log(2 * pi())",
+    "- 0.5 * (N_3 - 1) * M_3 * log(2 * pi())",
+    "- 0.5 * 4 * log(2 * pi())",
+    "mean_r_s2z_1 += L_Sigma_s2z_1 *",
+    "mean_r_s2z_2 += L_Sigma_s2z_2 *",
+    "mean_r_s2z_3 += L_Sigma_s2z_3 *",
+    "r_s2z_3 ./ rep_matrix(sd_3', N_3)",
+    "q_recovered_s2z_1 = theta_s2z;"
+  )) {
+    expect_true(grepl(term, scode, fixed = TRUE), info = term)
+  }
+  expect_false(grepl(
+    "L_Sigma_s2z_3, r_s2z_3", scode, fixed = TRUE
+  ))
+  expect_false(grepl("matrix[7, 7] P_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("L_P_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("H_joint_s2z_1", scode, fixed = TRUE))
+  expect_equal(
+    s2z_count_fixed(
+      scode,
+      "W_matheron_s2z_1 += tcrossprod(H_active_s2z * "
+    ),
+    3L
+  )
+  expect_equal(s2z_count_fixed(scode, "cholesky_decompose("), 1L)
+})
+
+test_that("conditional Student and Cauchy population priors use Matheron", {
+  form <- y ~ x +
+    (1 + x || gr(g, s2z = TRUE)) +
+    (1 + x | gr(h, s2z = TRUE))
+  bprior <- prior(student_t(5, 0.2, 1.7), class = Intercept) +
+    prior(cauchy(-0.1, 0.8), class = b)
+  scode <- stancode(form, data = s2z_dat, prior = bprior)
+
+  expect_match2(scode, "// fast Gaussian Matheron system")
+  expect_match2(scode, "real<lower=0> udf_b_s2z_1;")
+  expect_match2(scode, "real<lower=0> udf_b_s2z_2;")
+  expect_match2(scode, "inv_chi_square_lpdf(udf_b_s2z_1 | 5)")
+  expect_match2(scode, "inv_chi_square_lpdf(udf_b_s2z_2 | 1)")
+  expect_match2(scode, "prior_scale_s2z_1[1] = 1.7 * sqrt(5 *")
+  expect_match2(scode, "prior_scale_s2z_1[2] = ")
+  expect_match2(scode, "sqrt(1 * udf_b_s2z_2)")
+  expect_match2(scode, "matrix[2, 2] W_matheron_s2z_1;")
+  expect_match2(scode, "matrix[2, 2] L_W_matheron_s2z_1;")
+  expect_false(grepl("matrix[4, 4] P_s2z_1", scode, fixed = TRUE))
+})
+
+test_that("proper population coordinates outside group maps score independently", {
+  form <- y ~ x + z +
+    (1 | gr(g, s2z = TRUE)) +
+    (1 | gr(h, s2z = TRUE))
+  bprior <- prior(normal(0.2, 1.5), class = Intercept) +
+    prior(normal(-0.1, 0.7), class = b)
+  scode <- stancode(form, data = s2z_dat, prior = bprior)
+
+  expect_match2(scode, "// fast Gaussian Matheron system")
+  expect_match2(scode, "real<lower=0> W_matheron_s2z_1;")
+  expect_false(grepl("matrix[2, 2] P_s2z_1", scode, fixed = TRUE))
+  expect_equal(
+    s2z_count_fixed(
+      scode,
+      paste0(
+        "normal_lpdf(theta_s2z[2] | prior_mean_s2z_1[2], ",
+        "prior_scale_s2z_1[2])"
+      )
+    ),
+    1L
+  )
+  expect_equal(
+    s2z_count_fixed(
+      scode,
+      paste0(
+        "normal_lpdf(theta_s2z[3] | prior_mean_s2z_1[3], ",
+        "prior_scale_s2z_1[3])"
+      )
+    ),
+    1L
+  )
+  expect_false(grepl("normal_lpdf(theta_s2z[1]", scode, fixed = TRUE))
+  expect_match2(scode, "theta_s2z[1] - prior_mean_s2z_1[1]")
+})
+
+test_that("flat active population coordinates use the zero-rank fast path", {
+  form <- y ~ 0 + x +
+    (0 + x | gr(g, s2z = TRUE)) +
+    (0 + x | gr(h, s2z = TRUE))
+  scode <- stancode(form, data = s2z_dat)
+
+  expect_match2(scode, "// fast Gaussian Matheron system")
+  expect_false(grepl("W_matheron_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("theta_star_s2z", scode, fixed = TRUE))
+  expect_false(grepl("delta_s2z", scode, fixed = TRUE))
+  expect_false(grepl("P_s2z_1", scode, fixed = TRUE))
+  expect_match2(scode, "q_recovered_s2z_1 = theta_s2z;")
+  expect_match2(
+    scode,
+    "q_recovered_s2z_1 -= H_s2z_1 * mean_r_s2z_1;"
+  )
+  expect_match2(
+    scode,
+    "q_recovered_s2z_1 -= H_s2z_2 * mean_r_s2z_2;"
+  )
+})
+
+test_that("nonseparable or nonbeneficial multiblock models keep dense fallback", {
+  cases <- list(
+    list(
+      form = y ~ 0 + x + z +
+        (0 + x | gr(g, s2z = TRUE)) +
+        (0 + z | gr(h, s2z = TRUE)),
+      prior = prior(normal(0, 1), class = b), total = 2L
+    ),
+    list(
+      form = y ~ x +
+        (1 + x | gr(g, s2z = TRUE, dist = "student")) +
+        (1 + x | gr(h, s2z = TRUE)),
+      prior = prior(normal(0, 2), class = Intercept) +
+        prior(normal(0, 1), class = b), total = 4L
+    )
+  )
+  for (case in cases) {
+    scode <- stancode(case$form, data = s2z_dat, prior = case$prior)
+    expect_false(
+      grepl("fast Gaussian Matheron system", scode, fixed = TRUE),
+      info = deparse0(case$form)
+    )
+    expect_match2(
+      scode, sprintf("matrix[%s, %s] P_s2z_1;", case$total, case$total)
+    )
+    expect_match2(scode, "L_P_s2z_1 = cholesky_decompose(P_s2z_1);")
+  }
+})
+
 test_that("crossed scalar S2Z factors share one omitted-mean system", {
   form <- y ~ 1 +
     (1 | gr(g, s2z = TRUE)) +
@@ -600,38 +792,35 @@ test_that("crossed scalar S2Z factors share one omitted-mean system", {
   bprior <- prior(normal(0, 2), class = Intercept)
   scode <- stancode(form, data = s2z_dat, prior = bprior)
   for (term in c(
-    "matrix[M_1, M_1] P_group_s2z_1;",
-    "matrix[M_2, M_2] P_group_s2z_2;",
-    "matrix[1, 2] H_joint_s2z_1;",
-    "matrix[2, 2] P_s2z_1;",
-    "matrix[2, 2] L_P_s2z_1;",
-    "vector[2] h_joint_s2z_1;",
-    "vector[2] mhat_s2z_1;",
-    "H_joint_s2z_1[, 1:1] = H_s2z_1 * L_Sigma_s2z_1;",
-    "H_joint_s2z_1[, 2:2] = H_s2z_2 * L_Sigma_s2z_2;",
-    "P_s2z_1[1:1, 1:1] = P_group_s2z_1;",
-    "P_s2z_1[2:2, 2:2] = P_group_s2z_2;",
+    "// fast Gaussian Matheron system for S2Z blocks 1, 2",
+    "real<lower=0> W_matheron_s2z_1;",
+    "real<lower=0> sqrt_W_matheron_s2z_1;",
+    "W_matheron_s2z_1 += dot_self(H_s2z_1[1, ] * L_Sigma_s2z_1)",
+    "W_matheron_s2z_1 += dot_self(H_s2z_2[1, ] * L_Sigma_s2z_2)",
+    "- (N_1 - 1) * sum(log(diagonal(L_Sigma_s2z_1)))",
+    "- (N_2 - 1) * sum(log(diagonal(L_Sigma_s2z_2)))",
+    "mean_r_s2z_1 += L_Sigma_s2z_1 *",
+    "mean_r_s2z_2 += L_Sigma_s2z_2 *",
+    "q_recovered_s2z_1 = theta_s2z;",
     "r_1_1 = r_s2z_1_1 + mean_r_s2z_1[1];",
     "r_2_1 = r_s2z_2_1 + mean_r_s2z_2[1];"
   )) {
     expect_true(grepl(term, scode, fixed = TRUE), info = term)
   }
   expect_equal(
-    s2z_count_fixed(scode, "cholesky_decompose(P_s2z_1)"), 1L
+    s2z_count_fixed(scode, "cholesky_decompose("), 0L
   )
   expect_equal(
     s2z_count_fixed(
       scode,
-      paste0(
-        "q_recovered_s2z_1 = theta_s2z - ",
-        "H_joint_s2z_1 * mean_white_s2z;"
-      )
+      "q_recovered_s2z_1 -= H_s2z_"
     ),
-    1L
+    2L
   )
-  expect_equal(
-    s2z_count_fixed(scode, "normal_lpdf(theta_s2z[1] | 0, 2)"), 1L
-  )
+  expect_match2(scode, "prior_mean_s2z_1[1] = 0;")
+  expect_match2(scode, "prior_scale_s2z_1[1] = 2;")
+  expect_false(grepl("P_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("H_joint_s2z_1", scode, fixed = TRUE))
   expect_equal(s2z_count_fixed(scode, "real Intercept;"), 1L)
   expect_equal(s2z_count_fixed(scode, "real b_Intercept;"), 1L)
 
@@ -645,16 +834,14 @@ test_that("independent and correlated interaction blocks stay specialized", {
     prior(normal(0, 1), class = b)
   scode <- stancode(form, data = s2z_dat, prior = bprior)
   for (term in c(
-    "matrix[4, 8] H_joint_s2z_1;",
-    "matrix[8, 8] P_s2z_1;",
-    "H_joint_s2z_1[, 1:4] = H_s2z_1 * L_Sigma_s2z_1;",
-    "H_joint_s2z_1[, 5:8] = H_s2z_2 * L_Sigma_s2z_2;",
-    "P_s2z_1[1:4, 1:4] = P_group_s2z_1;",
-    "P_s2z_1[5:8, 5:8] = P_group_s2z_2;",
+    "// fast Gaussian Matheron system for S2Z blocks 1, 2",
+    "matrix[4, 4] W_matheron_s2z_1;",
+    "matrix[4, 4] L_W_matheron_s2z_1;",
+    "W_matheron_s2z_1 += tcrossprod(H_active_s2z *",
     "L_Sigma_s2z_1 = diag_matrix(sd_1);",
     "L_Sigma_s2z_2 = diag_pre_multiply(sd_2, L_2);",
-    "P_group_s2z_1 = diag_matrix(rep_vector(1.0 * N_1, M_1));",
-    "P_group_s2z_2 = diag_matrix(rep_vector(1.0 * N_2, M_2));",
+    "- (N_1 - 1) * sum(log(diagonal(L_Sigma_s2z_1)))",
+    "- (N_2 - 1) * sum(log(diagonal(L_Sigma_s2z_2)))",
     "r_1_1 = r_s2z_1_1 + mean_r_s2z_1[1];",
     "r_1_4 = r_s2z_1_4 + mean_r_s2z_1[4];",
     "r_2 = r_s2z_2 + rep_matrix(mean_r_s2z_2', N_2);",
@@ -664,7 +851,7 @@ test_that("independent and correlated interaction blocks stay specialized", {
     expect_true(grepl(term, scode, fixed = TRUE), info = term)
   }
   # The K=4 independent block remains elementwise. Only the correlated block
-  # may perform coefficient-space triangular work before the joint solve.
+  # may perform coefficient-space triangular work before the Matheron update.
   expect_false(grepl(
     "mdivide_left_tri_low(L_Sigma_s2z_1", scode, fixed = TRUE
   ))
@@ -681,20 +868,22 @@ test_that("independent and correlated interaction blocks stay specialized", {
   expect_equal(
     s2z_count_fixed(
       scode,
-      paste0(
-        "q_recovered_s2z_1 = theta_s2z - ",
-        "H_joint_s2z_1 * mean_white_s2z;"
-      )
+      "q_recovered_s2z_1 -= H_s2z_"
     ),
-    1L
+    2L
   )
+  expect_match2(scode, "q_recovered_s2z_1 = theta_s2z;")
+  expect_false(grepl("matrix[8, 8] P_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("H_joint_s2z_1", scode, fixed = TRUE))
   expect_equal(s2z_count_fixed(scode, "vector[Kc] b;"), 1L)
   expect_equal(
     s2z_count_fixed(scode, "b = tail(q_recovered_s2z_1, Kc);"), 1L
   )
   for (k in seq_len(4L)) {
     expect_equal(
-      s2z_count_fixed(scode, sprintf("normal_lpdf(theta_s2z[%s]", k)),
+      s2z_count_fixed(
+        scode, sprintf("prior_scale_s2z_1[%s] =", k)
+      ),
       1L
     )
   }
@@ -732,7 +921,7 @@ test_that("Gaussian and Student blocks contribute separately to one solve", {
   )
 })
 
-test_that("joint S2Z code supports threading without normalizing constants", {
+test_that("Matheron S2Z supports threading without normalizing constants", {
   form <- y ~ 1 +
     (1 | gr(g, s2z = TRUE)) +
     (1 | gr(h, s2z = TRUE))
@@ -757,21 +946,25 @@ test_that("joint S2Z code supports threading without normalizing constants", {
       "r_s2z_2_1);"
     )
   )
-  expect_match2(scode, "normal_lupdf(theta_s2z[1] | 0, 2)")
+  expect_match2(scode, "// fast Gaussian Matheron system")
+  expect_match2(
+    scode, "- (N_1 - 1) * sum(log(diagonal(L_Sigma_s2z_1)))"
+  )
+  expect_match2(
+    scode, "- (N_2 - 1) * sum(log(diagonal(L_Sigma_s2z_2)))"
+  )
   expect_false(grepl("log(1.0 * N_1)", scode, fixed = TRUE))
   expect_false(grepl("log(1.0 * N_2)", scode, fixed = TRUE))
+  expect_false(grepl("log(2 * pi())", scode, fixed = TRUE))
   expect_equal(
-    s2z_count_fixed(scode, "cholesky_decompose(P_s2z_1)"), 1L
+    s2z_count_fixed(scode, "cholesky_decompose("), 0L
   )
   expect_equal(
     s2z_count_fixed(
       scode,
-      paste0(
-        "q_recovered_s2z_1 = theta_s2z - ",
-        "H_joint_s2z_1 * mean_white_s2z;"
-      )
+      "q_recovered_s2z_1 -= H_s2z_"
     ),
-    1L
+    2L
   )
 })
 
@@ -792,11 +985,12 @@ test_that("joint S2Z implementation details follow save_pars", {
   )
 
   internal <- c(
-    "P_group_s2z_1", "h_group_s2z_1", "H_s2z_1",
-    "L_Sigma_s2z_1", "P_group_s2z_2", "h_group_s2z_2",
-    "H_s2z_2", "L_Sigma_s2z_2", "P_s2z_1", "L_P_s2z_1",
-    "H_joint_s2z_1", "h_joint_s2z_1", "mhat_s2z_1",
-    "joint_quad_s2z_1", "q_recovered_s2z_1"
+    "H_s2z_1", "L_Sigma_s2z_1", "group_quad_s2z_1",
+    "H_s2z_2", "L_Sigma_s2z_2", "group_quad_s2z_2",
+    "prior_mean_s2z_1", "prior_scale_s2z_1",
+    "W_matheron_s2z_1", "L_W_matheron_s2z_1",
+    "theta_white_matheron_s2z_1", "joint_quad_s2z_1",
+    "mean_r_s2z_1", "mean_r_s2z_2", "q_recovered_s2z_1"
   )
   for (name in internal) {
     expect_true(name %in% default_excluded, info = name)

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -2,6 +2,12 @@ context("Tests for physical sum-to-zero group-level effects")
 
 expect_match2 <- brms:::expect_match2
 
+s2z_count_fixed <- function(x, pattern) {
+  unname(lengths(regmatches(
+    x, gregexpr(pattern, x, fixed = TRUE)
+  )))
+}
+
 s2z_dat <- local({
   set.seed(1916)
   n <- 72
@@ -564,18 +570,334 @@ test_that("S2Z blocks can belong to distinct distributional predictors", {
   )
 })
 
+test_that("an S2Z ID cannot span linear predictors in either term order", {
+  mixed_ids <- list(
+    bf(
+      y ~ 1 + (1 | gr(g, id = "across", s2z = TRUE)),
+      sigma ~ 1 + (1 | gr(g, id = "across", s2z = FALSE))
+    ),
+    bf(
+      y ~ 1 + (1 | gr(g, id = "across", s2z = FALSE)),
+      sigma ~ 1 + (1 | gr(g, id = "across", s2z = TRUE))
+    ),
+    bf(
+      y ~ 1 + (1 | gr(g, id = "across", s2z = TRUE)),
+      sigma ~ 1 + (1 | gr(g, id = "across", s2z = TRUE))
+    )
+  )
+  for (form in mixed_ids) {
+    expect_error(
+      stancode(form, data = s2z_dat),
+      "cannot span multiple linear predictors"
+    )
+  }
+})
+
+test_that("crossed scalar S2Z factors share one omitted-mean system", {
+  form <- y ~ 1 +
+    (1 | gr(g, s2z = TRUE)) +
+    (1 | gr(h, s2z = TRUE))
+  bprior <- prior(normal(0, 2), class = Intercept)
+  scode <- stancode(form, data = s2z_dat, prior = bprior)
+  for (term in c(
+    "matrix[M_1, M_1] P_group_s2z_1;",
+    "matrix[M_2, M_2] P_group_s2z_2;",
+    "matrix[1, 2] H_joint_s2z_1;",
+    "matrix[2, 2] P_s2z_1;",
+    "matrix[2, 2] L_P_s2z_1;",
+    "vector[2] h_joint_s2z_1;",
+    "vector[2] mhat_s2z_1;",
+    "H_joint_s2z_1[, 1:1] = H_s2z_1 * L_Sigma_s2z_1;",
+    "H_joint_s2z_1[, 2:2] = H_s2z_2 * L_Sigma_s2z_2;",
+    "P_s2z_1[1:1, 1:1] = P_group_s2z_1;",
+    "P_s2z_1[2:2, 2:2] = P_group_s2z_2;",
+    "r_1_1 = r_s2z_1_1 + mean_r_s2z_1[1];",
+    "r_2_1 = r_s2z_2_1 + mean_r_s2z_2[1];"
+  )) {
+    expect_true(grepl(term, scode, fixed = TRUE), info = term)
+  }
+  expect_equal(
+    s2z_count_fixed(scode, "cholesky_decompose(P_s2z_1)"), 1L
+  )
+  expect_equal(
+    s2z_count_fixed(
+      scode,
+      paste0(
+        "q_recovered_s2z_1 = theta_s2z - ",
+        "H_joint_s2z_1 * mean_white_s2z;"
+      )
+    ),
+    1L
+  )
+  expect_equal(
+    s2z_count_fixed(scode, "normal_lpdf(theta_s2z[1] | 0, 2)"), 1L
+  )
+  expect_equal(s2z_count_fixed(scode, "real Intercept;"), 1L)
+  expect_equal(s2z_count_fixed(scode, "real b_Intercept;"), 1L)
+
+})
+
+test_that("independent and correlated interaction blocks stay specialized", {
+  form <- y ~ x * z +
+    (1 + x * z || gr(g, s2z = TRUE)) +
+    (1 + x * z | gr(h, s2z = TRUE))
+  bprior <- prior(normal(0, 2), class = Intercept) +
+    prior(normal(0, 1), class = b)
+  scode <- stancode(form, data = s2z_dat, prior = bprior)
+  for (term in c(
+    "matrix[4, 8] H_joint_s2z_1;",
+    "matrix[8, 8] P_s2z_1;",
+    "H_joint_s2z_1[, 1:4] = H_s2z_1 * L_Sigma_s2z_1;",
+    "H_joint_s2z_1[, 5:8] = H_s2z_2 * L_Sigma_s2z_2;",
+    "P_s2z_1[1:4, 1:4] = P_group_s2z_1;",
+    "P_s2z_1[5:8, 5:8] = P_group_s2z_2;",
+    "L_Sigma_s2z_1 = diag_matrix(sd_1);",
+    "L_Sigma_s2z_2 = diag_pre_multiply(sd_2, L_2);",
+    "P_group_s2z_1 = diag_matrix(rep_vector(1.0 * N_1, M_1));",
+    "P_group_s2z_2 = diag_matrix(rep_vector(1.0 * N_2, M_2));",
+    "r_1_1 = r_s2z_1_1 + mean_r_s2z_1[1];",
+    "r_1_4 = r_s2z_1_4 + mean_r_s2z_1[4];",
+    "r_2 = r_s2z_2 + rep_matrix(mean_r_s2z_2', N_2);",
+    "vector[Kc] b;",
+    "b = tail(q_recovered_s2z_1, Kc);"
+  )) {
+    expect_true(grepl(term, scode, fixed = TRUE), info = term)
+  }
+  # The K=4 independent block remains elementwise. Only the correlated block
+  # may perform coefficient-space triangular work before the joint solve.
+  expect_false(grepl(
+    "mdivide_left_tri_low(L_Sigma_s2z_1", scode, fixed = TRUE
+  ))
+  expect_match2(
+    scode,
+    paste0(
+      "matrix[N_1, M_1] white_group_s2z = r_s2z_1 ./ ",
+      "rep_matrix(sd_1', N_1);"
+    )
+  )
+  expect_false(grepl("corr_matrix[M_1] Cor_1", scode, fixed = TRUE))
+  expect_match2(scode, "corr_matrix[M_2] Cor_2")
+  expect_equal(s2z_count_fixed(scode, "cholesky_decompose("), 1L)
+  expect_equal(
+    s2z_count_fixed(
+      scode,
+      paste0(
+        "q_recovered_s2z_1 = theta_s2z - ",
+        "H_joint_s2z_1 * mean_white_s2z;"
+      )
+    ),
+    1L
+  )
+  expect_equal(s2z_count_fixed(scode, "vector[Kc] b;"), 1L)
+  expect_equal(
+    s2z_count_fixed(scode, "b = tail(q_recovered_s2z_1, Kc);"), 1L
+  )
+  for (k in seq_len(4L)) {
+    expect_equal(
+      s2z_count_fixed(scode, sprintf("normal_lpdf(theta_s2z[%s]", k)),
+      1L
+    )
+  }
+})
+
+test_that("Gaussian and Student blocks contribute separately to one solve", {
+  form <- y ~ x +
+    (1 + x | gr(g, s2z = TRUE, dist = "gaussian")) +
+    (1 + x | gr(h, s2z = TRUE, dist = "student"))
+  bprior <- prior(normal(0, 2), class = Intercept) +
+    prior(normal(0, 1), class = b)
+  scode <- stancode(form, data = s2z_dat, prior = bprior)
+
+  for (term in c(
+    "P_group_s2z_1 = diag_matrix(rep_vector(1.0 * N_1, M_1));",
+    "group_scale_s2z_2 = dfm_2;",
+    "group_prec_s2z_2 = inv_square(group_scale_s2z_2);",
+    "P_group_s2z_2 = diag_matrix(rep_vector(",
+    "sum(group_prec_s2z_2), M_2));",
+    "h_group_s2z_2 = -white_group_s2z * group_prec_s2z_2;",
+    "- M_2 * sum(log(group_scale_s2z_2))",
+    "P_s2z_1[1:2, 1:2] = P_group_s2z_1;",
+    "P_s2z_1[3:4, 3:4] = P_group_s2z_2;"
+  )) {
+    expect_true(grepl(term, scode, fixed = TRUE), info = term)
+  }
+  expect_false(grepl("group_scale_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("group_prec_s2z_1", scode, fixed = TRUE))
+  expect_equal(s2z_count_fixed(scode, "cholesky_decompose("), 1L)
+  expect_equal(
+    s2z_count_fixed(scode, "normal_lpdf(theta_s2z[1]"), 1L
+  )
+  expect_equal(
+    s2z_count_fixed(scode, "normal_lpdf(theta_s2z[2]"), 1L
+  )
+})
+
+test_that("joint S2Z code supports threading without normalizing constants", {
+  form <- y ~ 1 +
+    (1 | gr(g, s2z = TRUE)) +
+    (1 | gr(h, s2z = TRUE))
+  scode <- stancode(
+    form, data = s2z_dat,
+    prior = prior(normal(0, 2), class = Intercept),
+    threads = threading(2), normalize = FALSE, parse = FALSE
+  )
+
+  expect_match2(
+    scode,
+    paste0(
+      "data vector Z_1_1, vector r_s2z_1_1, data array[] int J_2, ",
+      "data vector Z_2_1, vector r_s2z_2_1"
+    )
+  )
+  expect_match2(
+    scode,
+    paste0(
+      "target += reduce_sum(partial_log_lik_lpmf, seq, grainsize, Y, ",
+      "theta_s2z, sigma, J_1, Z_1_1, r_s2z_1_1, J_2, Z_2_1, ",
+      "r_s2z_2_1);"
+    )
+  )
+  expect_match2(scode, "normal_lupdf(theta_s2z[1] | 0, 2)")
+  expect_false(grepl("log(1.0 * N_1)", scode, fixed = TRUE))
+  expect_false(grepl("log(1.0 * N_2)", scode, fixed = TRUE))
+  expect_equal(
+    s2z_count_fixed(scode, "cholesky_decompose(P_s2z_1)"), 1L
+  )
+  expect_equal(
+    s2z_count_fixed(
+      scode,
+      paste0(
+        "q_recovered_s2z_1 = theta_s2z - ",
+        "H_joint_s2z_1 * mean_white_s2z;"
+      )
+    ),
+    1L
+  )
+})
+
+test_that("joint S2Z implementation details follow save_pars", {
+  form <- y ~ x * z +
+    (1 + x * z || gr(g, s2z = TRUE)) +
+    (1 + x * z | gr(h, s2z = TRUE))
+  default_fit <- brm(form, data = s2z_dat, empty = TRUE)
+  saved_fit <- brm(
+    form, data = s2z_dat, empty = TRUE,
+    save_pars = save_pars(all = TRUE)
+  )
+  default_excluded <- unlist(
+    brms:::exclude_pars(default_fit), use.names = FALSE
+  )
+  saved_excluded <- unlist(
+    brms:::exclude_pars(saved_fit), use.names = FALSE
+  )
+
+  internal <- c(
+    "P_group_s2z_1", "h_group_s2z_1", "H_s2z_1",
+    "L_Sigma_s2z_1", "P_group_s2z_2", "h_group_s2z_2",
+    "H_s2z_2", "L_Sigma_s2z_2", "P_s2z_1", "L_P_s2z_1",
+    "H_joint_s2z_1", "h_joint_s2z_1", "mhat_s2z_1",
+    "joint_quad_s2z_1", "q_recovered_s2z_1"
+  )
+  for (name in internal) {
+    expect_true(name %in% default_excluded, info = name)
+    expect_false(name %in% saved_excluded, info = name)
+  }
+})
+
+test_that("split same-ID S2Z terms validate every constituent", {
+  split_dist <- list(
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE, dist = "gaussian")) +
+      (0 + x | gr(g, id = "split", s2z = TRUE, dist = "student")),
+    y ~ x +
+      (0 + x | gr(g, id = "split", s2z = TRUE, dist = "student")) +
+      (1 | gr(g, id = "split", s2z = TRUE, dist = "gaussian"))
+  )
+  for (form in split_dist) {
+    expect_error(
+      stancode(form, data = s2z_dat),
+      "same group-level distribution"
+    )
+  }
+
+  split_cor <- list(
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE)) +
+      (0 + x || gr(g, id = "split", s2z = TRUE)),
+    y ~ x +
+      (0 + x || gr(g, id = "split", s2z = TRUE)) +
+      (1 | gr(g, id = "split", s2z = TRUE))
+  )
+  for (form in split_cor) {
+    expect_error(stancode(form, data = s2z_dat), "same 'cor' setting")
+  }
+
+  by_dat <- transform(
+    s2z_dat, f_by = factor(rep(c("a", "b"), each = nrow(s2z_dat) / 2))
+  )
+  split_by <- list(
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE, by = f_by)) +
+      (0 + x | gr(g, id = "split", s2z = TRUE)),
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE)) +
+      (0 + x | gr(g, id = "split", s2z = TRUE, by = f_by))
+  )
+  for (form in split_by) {
+    expect_error(stancode(form, data = by_dat), "'by', 'cov', and 'pw'")
+  }
+
+  split_pw <- list(
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE, pw = w)) +
+      (0 + x | gr(g, id = "split", s2z = TRUE)),
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE)) +
+      (0 + x | gr(g, id = "split", s2z = TRUE, pw = w))
+  )
+  for (form in split_pw) {
+    expect_error(stancode(form, data = s2z_dat), "'by', 'cov', and 'pw'")
+  }
+
+  covariance <- diag(nlevels(s2z_dat$g))
+  dimnames(covariance) <- list(levels(s2z_dat$g), levels(s2z_dat$g))
+  split_cov <- list(
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE, cov = covariance)) +
+      (0 + x | gr(g, id = "split", s2z = TRUE)),
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE)) +
+      (0 + x | gr(g, id = "split", s2z = TRUE, cov = covariance))
+  )
+  for (form in split_cov) {
+    expect_error(
+      stancode(
+        form, data = s2z_dat, data2 = list(covariance = covariance)
+      ),
+      "'by', 'cov', and 'pw'"
+    )
+  }
+
+  split_group <- list(
+    y ~ x +
+      (1 | gr(g, id = "split", s2z = TRUE)) +
+      (0 + x | gr(h, id = "split", s2z = TRUE)),
+    y ~ x +
+      (0 + x | gr(h, id = "split", s2z = TRUE)) +
+      (1 | gr(g, id = "split", s2z = TRUE))
+  )
+  for (form in split_group) {
+    expect_error(
+      stancode(form, data = s2z_dat),
+      "same grouping factor"
+    )
+  }
+})
+
 test_that("unsupported S2Z structures fail clearly", {
   expect_error(
     stancode(y ~ x + (1 + x + z | gr(g, s2z = TRUE)), s2z_dat),
     "matching population-level design column"
-  )
-  expect_error(
-    stancode(
-      y ~ x + (1 + x | gr(g, s2z = TRUE)) +
-        (1 + x | gr(h, s2z = TRUE)),
-      s2z_dat
-    ),
-    "Only one sum-to-zero"
   )
   by_dat <- transform(
     s2z_dat, f_by = factor(rep(c("a", "b"), each = nrow(s2z_dat) / 2))

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -1,0 +1,240 @@
+context("Tests for marginalized sum-to-zero group-level effects")
+
+expect_match2 <- brms:::expect_match2
+
+s2z_dat <- local({
+  set.seed(1916)
+  n <- 72
+  data.frame(
+    y = rnorm(n),
+    x = seq(1.25, 4.75, length.out = n),
+    z = rep(c(-0.5, 2), length.out = n),
+    f = factor(rep(c("a", "b", "c"), length.out = n)),
+    g = factor(rep(seq_len(6), each = 12)),
+    h = factor(rep(seq_len(8), each = 9)),
+    w = rep(seq(0.8, 1.2, length.out = 6), each = 12)
+  )
+})
+
+test_that("S2Z Stan code covers intercepts, slopes, and interactions", {
+  scode <- stancode(
+    y ~ x * z + (1 + x * z | gr(g, s2z = TRUE)), data = s2z_dat
+  )
+  sdata <- standata(
+    y ~ x * z + (1 + x * z | gr(g, s2z = TRUE)), data = s2z_dat
+  )
+
+  expect_equal(sdata$M_1, 4)
+  expect_equal(sdata$NC_1, 6)
+  expect_match2(scode, "array[M_1] vector[N_1 - 1] z_s2z_1;")
+  expect_match2(scode, "matrix[N_1, M_1] r_s2z_1;")
+  expect_match2(scode, "H_s2z_1[1, 2] = means_X[1];")
+  expect_match2(scode, "H_s2z_1[1, 3] = means_X[2];")
+  expect_match2(scode, "H_s2z_1[1, 4] = means_X[3];")
+  expect_match2(scode, "r_s2z_1[, k] = sum_to_zero_constrain_brms")
+  expect_match2(scode, "mu += theta_s2z[1]")
+  expect_match2(
+    scode,
+    "normal_id_glm_lpdf(Y | Xc, mu, tail(theta_s2z, 3), sigma)"
+  )
+  expect_match2(scode, "q_recovered_s2z_1 = theta_s2z")
+  expect_match2(scode, "r_1 = r_s2z_1 + rep_matrix(mean_r_s2z_1'")
+  expect_match2(scode, "b_Intercept = Intercept - dot_product(means_X, b)")
+  expect_true(grepl("normal_id_glm", scode, fixed = TRUE))
+})
+
+test_that("S2Z uses actual mixed-interaction design columns", {
+  form <- y ~ f * x + (1 + f * x | gr(g, s2z = TRUE))
+  sdata <- standata(form, data = s2z_dat)
+  Z <- model.matrix(~ f * x, s2z_dat)
+
+  expect_equal(sdata$M_1, ncol(Z))
+  expect_equal(sdata$NC_1, choose(ncol(Z), 2))
+  for (k in seq_len(ncol(Z))) {
+    expect_equal(
+      unname(sdata[[sprintf("Z_1_%s", k)]]),
+      as.array(unname(Z[, k]))
+    )
+  }
+
+  scode <- stancode(form, data = s2z_dat)
+  for (k in seq_len(ncol(Z) - 1L)) {
+    expect_match2(
+      scode,
+      sprintf("H_s2z_1[1, %s] = means_X[%s];", k + 1L, k)
+    )
+  }
+})
+
+test_that("S2Z supports correlated and diagonal Gaussian effects", {
+  sc_cor <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)), data = s2z_dat
+  )
+  sc_diag <- stancode(
+    y ~ x + (1 + x || gr(g, s2z = TRUE)), data = s2z_dat
+  )
+
+  expect_match2(sc_cor, "cholesky_factor_corr[M_1] L_1;")
+  expect_match2(sc_cor, "diag_pre_multiply(sd_1, L_1)")
+  expect_match2(sc_cor, "corr_matrix[M_1] Cor_1")
+  expect_false(grepl("cholesky_factor_corr[M_1] L_1;", sc_diag, fixed = TRUE))
+  expect_match2(sc_diag, "L_Sigma_s2z_1 = diag_matrix(sd_1);")
+})
+
+test_that("S2Z handles Student-t effects by conditional marginalization", {
+  scode <- stancode(
+    y ~ x + (1 + x | gr(g, dist = "student", s2z = TRUE)),
+    data = s2z_dat
+  )
+  expect_match2(scode, "vector<lower=0>[N_1] udf_1;")
+  expect_match2(scode, "dfm_1 = sqrt(df_1 * udf_1);")
+  expect_match2(scode, "group_scale_s2z_1 = dfm_1;")
+  expect_match2(scode, "group_prec_s2z_1 = inv_square(group_scale_s2z_1)")
+  expect_match2(scode, "r_s2z_1' * group_prec_s2z_1")
+  expect_match2(scode, "M_1 * sum(log(group_scale_s2z_1))")
+  expect_match2(scode, "inv_chi_square_lpdf(udf_1 | df_1)")
+})
+
+test_that("S2Z supports Gaussian scale-mixture population priors", {
+  priors <- c(
+    prior(student_t(7, 1, 2), class = Intercept),
+    prior(cauchy(0, 1), class = b, coef = x)
+  )
+  scode <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)),
+    data = s2z_dat, prior = priors
+  )
+  expect_match2(scode, "udf_b_s2z_1;")
+  expect_match2(scode, "udf_b_s2z_2;")
+  expect_match2(scode, "inv_chi_square_lpdf(udf_b_s2z_1 | 7)")
+  expect_match2(scode, "inv_chi_square_lpdf(udf_b_s2z_2 | 1)")
+  expect_match2(scode, "normal_lpdf(qhat_s2z_1[1]")
+  expect_match2(scode, "normal_lpdf(qhat_s2z_1[2]")
+
+  scode_normal <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)), data = s2z_dat,
+    prior = c(
+      prior(normal(0, 2), class = Intercept),
+      prior(normal(0, 1), class = b)
+    )
+  )
+  expect_false(grepl("udf_b_s2z", scode_normal, fixed = TRUE))
+  expect_match2(scode_normal, "prior_prec_s2z_1[1] = inv_square")
+  expect_match2(scode_normal, "prior_prec_s2z_1[2] = inv_square")
+})
+
+test_that("S2Z keeps all parameter-dependent normalizers", {
+  sc_norm <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)),
+    data = s2z_dat, normalize = TRUE
+  )
+  sc_kernel <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)),
+    data = s2z_dat, normalize = FALSE
+  )
+
+  for (term in c(
+    "N_1 * sum(log(diagonal(L_Sigma_s2z_1)))",
+    "M_1 * sum(log(group_scale_s2z_1))",
+    "sum(log(diagonal(L_P_s2z_1)))"
+  )) {
+    expect_true(grepl(term, sc_norm, fixed = TRUE))
+    expect_true(grepl(term, sc_kernel, fixed = TRUE))
+  }
+  expect_match2(sc_norm, "0.5 * M_1 * log(1.0 * N_1)")
+  expect_false(grepl("log(1.0 * N_1)", sc_kernel, fixed = TRUE))
+})
+
+test_that("s2z FALSE leaves conventional code unchanged", {
+  implicit <- stancode(y ~ x + (1 + x | g), data = s2z_dat)
+  explicit <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = FALSE)), data = s2z_dat
+  )
+  expect_identical(implicit, explicit)
+})
+
+test_that("S2Z blocks can belong to distinct distributional predictors", {
+  form <- bf(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)),
+    sigma ~ z + (1 + z | gr(h, s2z = TRUE))
+  )
+  scode <- stancode(form, data = s2z_dat)
+
+  expect_match2(scode, "vector[2] theta_s2z;")
+  expect_match2(scode, "vector[2] theta_s2z_sigma;")
+  expect_match2(scode, "matrix[N_1, M_1] r_s2z_1;")
+  expect_match2(scode, "matrix[N_2, M_2] r_s2z_2;")
+  expect_equal(
+    lengths(regmatches(
+      scode, gregexpr("vector sum_to_zero_constrain_brms", scode, fixed = TRUE)
+    )),
+    1L
+  )
+})
+
+test_that("unsupported S2Z structures fail clearly", {
+  expect_error(
+    stancode(y ~ x + (1 + x + z | gr(g, s2z = TRUE)), s2z_dat),
+    "matching population-level design column"
+  )
+  expect_error(
+    stancode(
+      y ~ x + (1 + x | gr(g, s2z = TRUE)) +
+        (1 + x | gr(h, s2z = TRUE)),
+      s2z_dat
+    ),
+    "Only one marginalized sum-to-zero"
+  )
+  by_dat <- transform(
+    s2z_dat, f_by = factor(rep(c("a", "b"), each = nrow(s2z_dat) / 2))
+  )
+  expect_error(
+    stancode(y ~ x + (1 + x | gr(g, by = f_by, s2z = TRUE)), by_dat),
+    "not yet supported"
+  )
+  expect_error(
+    stancode(y ~ x + (1 + x | gr(g, pw = w, s2z = TRUE)), s2z_dat),
+    "not yet supported"
+  )
+  expect_error(
+    stancode(
+      y ~ x + (1 + x | gr(g, s2z = TRUE)), s2z_dat,
+      sample_prior = "yes"
+    ),
+    "sample_prior"
+  )
+  expect_error(
+    stancode(
+      y ~ x + (1 + x | gr(g, s2z = TRUE)), s2z_dat,
+      prior = prior(laplace(0, 1), class = b, coef = x)
+    ),
+    "not supported by the marginalized"
+  )
+  expect_error(
+    stancode(
+      y ~ x + (1 + x | gr(g, s2z = TRUE)), s2z_dat,
+      prior = prior(constant(0), class = sd)
+    ),
+    "standard deviations fixed with 'constant' must be positive"
+  )
+  expect_match2(
+    stancode(
+      y ~ x + (1 + x | gr(g, s2z = TRUE)), s2z_dat,
+      prior = prior(constant(1), class = sd)
+    ),
+    "vector<lower=0>[M_1] sd_1;"
+  )
+  ordered_mix <- bf(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)),
+    family = mixture(gaussian, gaussian, order = "mu")
+  )
+  expect_error(
+    stancode(ordered_mix, s2z_dat),
+    "Ordered mixture intercepts are not yet supported"
+  )
+  one_group <- transform(s2z_dat, g = factor("only"))
+  expect_error(
+    stancode(y ~ x + (1 + x | gr(g, s2z = TRUE)), one_group),
+    "at least two observed grouping levels"
+  )
+})

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -261,7 +261,177 @@ test_that("S2Z supports correlated and diagonal Gaussian effects", {
   expect_match2(sc_cor, "diag_pre_multiply(sd_1, L_1)")
   expect_match2(sc_cor, "corr_matrix[M_1] Cor_1")
   expect_false(grepl("cholesky_factor_corr[M_1] L_1;", sc_diag, fixed = TRUE))
-  expect_match2(sc_diag, "L_Sigma_s2z_1 = diag_matrix(sd_1);")
+  expect_match2(sc_diag, "D_diag_s2z_1")
+  expect_match2(sc_diag, "rank1_info_s2z_1")
+  expect_false(grepl("L_Sigma_s2z_1", sc_diag, fixed = TRUE))
+})
+
+test_that("independent S2Z specializes centered slopes and interactions", {
+  form <- y ~ x * z + (1 + x * z || gr(g, s2z = TRUE))
+  scode <- stancode(
+    form, data = s2z_dat,
+    prior = prior(normal(0, 2), class = Intercept) +
+      prior(normal(0, 1.5), class = b)
+  )
+  sdata <- standata(form, data = s2z_dat)
+
+  expect_equal(sdata$M_1, 4)
+  expect_match2(scode, "array[M_1] vector[N_1 - 1] z_s2z_1;")
+  for (k in seq_len(sdata$M_1)) {
+    expect_match2(scode, sprintf("vector[N_1] r_s2z_1_%s;", k))
+    expect_match2(
+      scode,
+      sprintf(
+        "r_s2z_1_%1$s = sum_to_zero_constrain_brms(z_s2z_1[%1$s]);",
+        k
+      )
+    )
+  }
+  expect_match2(scode, "intercept_map_s2z_1[1] = 1.0;")
+  expect_match2(scode, "intercept_map_s2z_1[2] = means_X[1];")
+  expect_match2(scode, "intercept_map_s2z_1[3] = means_X[2];")
+  expect_match2(scode, "intercept_map_s2z_1[4] = means_X[3];")
+  expect_match2(
+    scode,
+    "D_diag_s2z_1 = group_info_s2z + square(sd_1) .* base_info_s2z;"
+  )
+  expect_match2(scode, "real group_info_s2z = N_1;")
+  expect_false(grepl("group_scale_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("group_prec_s2z_1", scode, fixed = TRUE))
+  expect_match2(
+    scode,
+    "rank1_info_s2z_1 = prior_prec_s2z_1[1] * dot_product("
+  )
+  expect_match2(scode, "- 0.5 * sum(log(D_diag_s2z_1))")
+  expect_match2(scode, "- 0.5 * log1p(rank1_info_s2z_1)")
+  expect_match2(scode, "+ 0.5 * M_1 * log(1.0 * N_1)")
+  expect_match2(scode, "real sqrt_rank1_s2z")
+  expect_match2(scode, "real rank1_adjust_s2z;")
+  expect_match2(
+    scode,
+    "q_recovered_s2z_1[1] -= dot_product(intercept_map_s2z_1"
+  )
+  expect_match2(scode, "r_1_4 = r_s2z_1_4 + mean_r_s2z_1[4];")
+  expect_false(grepl("corr_matrix[M_1] Cor_1", scode, fixed = TRUE))
+
+  # The independent specialization must be O(K): no dense K by K storage,
+  # factorization, or positive-definite solve is emitted anywhere in the block.
+  for (term in c(
+    "matrix[N_1, M_1] r_s2z_1;",
+    "matrix[M_1, M_1]",
+    "L_Sigma_s2z_1",
+    "Q_Sigma_s2z_1",
+    "P_s2z_1",
+    "L_P_s2z_1",
+    "cholesky_decompose(",
+    "mdivide_left_spd(",
+    "mdivide_left_tri_low(",
+    "mdivide_right_tri_low("
+  )) {
+    expect_false(grepl(term, scode, fixed = TRUE), info = term)
+  }
+})
+
+test_that("independent S2Z uses H identity for ten no-intercept effects", {
+  ten_dat <- data.frame(
+    y = seq(-1, 1, length.out = 80),
+    ten = factor(rep(letters[1:10], 8)),
+    g = factor(rep(seq_len(8), each = 10))
+  )
+  form <- y ~ 0 + ten + (0 + ten || gr(g, s2z = TRUE))
+  scode <- stancode(
+    form, data = ten_dat,
+    prior = prior(normal(0, 2), class = b), normalize = FALSE
+  )
+  sdata <- standata(form, data = ten_dat)
+
+  expect_equal(sdata$M_1, 10)
+  expect_equal(sdata$K, 10)
+  expect_match2(scode, "vector[10] theta_s2z;")
+  expect_match2(scode, "intercept_map_s2z_1 = rep_vector(0.0, M_1);")
+  expect_false(grepl("intercept_map_s2z_1[1] =", scode, fixed = TRUE))
+  expect_match2(scode, "rank1_info_s2z_1 = 0.0 * dot_product(")
+  for (k in seq_len(10L)) {
+    expect_match2(
+      scode,
+      sprintf("base_info_s2z[%1$s] = prior_prec_s2z_1[%1$s];", k)
+    )
+    expect_match2(
+      scode,
+      sprintf("qhat_s2z_1[%1$s] -= mhat_s2z_1[%1$s];", k)
+    )
+    expect_match2(
+      scode,
+      sprintf(
+        "q_recovered_s2z_1[%1$s] -= mean_r_s2z_1[%1$s];", k
+      )
+    )
+  }
+  expect_match2(scode, "b = q_recovered_s2z_1;")
+  expect_false(grepl("real b_Intercept;", scode, fixed = TRUE))
+  expect_false(grepl("matrix[M_1, M_1]", scode, fixed = TRUE))
+  expect_false(grepl("cholesky_decompose(", scode, fixed = TRUE))
+  expect_false(grepl("mdivide_left_spd(", scode, fixed = TRUE))
+  expect_false(grepl("log(1.0 * N_1)", scode, fixed = TRUE))
+})
+
+test_that("independent Student S2Z retains weighted scales unnormalized", {
+  scode <- stancode(
+    y ~ x * z +
+      (1 + x * z || gr(g, dist = "student", s2z = TRUE)),
+    data = s2z_dat, normalize = FALSE
+  )
+
+  expect_match2(scode, "group_scale_s2z_1 = dfm_1;")
+  expect_match2(
+    scode,
+    "group_prec_s2z_1 = inv_square(group_scale_s2z_1);"
+  )
+  expect_match2(scode, "real group_info_s2z = sum(group_prec_s2z_1);")
+  for (k in seq_len(4L)) {
+    expect_match2(
+      scode,
+      sprintf(
+        "dot_product(r_s2z_1_%s, group_prec_s2z_1)", k
+      )
+    )
+  }
+  expect_match2(scode, "- M_1 * sum(log(group_scale_s2z_1))")
+  expect_match2(scode, "- (N_1 - 1) * sum(log(sd_1))")
+  expect_match2(scode, "- 0.5 * sum(log(D_diag_s2z_1))")
+  expect_match2(scode, "- 0.5 * log1p(rank1_info_s2z_1)")
+  expect_false(grepl("log(1.0 * N_1)", scode, fixed = TRUE))
+  expect_false(grepl("matrix[M_1, M_1]", scode, fixed = TRUE))
+  expect_false(grepl("cholesky_decompose(", scode, fixed = TRUE))
+  expect_false(grepl("mdivide_left_spd(", scode, fixed = TRUE))
+  expect_false(grepl("mdivide_left_tri_low(", scode, fixed = TRUE))
+  expect_false(grepl("mdivide_right_tri_low(", scode, fixed = TRUE))
+})
+
+test_that("independent S2Z handles slope subsets and heavy-tailed priors", {
+  form <- y ~ x * z + (0 + x + x:z || gr(g, s2z = TRUE))
+  bprior <- c(
+    prior(cauchy(0, 1), class = Intercept),
+    prior(student_t(5, 0, 1.5), class = b, coef = x),
+    prior(normal(0, 2), class = b, coef = "x:z"),
+    prior(constant(0.4), class = sd, group = g, coef = x),
+    prior(constant(0.7), class = sd, group = g, coef = "x:z")
+  )
+  scode <- stancode(form, data = s2z_dat, prior = bprior)
+  sdata <- standata(form, data = s2z_dat, prior = bprior)
+
+  expect_equal(sdata$M_1, 2)
+  expect_equal(sdata$Kc, 3)
+  expect_match2(scode, "intercept_map_s2z_1[1] = means_X[1];")
+  expect_match2(scode, "intercept_map_s2z_1[2] = means_X[3];")
+  expect_match2(scode, "base_info_s2z[1] = prior_prec_s2z_1[2];")
+  expect_match2(scode, "base_info_s2z[2] = prior_prec_s2z_1[4];")
+  expect_match2(scode, "qhat_s2z_1[2] -= mhat_s2z_1[1];")
+  expect_match2(scode, "qhat_s2z_1[4] -= mhat_s2z_1[2];")
+  expect_false(grepl("qhat_s2z_1[3] -=", scode, fixed = TRUE))
+  expect_match2(scode, "inv_chi_square_lpdf(udf_b_s2z_1 | 1)")
+  expect_match2(scode, "inv_chi_square_lpdf(udf_b_s2z_2 | 5)")
+  expect_false(grepl("matrix[M_1, M_1]", scode, fixed = TRUE))
 })
 
 test_that("S2Z preserves ordinary priors on every varying effect", {

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -1069,7 +1069,7 @@ test_that("split same-ID S2Z terms validate every constituent", {
       (0 + x | gr(g, id = "split", s2z = TRUE, by = f_by))
   )
   for (form in split_by) {
-    expect_error(stancode(form, data = by_dat), "'by', 'cov', and 'pw'")
+    expect_error(stancode(form, data = by_dat), "Argument 'by'")
   }
 
   split_pw <- list(
@@ -1081,7 +1081,7 @@ test_that("split same-ID S2Z terms validate every constituent", {
       (0 + x | gr(g, id = "split", s2z = TRUE, pw = w))
   )
   for (form in split_pw) {
-    expect_error(stancode(form, data = s2z_dat), "'by', 'cov', and 'pw'")
+    expect_error(stancode(form, data = s2z_dat), "Argument 'pw'")
   }
 
   covariance <- diag(nlevels(s2z_dat$g))
@@ -1099,7 +1099,7 @@ test_that("split same-ID S2Z terms validate every constituent", {
       stancode(
         form, data = s2z_dat, data2 = list(covariance = covariance)
       ),
-      "'by', 'cov', and 'pw'"
+      "Argument 'cov'"
     )
   }
 

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -1,4 +1,4 @@
-context("Tests for marginalized sum-to-zero group-level effects")
+context("Tests for physical sum-to-zero group-level effects")
 
 expect_match2 <- brms:::expect_match2
 
@@ -473,7 +473,7 @@ test_that("S2Z preserves ordinary priors on every varying effect", {
   expect_match2(student_code, "inv_chi_square_lpdf(udf_1 | df_1)")
 })
 
-test_that("S2Z handles Student-t effects by conditional marginalization", {
+test_that("S2Z handles Student-t effects by conditional Gaussian integration", {
   scode <- stancode(
     y ~ x + (1 + x | gr(g, dist = "student", s2z = TRUE)),
     data = s2z_dat
@@ -575,7 +575,7 @@ test_that("unsupported S2Z structures fail clearly", {
         (1 + x | gr(h, s2z = TRUE)),
       s2z_dat
     ),
-    "Only one marginalized sum-to-zero"
+    "Only one sum-to-zero"
   )
   by_dat <- transform(
     s2z_dat, f_by = factor(rep(c("a", "b"), each = nrow(s2z_dat) / 2))
@@ -600,7 +600,7 @@ test_that("unsupported S2Z structures fail clearly", {
       y ~ x + (1 + x | gr(g, s2z = TRUE)), s2z_dat,
       prior = prior(laplace(0, 1), class = b, coef = x)
     ),
-    "not supported by the marginalized"
+    "not supported by the sum-to-zero"
   )
   expect_error(
     stancode(

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -16,6 +16,189 @@ s2z_dat <- local({
   )
 })
 
+test_that("S2Z uses the dedicated Gaussian scalar kernel", {
+  form <- y ~ 1 + (1 | gr(g, s2z = TRUE))
+  scode <- stancode(
+    form, data = s2z_dat,
+    prior = prior(normal(0, 2), class = Intercept)
+  )
+  sdata <- standata(form, data = s2z_dat)
+
+  expect_equal(sdata$M_1, 1)
+  expect_match2(scode, "vector[N_1 - 1] z_s2z_1;")
+  expect_match2(scode, "vector[N_1] r_s2z_1_1;")
+  expect_match2(scode, "vector[1] H_s2z_1;")
+  expect_match2(scode, "real<lower=0> D_s2z_1;")
+  expect_match2(scode, "real<lower=0> sqrt_D_s2z_1;")
+  expect_match2(scode, "real mhat_s2z_1;")
+  expect_match2(scode, "vector[N_1] white_s2z_1;")
+  expect_match2(
+    scode,
+    "r_s2z_1_1 = sum_to_zero_constrain_brms(z_s2z_1);"
+  )
+  expect_match2(
+    scode,
+    "D_s2z_1 = tau_sq_s2z * prior_info_s2z + N_1;"
+  )
+  expect_false(grepl(
+    "dot_product(r_s2z_1_1, group_prec_s2z_1)", scode, fixed = TRUE
+  ))
+  expect_false(grepl("group_scale_s2z_1", scode, fixed = TRUE))
+  expect_false(grepl("group_prec_s2z_1", scode, fixed = TRUE))
+  expect_match2(scode, "- (N_1 - 1) * log(sd_1[1])")
+  expect_match2(scode, "- 0.5 * log(D_s2z_1)")
+  expect_match2(scode, "+ 0.5 * log(1.0 * N_1)")
+
+  # The scalar branch must not instantiate one-by-one matrix factorizations.
+  for (term in c(
+    "array[M_1] vector[N_1 - 1] z_s2z_1;",
+    "matrix[N_1, M_1] r_s2z_1;",
+    "matrix[M_1, M_1] Q_Sigma_s2z_1;",
+    "cholesky_decompose(P_s2z_1)",
+    "mdivide_left_spd(P_s2z_1",
+    "mdivide_left_tri_low(L_Sigma_s2z_1"
+  )) {
+    expect_false(grepl(term, scode, fixed = TRUE))
+  }
+
+  expect_match2(scode, "real mean_r_s2z_1;")
+  expect_match2(
+    scode,
+    paste0(
+      "mean_r_s2z_1 = mhat_s2z_1 + sd_1[1] * std_normal_rng() / ",
+      "sqrt_D_s2z_1;"
+    )
+  )
+  expect_match2(
+    scode,
+    "r_1_1 = r_s2z_1_1 + mean_r_s2z_1;"
+  )
+  expect_match2(scode, "Intercept = q_recovered_s2z_1[1];")
+  expect_match2(scode, "b_Intercept = Intercept;")
+})
+
+test_that("S2Z scalar kernel handles Student group scales exactly", {
+  scode <- stancode(
+    y ~ 1 + (1 | gr(g, dist = "student", s2z = TRUE)),
+    data = s2z_dat,
+    prior = prior(normal(0, 2), class = Intercept)
+  )
+
+  expect_match2(scode, "vector<lower=0>[N_1] udf_1;")
+  expect_match2(scode, "group_scale_s2z_1 = dfm_1;")
+  expect_match2(
+    scode,
+    paste0(
+      "D_s2z_1 = tau_sq_s2z * prior_info_s2z + ",
+      "sum(group_prec_s2z_1);"
+    )
+  )
+  expect_match2(
+    scode,
+    "dot_product(r_s2z_1_1, group_prec_s2z_1)"
+  )
+  expect_match2(scode, "- sum(log(group_scale_s2z_1))")
+  expect_match2(scode, "inv_chi_square_lpdf(udf_1 | df_1)")
+  expect_false(grepl("matrix[M_1, M_1] P_s2z_1;", scode, fixed = TRUE))
+})
+
+test_that("S2Z scalar kernel handles a varying slope without an intercept", {
+  form <- y ~ 0 + x + (0 + x | gr(g, s2z = TRUE))
+  scode <- stancode(
+    form, data = s2z_dat,
+    prior = prior(normal(0, 2), class = b, coef = x)
+  )
+  sdata <- standata(form, data = s2z_dat)
+
+  expect_equal(sdata$M_1, 1)
+  expect_match2(scode, "vector[N_1 - 1] z_s2z_1;")
+  expect_match2(scode, "H_s2z_1[1] = 1.0;")
+  expect_match2(
+    scode,
+    "normal_id_glm_lpdf(Y | X, mu, theta_s2z, sigma)"
+  )
+  expect_match2(scode, "vector[1] b;")
+  expect_match2(scode, "b = q_recovered_s2z_1;")
+  expect_match2(scode, "vector[N_1] r_1_1;")
+  expect_false(grepl("real b_Intercept;", scode, fixed = TRUE))
+})
+
+test_that("S2Z scalar kernel maps a centered varying interaction", {
+  form <- y ~ x * z + (0 + x:z | gr(g, s2z = TRUE))
+  scode <- stancode(
+    form, data = s2z_dat,
+    prior = prior(normal(0, 2), class = b)
+  )
+  sdata <- standata(form, data = s2z_dat)
+
+  expect_equal(sdata$M_1, 1)
+  expect_equal(sdata$Kc, 3)
+  expect_match2(scode, "vector[4] H_s2z_1;")
+  expect_match2(scode, "H_s2z_1[4] = 1.0;")
+  expect_match2(scode, "H_s2z_1[1] = means_X[3];")
+  expect_match2(
+    scode,
+    "normal_id_glm_lpdf(Y | Xc, mu, tail(theta_s2z, 3), sigma)"
+  )
+})
+
+test_that("S2Z scalar fixed SD and unnormalized code retain the kernel", {
+  form <- y ~ 1 + (1 | gr(g, s2z = TRUE))
+  bprior <- prior(normal(0, 2), class = Intercept) +
+    prior(constant(1.25), class = sd)
+  scode <- stancode(
+    form, data = s2z_dat, prior = bprior, normalize = FALSE
+  )
+
+  expect_match2(scode, "sd_1 = rep_vector(1.25, rows(sd_1));")
+  expect_equal(
+    unname(lengths(regmatches(
+      scode,
+      gregexpr(
+        "sd_1 = rep_vector(1.25, rows(sd_1));", scode, fixed = TRUE
+      )
+    ))),
+    1L
+  )
+  expect_match2(scode, "real tau_sq_s2z = square(sd_1[1]);")
+  expect_match2(scode, "- (N_1 - 1) * log(sd_1[1])")
+  expect_match2(scode, "- 0.5 * log(D_s2z_1)")
+  expect_false(grepl("log(1.0 * N_1)", scode, fixed = TRUE))
+  expect_false(grepl(
+    "+ 0.5 * log(2 * pi())", scode, fixed = TRUE
+  ))
+  expect_error(
+    stancode(
+      form, data = s2z_dat,
+      prior = prior(constant(0), class = sd)
+    ),
+    "standard deviations fixed with 'constant' must be positive"
+  )
+})
+
+test_that("threaded S2Z scalar likelihood receives the internal vector", {
+  scode <- stancode(
+    y ~ 1 + (1 | gr(g, s2z = TRUE)), data = s2z_dat,
+    threads = threading(2), parse = FALSE
+  )
+
+  expect_match2(
+    scode,
+    paste0(
+      "real partial_log_lik_lpmf(array[] int seq, int start, int end, ",
+      "data vector Y, vector theta_s2z, real sigma, data array[] int J_1, ",
+      "data vector Z_1_1, vector r_s2z_1_1)"
+    )
+  )
+  expect_match2(
+    scode,
+    paste0(
+      "target += reduce_sum(partial_log_lik_lpmf, seq, grainsize, Y, ",
+      "theta_s2z, sigma, J_1, Z_1_1, r_s2z_1_1);"
+    )
+  )
+})
+
 test_that("S2Z Stan code covers intercepts, slopes, and interactions", {
   scode <- stancode(
     y ~ x * z + (1 + x * z | gr(g, s2z = TRUE)), data = s2z_dat

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -264,6 +264,45 @@ test_that("S2Z supports correlated and diagonal Gaussian effects", {
   expect_match2(sc_diag, "L_Sigma_s2z_1 = diag_matrix(sd_1);")
 })
 
+test_that("S2Z preserves ordinary priors on every varying effect", {
+  form <- y ~ x * z + (1 + x * z | gr(g, s2z = TRUE))
+  varying_priors <- c(
+    prior(exponential(2), class = "sd", group = "g", coef = "Intercept"),
+    prior(normal(0, 0.4), class = "sd", group = "g", coef = "x"),
+    prior(student_t(4, 0, 0.3), class = "sd", group = "g", coef = "z"),
+    prior(exponential(3), class = "sd", group = "g", coef = "x:z"),
+    prior(lkj(4), class = "cor", group = "g")
+  )
+  available <- as.data.frame(get_prior(form, data = s2z_dat))
+  group_sd <- subset(
+    available, class == "sd" & group == "g" & nzchar(coef)
+  )
+  expect_setequal(
+    group_sd$coef, c("Intercept", "x", "z", "x:z")
+  )
+
+  scode <- stancode(form, data = s2z_dat, prior = varying_priors)
+  expect_match2(scode, "exponential_lpdf(sd_1[1] | 2)")
+  expect_match2(scode, "normal_lpdf(sd_1[2] | 0, 0.4)")
+  expect_match2(scode, "student_t_lpdf(sd_1[3] | 4, 0, 0.3)")
+  expect_match2(scode, "exponential_lpdf(sd_1[4] | 3)")
+  expect_match2(scode, "lkj_corr_cholesky_lpdf(L_1 | 4)")
+
+  scalar_code <- stancode(
+    y ~ 0 + x + (0 + x | gr(g, s2z = TRUE)), data = s2z_dat,
+    prior = prior(exponential(7), class = "sd", group = "g", coef = "x")
+  )
+  expect_match2(scalar_code, "exponential_lpdf(sd_1[1] | 7)")
+
+  student_code <- stancode(
+    y ~ x + (1 + x | gr(g, dist = "student", s2z = TRUE)),
+    data = s2z_dat,
+    prior = prior(gamma(3, 0.25), class = "df", group = "g")
+  )
+  expect_match2(student_code, "gamma_lpdf(df_1 | 3, 0.25)")
+  expect_match2(student_code, "inv_chi_square_lpdf(udf_1 | df_1)")
+})
+
 test_that("S2Z handles Student-t effects by conditional marginalization", {
   scode <- stancode(
     y ~ x + (1 + x | gr(g, dist = "student", s2z = TRUE)),

--- a/tests/testthat/tests.s2z-code.R
+++ b/tests/testthat/tests.s2z-code.R
@@ -37,7 +37,8 @@ test_that("S2Z uses the dedicated Gaussian scalar kernel", {
   expect_match2(scode, "real<lower=0> D_s2z_1;")
   expect_match2(scode, "real<lower=0> sqrt_D_s2z_1;")
   expect_match2(scode, "real mhat_s2z_1;")
-  expect_match2(scode, "vector[N_1] white_s2z_1;")
+  expect_match2(scode, "real<lower=0> group_quad_s2z_1;")
+  expect_match2(scode, "vector[N_1] white_s2z =")
   expect_match2(
     scode,
     "r_s2z_1_1 = sum_to_zero_constrain_brms(z_s2z_1);"
@@ -215,7 +216,7 @@ test_that("S2Z Stan code covers intercepts, slopes, and interactions", {
 
   expect_equal(sdata$M_1, 4)
   expect_equal(sdata$NC_1, 6)
-  expect_match2(scode, "array[M_1] vector[N_1 - 1] z_s2z_1;")
+  expect_match2(scode, "vector[M_1 * (N_1 - 1)] z_s2z_1;")
   expect_match2(scode, "matrix[N_1, M_1] r_s2z_1;")
   expect_match2(scode, "H_s2z_1[1, 2] = means_X[1];")
   expect_match2(scode, "H_s2z_1[1, 3] = means_X[2];")
@@ -227,7 +228,8 @@ test_that("S2Z Stan code covers intercepts, slopes, and interactions", {
     "normal_id_glm_lpdf(Y | Xc, mu, tail(theta_s2z, 3), sigma)"
   )
   expect_match2(scode, "q_recovered_s2z_1 = theta_s2z")
-  expect_match2(scode, "r_1 = r_s2z_1 + rep_matrix(mean_r_s2z_1'")
+  expect_match2(scode, "r_1 = r_s2z_1;")
+  expect_match2(scode, "for (j in 1:N_1) r_1[j] += mean_r_s2z_1';")
   expect_match2(scode, "b_Intercept = Intercept - dot_product(means_X, b)")
   expect_true(grepl("normal_id_glm", scode, fixed = TRUE))
 })
@@ -282,13 +284,16 @@ test_that("independent S2Z specializes centered slopes and interactions", {
   sdata <- standata(form, data = s2z_dat)
 
   expect_equal(sdata$M_1, 4)
-  expect_match2(scode, "array[M_1] vector[N_1 - 1] z_s2z_1;")
+  expect_match2(scode, "vector[M_1 * (N_1 - 1)] z_s2z_1;")
   for (k in seq_len(sdata$M_1)) {
     expect_match2(scode, sprintf("vector[N_1] r_s2z_1_%s;", k))
     expect_match2(
       scode,
       sprintf(
-        "r_s2z_1_%1$s = sum_to_zero_constrain_brms(z_s2z_1[%1$s]);",
+        paste0(
+          "r_s2z_1_%1$s = sum_to_zero_constrain_brms(segment(z_s2z_1, ",
+          "(%1$s - 1) * (N_1 - 1) + 1, N_1 - 1));"
+        ),
         k
       )
     )
@@ -354,7 +359,7 @@ test_that("independent S2Z uses H identity for ten no-intercept effects", {
   expect_equal(sdata$M_1, 10)
   expect_equal(sdata$K, 10)
   expect_match2(scode, "vector[10] theta_s2z;")
-  expect_match2(scode, "intercept_map_s2z_1 = rep_vector(0.0, M_1);")
+  expect_match2(scode, "intercept_map_s2z_1 = zeros_vector(M_1);")
   expect_false(grepl("intercept_map_s2z_1[1] =", scode, fixed = TRUE))
   expect_match2(scode, "rank1_info_s2z_1 = 0.0 * dot_product(")
   for (k in seq_len(10L)) {
@@ -657,7 +662,7 @@ test_that("Matheron supports overlapping physical S2Z blocks", {
     "mean_r_s2z_1 += L_Sigma_s2z_1 *",
     "mean_r_s2z_2 += L_Sigma_s2z_2 *",
     "mean_r_s2z_3 += L_Sigma_s2z_3 *",
-    "r_s2z_3 ./ rep_matrix(sd_3', N_3)",
+    "r_s2z_3[, k] / sd_3[k]",
     "q_recovered_s2z_1 = theta_s2z;"
   )) {
     expect_true(grepl(term, scode, fixed = TRUE), info = term)
@@ -710,26 +715,23 @@ test_that("proper population coordinates outside group maps score independently"
   expect_match2(scode, "// fast Gaussian Matheron system")
   expect_match2(scode, "real<lower=0> W_matheron_s2z_1;")
   expect_false(grepl("matrix[2, 2] P_s2z_1", scode, fixed = TRUE))
-  expect_equal(
-    s2z_count_fixed(
-      scode,
-      paste0(
-        "normal_lpdf(theta_s2z[2] | prior_mean_s2z_1[2], ",
-        "prior_scale_s2z_1[2])"
-      )
-    ),
-    1L
+  expect_match2(
+    scode,
+    "vector[1] theta_s2z_active;  // S2Z-active finite-population coefficients"
+  )
+  expect_match2(
+    scode,
+    "vector[2] fixed_s2z;  // S2Z-inactive regression coefficients"
   )
   expect_equal(
     s2z_count_fixed(
       scode,
-      paste0(
-        "normal_lpdf(theta_s2z[3] | prior_mean_s2z_1[3], ",
-        "prior_scale_s2z_1[3])"
-      )
+      "normal_lpdf(fixed_s2z | -0.1, 0.7)"
     ),
     1L
   )
+  expect_match2(scode, "theta_s2z[2] = fixed_s2z[1];")
+  expect_match2(scode, "theta_s2z[3] = fixed_s2z[2];")
   expect_false(grepl("normal_lpdf(theta_s2z[1]", scode, fixed = TRUE))
   expect_match2(scode, "theta_s2z[1] - prior_mean_s2z_1[1]")
 })
@@ -844,7 +846,8 @@ test_that("independent and correlated interaction blocks stay specialized", {
     "- (N_2 - 1) * sum(log(diagonal(L_Sigma_s2z_2)))",
     "r_1_1 = r_s2z_1_1 + mean_r_s2z_1[1];",
     "r_1_4 = r_s2z_1_4 + mean_r_s2z_1[4];",
-    "r_2 = r_s2z_2 + rep_matrix(mean_r_s2z_2', N_2);",
+    "r_2 = r_s2z_2;",
+    "for (j in 1:N_2) r_2[j] += mean_r_s2z_2';",
     "vector[Kc] b;",
     "b = tail(q_recovered_s2z_1, Kc);"
   )) {
@@ -857,10 +860,7 @@ test_that("independent and correlated interaction blocks stay specialized", {
   ))
   expect_match2(
     scode,
-    paste0(
-      "matrix[N_1, M_1] white_group_s2z = r_s2z_1 ./ ",
-      "rep_matrix(sd_1', N_1);"
-    )
+    "vector[N_1] white_group_s2z = r_s2z_1[, k] / sd_1[k];"
   )
   expect_false(grepl("corr_matrix[M_1] Cor_1", scode, fixed = TRUE))
   expect_match2(scode, "corr_matrix[M_2] Cor_2")
@@ -905,8 +905,8 @@ test_that("Gaussian and Student blocks contribute separately to one solve", {
     "sum(group_prec_s2z_2), M_2));",
     "h_group_s2z_2 = -white_group_s2z * group_prec_s2z_2;",
     "- M_2 * sum(log(group_scale_s2z_2))",
-    "P_s2z_1[1:2, 1:2] = P_group_s2z_1;",
-    "P_s2z_1[3:4, 3:4] = P_group_s2z_2;"
+    "P_s2z_1[1:2, 1:2] += P_group_s2z_1;",
+    "P_s2z_1[3:4, 3:4] += P_group_s2z_2;"
   )) {
     expect_true(grepl(term, scode, fixed = TRUE), info = term)
   }
@@ -996,6 +996,37 @@ test_that("joint S2Z implementation details follow save_pars", {
     expect_true(name %in% default_excluded, info = name)
     expect_false(name %in% saved_excluded, info = name)
   }
+})
+
+test_that("fixed-only S2Z internals stay out of public coefficient discovery", {
+  form <- y ~ x + z + (1 + x | gr(g, s2z = TRUE))
+  default_fit <- brm(form, data = s2z_dat, empty = TRUE)
+  saved_fit <- brm(
+    form, data = s2z_dat, empty = TRUE,
+    save_pars = save_pars(all = TRUE)
+  )
+  default_excluded <- unlist(
+    brms:::exclude_pars(default_fit), use.names = FALSE
+  )
+  saved_excluded <- unlist(
+    brms:::exclude_pars(saved_fit), use.names = FALSE
+  )
+
+  internal <- c(
+    "theta_s2z", "theta_s2z_active", "fixed_s2z",
+    "zfixed_s2z", "sdfixed_s2z", "par_fixed_s2z_1"
+  )
+  expect_true(all(internal %in% default_excluded))
+  expect_false(any(internal %in% saved_excluded))
+
+  draw_names <- c(
+    "b_Intercept", "b_x", "b_z", "fixed_s2z[1]",
+    "zfixed_s2z[1]", "sdfixed_s2z[1]", "par_fixed_s2z_1"
+  )
+  expect_identical(
+    draw_names[grepl(brms:::fixef_pars(), draw_names)],
+    c("b_Intercept", "b_x", "b_z")
+  )
 })
 
 test_that("split same-ID S2Z terms validate every constituent", {
@@ -1114,7 +1145,7 @@ test_that("unsupported S2Z structures fail clearly", {
   expect_error(
     stancode(
       y ~ x + (1 + x | gr(g, s2z = TRUE)), s2z_dat,
-      prior = prior(laplace(0, 1), class = b, coef = x)
+      prior = prior(double_exponential(0, 1), class = b, coef = x)
     ),
     "not supported by the sum-to-zero"
   )

--- a/tests/testthat/tests.s2z-optimizations.R
+++ b/tests/testthat/tests.s2z-optimizations.R
@@ -1,0 +1,291 @@
+context("Allocation-safe physical S2Z Stan code")
+
+expect_match2 <- brms:::expect_match2
+
+s2z_opt_dat <- local({
+  set.seed(6129)
+  n <- 72L
+  data.frame(
+    y = rnorm(n),
+    x = seq(-1.5, 2.5, length.out = n),
+    z = rep(c(-0.75, 1.25), length.out = n),
+    g = factor(rep(seq_len(6L), each = 12L)),
+    h = factor(rep(seq_len(8L), each = 9L))
+  )
+})
+
+s2z_fixed_position <- function(code, pattern) {
+  out <- regexpr(pattern, code, fixed = TRUE)[1]
+  expect_gt(out, 0L)
+  out
+}
+
+test_that("fixed S2Z maps live in transformed data", {
+  code <- stancode(
+    y ~ x + z + (1 + x + z | gr(g, s2z = TRUE)),
+    data = s2z_opt_dat
+  )
+
+  means_pos <- s2z_fixed_position(
+    code, "means_X[i - 1] = mean(X[, i]);"
+  )
+  map_pos <- s2z_fixed_position(
+    code, "H_s2z_1[1, 2] = means_X[1];"
+  )
+  par_pos <- s2z_fixed_position(code, "\nparameters {\n")
+  expect_lt(means_pos, map_pos)
+  expect_lt(map_pos, par_pos)
+  expect_match2(code, "matrix[3, M_1] H_s2z_1;")
+
+  expect_match2(
+    code, "vector[M_1 * (N_1 - 1)] z_s2z_1;"
+  )
+  expect_match2(
+    code,
+    paste0(
+      "segment(z_s2z_1, (k - 1) * (N_1 - 1) + 1, ",
+      "N_1 - 1)"
+    )
+  )
+  expect_false(grepl(
+    "array[M_1] vector[N_1 - 1] z_s2z_1;", code, fixed = TRUE
+  ))
+  expect_match2(code, "vector[M_1] mean_white_s2z =")
+  expect_false(grepl(
+    "r_s2z_1 + rep_matrix(mhat_s2z_1'", code, fixed = TRUE
+  ))
+})
+
+test_that("scalar and independent kernels localize fixed and white work", {
+  scalar <- stancode(
+    y ~ 1 + (1 | gr(g, s2z = TRUE)), data = s2z_opt_dat,
+    prior = prior(normal(0, 2), class = Intercept)
+  )
+  scalar_par <- s2z_fixed_position(scalar, "\nparameters {\n")
+  expect_lt(
+    s2z_fixed_position(scalar, "vector[1] H_s2z_1;"), scalar_par
+  )
+  expect_match2(scalar, "real<lower=0> group_quad_s2z_1;")
+  expect_match2(scalar, "vector[N_1] white_s2z =")
+  expect_false(grepl(
+    "vector[N_1] white_s2z_1;", scalar, fixed = TRUE
+  ))
+
+  independent <- stancode(
+    y ~ x + z + (1 + x + z || gr(g, s2z = TRUE)),
+    data = s2z_opt_dat
+  )
+  independent_par <- s2z_fixed_position(independent, "\nparameters {\n")
+  expect_lt(
+    s2z_fixed_position(
+      independent, "vector[M_1] intercept_map_s2z_1;"
+    ),
+    independent_par
+  )
+  expect_match2(
+    independent, "intercept_map_s2z_1 = zeros_vector(M_1);"
+  )
+  expect_match2(
+    independent, "vector[M_1 * (N_1 - 1)] z_s2z_1;"
+  )
+  expect_match2(
+    independent,
+    paste0(
+      "segment(z_s2z_1, (1 - 1) * (N_1 - 1) + 1, ",
+      "N_1 - 1)"
+    )
+  )
+  expect_false(grepl(
+    "matrix[N_1, M_1] r_s2z_1;", independent, fixed = TRUE
+  ))
+})
+
+test_that("dense multiblock systems build the prior factor blockwise", {
+  code <- stancode(
+    y ~ x +
+      (1 + x | gr(g, dist = "student", s2z = TRUE)) +
+      (1 + x | gr(h, s2z = TRUE)),
+    data = s2z_opt_dat,
+    prior = prior(normal(0, 1.5), class = Intercept) +
+      prior(normal(0, 0.8), class = b)
+  )
+
+  expect_match2(code, "matrix[2, 4] prior_factor_s2z;")
+  expect_match2(
+    code,
+    paste0(
+      "prior_factor_s2z[, 1:2] = diag_pre_multiply(",
+      "sqrt(prior_prec_s2z_1), H_s2z_1 * L_Sigma_s2z_1);"
+    )
+  )
+  expect_match2(code, "P_s2z_1 = crossprod(prior_factor_s2z);")
+  expect_match2(
+    code, "P_s2z_1[1:2, 1:2] += P_group_s2z_1;"
+  )
+  expect_false(grepl("H_joint_s2z_1", code, fixed = TRUE))
+  expect_match2(code, "q_recovered_s2z_1 = theta_s2z;")
+  expect_match2(
+    code, "q_recovered_s2z_1 -= H_s2z_1 * mean_r_s2z_1;"
+  )
+  expect_match2(code, "for (j in 1:N_1) r_1[j] += mean_r_s2z_1';")
+})
+
+test_that("Matheron kernels use indexed active rows and row recovery", {
+  code <- stancode(
+    y ~ x +
+      (1 + x | gr(g, s2z = TRUE)) +
+      (1 + x | gr(h, s2z = TRUE)),
+    data = s2z_opt_dat,
+    prior = prior(normal(0, 1.5), class = Intercept) +
+      prior(normal(0, 0.8), class = b)
+  )
+
+  expect_match2(
+    code,
+    "diag_matrix(square(prior_scale_s2z_1[{1, 2}]))"
+  )
+  expect_match2(code, "H_s2z_1[{1, 2}, ];")
+  expect_match2(
+    code,
+    "theta_s2z[{1, 2}] - prior_mean_s2z_1[{1, 2}]"
+  )
+  expect_match2(code, "active_score_s2z = zeros_vector(M_1);")
+  expect_match2(code, "for (j in 1:N_1) r_1[j] += mean_r_s2z_1';")
+  expect_false(grepl(
+    "r_1 = r_s2z_1 + rep_matrix(mean_r_s2z_1'", code, fixed = TRUE
+  ))
+})
+
+test_that("Matheron indexing preserves noncontiguous active rows", {
+  code <- stancode(
+    y ~ x * z +
+      (1 + x * z | gr(g, s2z = TRUE)) +
+      (1 + x * z | gr(h, s2z = TRUE)),
+    data = s2z_opt_dat,
+    prior = prior(normal(0, 1.5), class = Intercept) +
+      prior(normal(0, 0.8), class = b, coef = "x:z")
+  )
+
+  expect_match2(
+    code,
+    "diag_matrix(square(prior_scale_s2z_1[{1, 4}]))"
+  )
+  expect_match2(code, "H_s2z_1[{1, 4}, ];")
+  expect_match2(
+    code,
+    "theta_s2z[{1, 4}] - prior_mean_s2z_1[{1, 4}]"
+  )
+  expect_false(grepl("{1, 2}", code, fixed = TRUE))
+})
+
+test_that("exact logistic blocks use the same allocation-safe foundation", {
+  code <- stancode(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)),
+    data = s2z_opt_dat,
+    prior = prior(normal(0, 2), class = Intercept) +
+      prior(logistic(0, 1), class = b)
+  )
+
+  expect_match2(
+    code, "vector[M_1 * (N_1 - 1)] z_s2z_1;"
+  )
+  expect_match2(code, "vector[M_1] z_mean_s2z_1;")
+  expect_lt(
+    s2z_fixed_position(code, "matrix[2, M_1] H_s2z_1;"),
+    s2z_fixed_position(code, "\nparameters {\n")
+  )
+  expect_match2(
+    code,
+    "group_quad_s2z_1 = dot_self(to_vector(white_group_s2z)) + "
+  )
+  expect_match2(code, "logistic_lpdf(q_explicit_s2z_1[2] | 0, 1);")
+  expect_false(grepl("H_joint_s2z_1", code, fixed = TRUE))
+
+  student_code <- stancode(
+    y ~ x + (1 + x | gr(g, dist = "student", s2z = TRUE)),
+    data = s2z_opt_dat,
+    prior = prior(normal(0, 2), class = Intercept) +
+      prior(logistic(0, 1), class = b)
+  )
+  expect_match2(
+    student_code,
+    "group_quad_s2z_1 += group_prec_s2z_1[j] * "
+  )
+  expect_match2(student_code, "vector[M_1] white_level_s2z =")
+})
+
+test_that("fixed-only special priors retain ordinary brms scaling", {
+  form <- y ~ x + z + (1 | gr(g, s2z = TRUE))
+  priors <- list(
+    prior(horseshoe(), class = b) +
+      prior(normal(0, 2), class = Intercept),
+    prior(R2D2(), class = b) +
+      prior(normal(0, 2), class = Intercept)
+  )
+
+  for (bprior in priors) {
+    code <- stancode(form, data = s2z_opt_dat, prior = bprior)
+    sdata <- standata(form, data = s2z_opt_dat, prior = bprior)
+    expect_equal(sdata$Kscales, sdata$Kc)
+    expect_match2(code, "vector[Kc] zfixed_s2z;")
+    expect_match2(code, "vector[Kc] fixed_s2z;")
+    expect_match2(code, "vector<lower=0>[Kc] sdfixed_s2z;")
+    expect_match2(code, "fixed_s2z = zfixed_s2z .* sdfixed_s2z;")
+    expect_match2(code, "theta_s2z[2] = fixed_s2z[1];")
+    expect_false(grepl("b_s2z_inactive", code, fixed = TRUE))
+
+    scale_pos <- s2z_fixed_position(
+      code, "fixed_s2z = zfixed_s2z .* sdfixed_s2z;"
+    )
+    theta_pos <- s2z_fixed_position(
+      code, "theta_s2z[2] = fixed_s2z[1];"
+    )
+    expect_lt(scale_pos, theta_pos)
+  }
+})
+
+test_that("blockwise dense algebra equals the concatenated-map algebra", {
+  set.seed(902)
+  q <- 4L
+  H1 <- matrix(rnorm(q * 2L), q)
+  H2 <- matrix(rnorm(q * 3L), q)
+  L1 <- matrix(c(1.2, 0.1, 0, 0.8), 2L, byrow = TRUE)
+  L2 <- matrix(c(1.1, 0, 0, -0.2, 0.9, 0, 0.1, 0.3, 1.3), 3L,
+               byrow = TRUE)
+  prior_prec <- rexp(q)
+  prior_sqrt <- diag(sqrt(prior_prec), q)
+
+  H_joint <- cbind(H1 %*% L1, H2 %*% L2)
+  old_factor <- prior_sqrt %*% H_joint
+  new_factor <- cbind(
+    prior_sqrt %*% H1 %*% L1,
+    prior_sqrt %*% H2 %*% L2
+  )
+  expect_equal(crossprod(new_factor), crossprod(old_factor), tolerance = 1e-12)
+
+  theta <- rnorm(q)
+  mean_white <- rnorm(5L)
+  old_q <- theta - H_joint %*% mean_white
+  new_q <- theta - H1 %*% (L1 %*% mean_white[1:2]) -
+    H2 %*% (L2 %*% mean_white[3:5])
+  expect_equal(drop(new_q), drop(old_q), tolerance = 1e-12)
+})
+
+test_that("explicit Gaussian quadratic shortcut preserves the target", {
+  set.seed(1803)
+  N <- 9L
+  M <- 3L
+  raw <- matrix(rnorm(N * M), N, M)
+  contrasts <- sweep(raw, 2L, colMeans(raw))
+  L <- matrix(c(1.2, 0, 0, 0.1, 0.8, 0, -0.2, 0.3, 1.1), M,
+              byrow = TRUE)
+  z_mean <- rnorm(M)
+  white <- solve(L, t(contrasts))
+  mean_white <- z_mean / sqrt(N)
+
+  loop_quad <- sum(vapply(seq_len(N), function(j) {
+    sum((white[, j] + mean_white)^2)
+  }, numeric(1)))
+  shortcut_quad <- sum(white^2) + sum(z_mean^2)
+  expect_equal(shortcut_quad, loop_quad, tolerance = 1e-12)
+})

--- a/tests/testthat/tests.s2z-validation.R
+++ b/tests/testthat/tests.s2z-validation.R
@@ -1,0 +1,201 @@
+context("Phased validation of physical sum-to-zero group-level effects")
+
+s2z_validation_dat <- local({
+  n <- 36L
+  data.frame(
+    y = sin(seq_len(n) / 5),
+    y_ord = ordered(rep(letters[1:3], length.out = n)),
+    x = seq(-1.5, 1.5, length.out = n),
+    z = cos(seq_len(n) / 7),
+    w = seq(0.2, 2.1, length.out = n),
+    sx = rep(0.1, n),
+    g = factor(rep(seq_len(6L), each = 6L)),
+    h = factor(rep(seq_len(4L), each = 9L))
+  )
+})
+
+s2z_error_message <- function(expr) {
+  error <- tryCatch(expr, error = identity)
+  expect_s3_class(error, "error")
+  conditionMessage(error)
+}
+
+test_that("S2Z logistic prior specifications are exact and validated", {
+  expect_equal(
+    parse_re_s2z_prior("logistic(0, 1)"),
+    list(dist = "logistic", location = 0, scale = 1, df = NA_real_)
+  )
+  expect_error(
+    parse_re_s2z_prior("logistic(0, 0)"),
+    "Scale and degrees-of-freedom arguments must be positive"
+  )
+  expect_error(
+    parse_re_s2z_prior("logistic(location, 1)"),
+    "must currently be numeric constants"
+  )
+})
+
+test_that("S2Z descriptors separate active and fixed-only coordinates", {
+  form <- y ~ x + z + w +
+    (1 + x | gr(g, id = "first", s2z = TRUE)) +
+    (0 + z | gr(h, id = "second", s2z = TRUE))
+  bframe <- brmsframe(brmsterms(form), data = s2z_validation_dat)
+  bfl <- bframe$dpars$mu
+  infos <- re_s2z_infos(bfl)
+
+  expect_length(infos, 2L)
+  for (info in infos) {
+    expect_equal(info$qnames, c("Intercept", "x", "z", "w"))
+    expect_equal(info$active_q, 1:3)
+    expect_equal(info$inactive_q, 4L)
+    expect_equal(info$active_names, c("Intercept", "x", "z"))
+    expect_equal(info$inactive_names, "w")
+    expect_equal(info$active_index, c(1L, 2L, 3L, NA_integer_))
+    expect_equal(info$match_active, match(info$match_q, info$active_q))
+  }
+
+  bprior <- prior(normal(0, 2), class = Intercept) +
+    prior(normal(0, 1), class = b, coef = x) +
+    prior(normal(0, 1.5), class = b, coef = z) +
+    prior(double_exponential(0, 1), class = b, coef = w)
+  effective_prior <- validate_prior(
+    bprior, formula = form, data = s2z_validation_dat
+  )
+  expect_no_error(
+    validate_re_s2z_prior_global(bframe, prior = effective_prior)
+  )
+  specs <- re_s2z_infos(bfl, prior = effective_prior)[[1L]]$prior
+  expect_equal(vapply(specs, `[[`, character(1), "dist"),
+               c("normal", "normal", "normal", "flat"))
+})
+
+test_that("multi-block prior diagnostics identify a touching S2Z block", {
+  form <- y ~ x + z +
+    (1 + x | gr(g, id = "gblock", s2z = TRUE)) +
+    (0 + z | gr(h, id = "hblock", s2z = TRUE))
+  msg <- s2z_error_message(stancode(
+    form, data = s2z_validation_dat,
+    prior = prior(double_exponential(0, 1), class = b, coef = z)
+  ))
+
+  expect_match(msg, "group 'h'", fixed = TRUE)
+  expect_match(msg, "ID 'hblock'", fixed = TRUE)
+  expect_match(msg, "coefficient(s) 'z'", fixed = TRUE)
+  expect_false(grepl("group 'g'", msg, fixed = TRUE))
+
+  special_form <- y ~ z +
+    (1 | gr(g, id = "intercept-block", s2z = TRUE)) +
+    (0 + z | gr(h, id = "slope-block", s2z = TRUE))
+  msg <- s2z_error_message(validate_prior(
+    prior(horseshoe(), class = b),
+    formula = special_form, data = s2z_validation_dat
+  ))
+  expect_match(msg, "S2Z capability 'active_special_prior'", fixed = TRUE)
+  expect_match(msg, "group 'h'", fixed = TRUE)
+  expect_match(msg, "ID 'slope-block'", fixed = TRUE)
+  expect_match(msg, "coefficient(s) 'z'", fixed = TRUE)
+})
+
+test_that("S2Z design matching is numerically exact", {
+  form <- y ~ x + (1 + x | gr(g, id = "exact", s2z = TRUE))
+  bframe <- brmsframe(brmsterms(form), data = s2z_validation_dat)$dpars$mu
+  expect_no_error(
+    validate_re_s2z_design(bframe, data = s2z_validation_dat)
+  )
+
+  bframe$sdata$fe$X[, 2L] <- bframe$sdata$fe$X[, 2L] + 1e-12
+  msg <- s2z_error_message(
+    validate_re_s2z_design(bframe, data = s2z_validation_dat)
+  )
+  expect_match(msg, "S2Z capability 'matching_values'", fixed = TRUE)
+  expect_match(msg, "coefficient(s) 'x'", fixed = TRUE)
+})
+
+test_that("S2Z structure errors precede design errors and carry context", {
+  ordinal_form <- y_ord ~ x +
+    (1 | gr(g, id = "score", s2z = TRUE))
+  msg <- s2z_error_message(stancode(
+    ordinal_form, data = s2z_validation_dat, family = cumulative()
+  ))
+  expect_match(msg, "S2Z capability 'ordinal_location'", fixed = TRUE)
+  expect_match(msg, "response 'y_ord'", fixed = TRUE)
+  expect_match(msg, "family 'cumulative'", fixed = TRUE)
+  expect_match(msg, "dpar 'mu'", fixed = TRUE)
+  expect_match(msg, "group 'g'", fixed = TRUE)
+  expect_match(msg, "ID 'score'", fixed = TRUE)
+  expect_match(msg, "Remedy:", fixed = TRUE)
+  expect_false(grepl("matching population-level", msg, fixed = TRUE))
+
+  special_form <- y ~ x +
+    (1 + me(x, sx) | gr(g, id = "me-score", s2z = TRUE))
+  msg <- s2z_error_message(stancode(
+    special_form, data = s2z_validation_dat
+  ))
+  expect_match(msg, "S2Z capability 'ordinary_gr_only'", fixed = TRUE)
+  expect_match(msg, "ID 'me-score'", fixed = TRUE)
+  expect_false(grepl("matching population-level", msg, fixed = TRUE))
+})
+
+test_that("the VerbAgg ordinal model reaches the intentional S2Z gate", {
+  skip_if_not_installed("lme4")
+  data_env <- new.env(parent = emptyenv())
+  utils::data("VerbAgg", package = "lme4", envir = data_env)
+  verbagg <- data_env$VerbAgg
+  form <- resp ~ (Anger + Gender + btype + situ)^2 +
+    (1 | gr(id, id = "person-s2z", s2z = TRUE)) +
+    (1 | gr(item, id = "item-s2z", s2z = TRUE))
+
+  msg <- s2z_error_message(stancode(
+    form, data = verbagg, family = cumulative()
+  ))
+  expect_match(msg, "S2Z capability 'ordinal_location'", fixed = TRUE)
+  expect_match(msg, "response 'resp'", fixed = TRUE)
+  expect_match(msg, "family 'cumulative'", fixed = TRUE)
+  expect_match(msg, "group 'id'", fixed = TRUE)
+  expect_match(msg, "ID 'person-s2z'", fixed = TRUE)
+  expect_match(msg, "ordinal S2Z support", fixed = TRUE)
+  expect_false(grepl("matching population-level", msg, fixed = TRUE))
+})
+
+test_that("S2Z design and prior/global phases use capability diagnostics", {
+  missing_form <- y ~ x +
+    (1 + x + z | gr(g, id = "score", s2z = TRUE))
+  msg <- s2z_error_message(stancode(
+    missing_form, data = s2z_validation_dat
+  ))
+  expect_match(msg, "S2Z capability 'matching_name'", fixed = TRUE)
+  expect_match(msg, "coefficient(s) 'z'", fixed = TRUE)
+  expect_match(msg, "Remedy:", fixed = TRUE)
+
+  active_prior_form <- y ~ x + w +
+    (1 + x | gr(g, id = "score", s2z = TRUE))
+  msg <- s2z_error_message(stancode(
+    active_prior_form, data = s2z_validation_dat,
+    prior = prior(double_exponential(0, 1), class = b, coef = x)
+  ))
+  expect_match(
+    msg, "S2Z capability 'active_prior_distribution'", fixed = TRUE
+  )
+  expect_match(msg, "prior 'double_exponential(0,1)'", fixed = TRUE)
+  expect_match(msg, "Remedy:", fixed = TRUE)
+
+  msg <- s2z_error_message(validate_prior(
+    prior(double_exponential(0, 1), class = b, coef = x),
+    formula = active_prior_form, data = s2z_validation_dat
+  ))
+  expect_match(
+    msg, "S2Z capability 'active_prior_distribution'", fixed = TRUE
+  )
+  expect_match(msg, "coefficient(s) 'x'", fixed = TRUE)
+
+  cross_form <- bf(
+    y ~ 1 + (1 | gr(g, id = "across", s2z = TRUE)),
+    sigma ~ 1 + (1 | gr(g, id = "across", s2z = FALSE))
+  )
+  msg <- s2z_error_message(stancode(
+    cross_form, data = s2z_validation_dat
+  ))
+  expect_match(msg, "S2Z capability 'cross_predictor_id'", fixed = TRUE)
+  expect_match(msg, "ID 'across'", fixed = TRUE)
+  expect_match(msg, "Remedy:", fixed = TRUE)
+})

--- a/tests/testthat/tests.s2z-validation.R
+++ b/tests/testthat/tests.s2z-validation.R
@@ -197,5 +197,66 @@ test_that("S2Z design and prior/global phases use capability diagnostics", {
   ))
   expect_match(msg, "S2Z capability 'cross_predictor_id'", fixed = TRUE)
   expect_match(msg, "ID 'across'", fixed = TRUE)
+  expect_match(msg, "Affected linear predictors:", fixed = TRUE)
+  expect_match(msg, "dpar 'mu'", fixed = TRUE)
+  expect_match(msg, "dpar 'sigma'", fixed = TRUE)
+  expect_match(msg, '`id = "y_mu_s2z"`', fixed = TRUE)
+  expect_match(msg, '`id = "y_sigma_s2z"`', fixed = TRUE)
   expect_match(msg, "Remedy:", fixed = TRUE)
+})
+
+test_that("cross-predictor diagnostics enumerate mvbind responses", {
+  form <- bf(
+    mvbind(y, z) ~ 1 + (1 | shared | gr(g, s2z = TRUE))
+  ) + set_rescor(FALSE)
+  msg <- s2z_error_message(stancode(
+    form, data = s2z_validation_dat
+  ))
+
+  expect_match(msg, "Affected linear predictors:", fixed = TRUE)
+  expect_match(msg, "response 'y'", fixed = TRUE)
+  expect_match(msg, "response 'z'", fixed = TRUE)
+  expect_match(msg, "ID 'shared'", fixed = TRUE)
+  expect_match(msg, '`id = "y_mu_s2z"`', fixed = TRUE)
+  expect_match(msg, '`id = "z_mu_s2z"`', fixed = TRUE)
+  expect_match(msg, "For `mvbind(...)` or category shorthand", fixed = TRUE)
+  expect_match(msg, "omit the shared `| shared |` tag", fixed = TRUE)
+  expect_match(msg, "separate `bf()` response formulas", fixed = TRUE)
+  expect_match(msg, "do not retain cross-predictor group-effect", fixed = TRUE)
+  expect_match(msg, "use s2z = FALSE", fixed = TRUE)
+})
+
+test_that("mvbind shorthand without a shared ID uses local S2Z blocks", {
+  form <- bf(
+    mvbind(y, z) ~ 1 + (1 | gr(g, s2z = TRUE))
+  ) + set_rescor(FALSE)
+  code <- stancode(form, data = s2z_validation_dat)
+  bframe <- brmsframe(brmsterms(form), data = s2z_validation_dat)
+  local_re <- lapply(bframe$terms, function(x) x$frame$re)
+
+  expect_s3_class(code, "brmsmodel")
+  expect_true(all(vapply(local_re, function(x) any(x$s2z), logical(1))))
+  expect_length(unique(unlist(lapply(local_re, `[[`, "id"))), 2L)
+})
+
+test_that("cov diagnostics identify the unsupported phylogenetic argument", {
+  phylo_dat <- data.frame(
+    phen = seq(-1, 1, length.out = 12),
+    cofactor = rep(c(-0.5, 0.5), 6),
+    phylo = factor(rep(letters[1:4], each = 3))
+  )
+  A <- diag(4)
+  dimnames(A) <- list(levels(phylo_dat$phylo), levels(phylo_dat$phylo))
+  msg <- s2z_error_message(stancode(
+    phen ~ cofactor + (1 | gr(phylo, cov = A, s2z = TRUE)),
+    data = phylo_dat, data2 = list(A = A)
+  ))
+
+  expect_match(msg, "Argument 'cov' is not yet supported", fixed = TRUE)
+  expect_match(msg, "S2Z capability 'cov'", fixed = TRUE)
+  expect_match(msg, "response 'phen'", fixed = TRUE)
+  expect_match(msg, "group 'phylo'", fixed = TRUE)
+  expect_match(msg, "use s2z = FALSE", fixed = TRUE)
+  expect_match(msg, "supplied group covariance matrix", fixed = TRUE)
+  expect_false(grepl("Arguments 'by', 'cov', and 'pw'", msg, fixed = TRUE))
 })

--- a/tests/testthat/tests.s2z.R
+++ b/tests/testthat/tests.s2z.R
@@ -116,6 +116,122 @@ test_that("Gaussian completed-square density is normalized in S2Z coordinates", 
   )
 })
 
+test_that("scalar completed-square density is normalized exactly", {
+  n <- 6L
+  basis <- .s2z_basis(n)
+  prior_mean <- -0.35
+  prior_sd <- 1.4
+  group_sd <- 0.65
+  H <- 0.8
+  theta <- 1.15
+  contrast <- c(-0.6, 0.2, 0.75, -0.1, 0.45)
+  r_s2z <- drop(basis %*% contrast)
+
+  prior_prec <- 1 / prior_sd^2
+  group_prec <- rep(1, n)
+  Q_sigma <- 1 / group_sd^2
+  P <- H^2 * prior_prec + sum(group_prec) * Q_sigma
+  h <- H * prior_prec * (theta - prior_mean) -
+    Q_sigma * sum(r_s2z * group_prec)
+  mhat <- h / P
+  A <- H^2 * prior_prec
+  a <- H * prior_prec * (theta - prior_mean)
+  D <- group_sd^2 * A + n
+  mhat_scaled <- group_sd^2 * a / D
+  qhat <- theta - H * mhat
+
+  log_complete <- stats::dnorm(
+    qhat, prior_mean, prior_sd, log = TRUE
+  ) + sum(stats::dnorm(
+    r_s2z + mhat, 0, group_sd, log = TRUE
+  )) + 0.5 * log(2 * pi) - 0.5 * log(P) + 0.5 * log(n)
+
+  # Independently transform (q, u_1, ..., u_n) to the finite-population
+  # coefficient theta = q + H * mean(u) and orthonormal contrasts B' u.
+  transform <- rbind(
+    c(1, rep(H / n, n)),
+    cbind(0, t(basis))
+  )
+  conventional_cov <- diag(c(prior_sd^2, rep(group_sd^2, n)))
+  transformed_cov <- transform %*% conventional_cov %*% t(transform)
+  transformed_value <- c(theta, drop(crossprod(basis, r_s2z)))
+  transformed_mean <- c(prior_mean, numeric(n - 1L))
+  log_direct <- .s2z_log_mvn(
+    transformed_value, transformed_mean, transformed_cov
+  )
+  log_scaled <- stats::dnorm(
+    qhat, prior_mean, prior_sd, log = TRUE
+  ) - 0.5 * sum(((r_s2z + mhat_scaled) / group_sd)^2) -
+    (n - 1) * log(group_sd) - 0.5 * log(D) -
+    0.5 * (n - 1) * log(2 * pi) + 0.5 * log(n)
+
+  expect_equal(mhat_scaled, mhat, tolerance = 1e-14)
+  expect_equal(log_complete, log_direct, tolerance = 1e-11)
+  expect_equal(log_scaled, log_direct, tolerance = 1e-11)
+  expect_equal(sum(r_s2z), 0, tolerance = 1e-14)
+})
+
+test_that("scalar Student mixture uses the exact heterogeneous complete square", {
+  n <- 6L
+  basis <- .s2z_basis(n)
+  prior_mean <- 0.25
+  prior_sd <- 1.1
+  group_sd <- 0.7
+  H <- -0.45
+  theta <- -0.8
+  r_s2z <- drop(basis %*% c(0.4, -0.7, 0.15, 0.9, -0.2))
+
+  # Conditional on these scales this is the scalar Student-t group model.
+  df <- 4.25
+  udf <- c(0.11, 0.35, 0.8, 1.6, 0.27, 0.52)
+  group_scale <- sqrt(df * udf)
+  group_prec <- 1 / group_scale^2
+  prior_prec <- 1 / prior_sd^2
+  Q_sigma <- 1 / group_sd^2
+  P <- H^2 * prior_prec + sum(group_prec) * Q_sigma
+  h <- H * prior_prec * (theta - prior_mean) -
+    Q_sigma * sum(r_s2z * group_prec)
+  mhat <- h / P
+  A <- H^2 * prior_prec
+  a <- H * prior_prec * (theta - prior_mean)
+  D <- group_sd^2 * A + sum(group_prec)
+  mhat_scaled <- (
+    group_sd^2 * a - sum(r_s2z * group_prec)
+  ) / D
+
+  log_joint_measure <- function(group_mean) {
+    q <- theta - H * group_mean
+    stats::dnorm(q, prior_mean, prior_sd, log = TRUE) +
+      sum(stats::dnorm(
+        r_s2z + group_mean, 0, group_sd * group_scale, log = TRUE
+      )) + 0.5 * log(n)
+  }
+  log_marginal <- log_joint_measure(mhat) +
+    0.5 * log(2 * pi) - 0.5 * log(P)
+  qhat <- theta - H * mhat_scaled
+  log_marginal_scaled <- stats::dnorm(
+    qhat, prior_mean, prior_sd, log = TRUE
+  ) - 0.5 * sum(
+    ((r_s2z + mhat_scaled) / (group_sd * group_scale))^2
+  ) - (n - 1) * log(group_sd) - sum(log(group_scale)) -
+    0.5 * log(D) - 0.5 * (n - 1) * log(2 * pi) + 0.5 * log(n)
+
+  expect_equal(mhat_scaled, mhat, tolerance = 1e-14)
+  expect_equal(log_marginal_scaled, log_marginal, tolerance = 1e-11)
+  expect_gt(diff(range(group_prec)), 1)
+  expect_gt(abs(sum(r_s2z * group_prec)), 0.1)
+  for (group_mean in c(mhat, mhat + 0.55, -1.2)) {
+    log_conditional <- stats::dnorm(
+      group_mean, mhat, sqrt(1 / P), log = TRUE
+    )
+    expect_equal(
+      log_joint_measure(group_mean) - log_conditional,
+      log_marginal,
+      tolerance = 1e-11
+    )
+  }
+})
+
 test_that("heterogeneous Student mixture scales obey the complete square", {
   n <- 5L
   m <- 2L

--- a/tests/testthat/tests.s2z.R
+++ b/tests/testthat/tests.s2z.R
@@ -32,6 +32,134 @@ context("Tests for marginalized sum-to-zero group-level effects")
     0.5 * sum(z^2)
 }
 
+# Compare the component-wise diagonal-plus-rank-one implementation with the
+# dense complete square it replaces.  This deliberately mirrors the scaled
+# equations in .stan_re_s2z_independent without calling code under test.
+.s2z_independent_case <- function(k, student = FALSE, center = TRUE) {
+  n <- 11L
+  basis <- .s2z_basis(n)
+  contrast <- matrix(
+    sin(seq_len((n - 1L) * k) * 0.71) +
+      cos(seq_len((n - 1L) * k) * 0.19),
+    nrow = n - 1L, ncol = k
+  ) / 3
+  r_s2z <- basis %*% contrast
+  theta <- seq(-0.8, 1.1, length.out = k)
+  prior_mean <- seq(0.45, -0.35, length.out = k)
+  prior_sd <- seq(0.65, 1.55, length.out = k)
+  prior_prec <- 1 / prior_sd^2
+  group_sd <- seq(0.4, 1.25, length.out = k)
+  intercept_map <- if (center) {
+    c(1, seq(-0.55, 0.65, length.out = k - 1L))
+  } else {
+    numeric(k)
+  }
+  H <- diag(k)
+  if (center) {
+    H[1L, ] <- intercept_map
+  }
+  group_scale <- if (student) {
+    sqrt(4.25 * seq(0.09, 1.37, length.out = n)^1.35)
+  } else {
+    rep(1, n)
+  }
+  group_prec <- 1 / group_scale^2
+  weighted_contrast <- drop(crossprod(r_s2z, group_prec))
+
+  # Dense K-dimensional complete square.
+  Q_group <- diag(1 / group_sd^2, k)
+  P <- crossprod(H, prior_prec * H) + sum(group_prec) * Q_group
+  h <- drop(crossprod(H, prior_prec * (theta - prior_mean))) -
+    drop(Q_group %*% weighted_contrast)
+  dense_mode <- drop(solve(P, h))
+  dense_qhat <- drop(theta - H %*% dense_mode)
+
+  # Scaled diagonal-plus-rank-one equations used by the specialization.
+  base_info <- prior_prec
+  base_score <- prior_prec * (theta - prior_mean)
+  coupling_prec <- 0
+  coupling_resid <- 0
+  if (center) {
+    base_info[1L] <- 0
+    base_score[1L] <- 0
+    coupling_prec <- prior_prec[1L]
+    coupling_resid <- theta[1L] - prior_mean[1L]
+  }
+  D <- sum(group_prec) + group_sd^2 * base_info
+  scaled_score <- group_sd^2 * base_score
+  if (student) {
+    scaled_score <- scaled_score - weighted_contrast
+  }
+  independent_mode <- scaled_score / D
+  rank1_info <- coupling_prec * sum(
+    group_sd^2 * intercept_map^2 / D
+  )
+  fast_mode <- independent_mode +
+    coupling_prec * group_sd^2 * intercept_map / D *
+    (coupling_resid - sum(intercept_map * independent_mode)) /
+    (1 + rank1_info)
+  fast_qhat <- theta - H %*% fast_mode
+
+  log_joint_measure <- function(group_mean) {
+    q <- drop(theta - H %*% group_mean)
+    group_log <- sum(vapply(
+      seq_len(n),
+      function(i) {
+        sum(stats::dnorm(
+          r_s2z[i, ] + group_mean, 0,
+          group_sd * group_scale[i], log = TRUE
+        ))
+      },
+      numeric(1)
+    ))
+    sum(stats::dnorm(q, prior_mean, prior_sd, log = TRUE)) +
+      group_log + 0.5 * k * log(n)
+  }
+  dense_log <- log_joint_measure(dense_mode) +
+    0.5 * k * log(2 * pi) -
+    0.5 * as.numeric(determinant(P, logarithm = TRUE)$modulus)
+  group_quad <- sum(vapply(
+    seq_len(k),
+    function(j) {
+      sum(((r_s2z[, j] + fast_mode[j]) /
+             (group_sd[j] * group_scale))^2)
+    },
+    numeric(1)
+  ))
+  fast_log <- sum(stats::dnorm(
+    fast_qhat, prior_mean, prior_sd, log = TRUE
+  )) - 0.5 * group_quad - (n - 1L) * sum(log(group_sd)) -
+    ifelse(student, k * sum(log(group_scale)), 0) -
+    0.5 * sum(log(D)) - 0.5 * log1p(rank1_info) -
+    0.5 * n * k * log(2 * pi) + 0.5 * k * log(2 * pi) +
+    0.5 * k * log(n)
+
+  # The generated-quantities draw is a square-root rank-one downdate of the
+  # independent covariance diag(group_sd^2 / D).
+  independent_cov <- diag(group_sd^2 / D, k)
+  sqrt_rank1 <- sqrt(1 + rank1_info)
+  rank1_coef <- coupling_prec /
+    (sqrt_rank1 * (1 + sqrt_rank1))
+  adjustment <- diag(k) - rank1_coef * outer(
+    group_sd^2 * intercept_map / D, intercept_map
+  )
+  gq_cov <- adjustment %*% independent_cov %*% t(adjustment)
+
+  list(
+    r_s2z = r_s2z,
+    weighted_contrast = weighted_contrast,
+    dense_mode = dense_mode,
+    fast_mode = fast_mode,
+    dense_qhat = dense_qhat,
+    fast_qhat = drop(fast_qhat),
+    dense_log = dense_log,
+    fast_log = fast_log,
+    conditional_cov = solve(P),
+    gq_cov = gq_cov,
+    rank1_info = rank1_info
+  )
+}
+
 test_that("the physical sum-to-zero transform is orthonormal", {
   for (n in c(2L, 3L, 7L)) {
     basis <- .s2z_basis(n)
@@ -114,6 +242,59 @@ test_that("Gaussian completed-square density is normalized in S2Z coordinates", 
     log_direct - (log_complete - 0.5 * m * log(n)),
     0.5 * m * log(n), tolerance = 1e-12
   )
+})
+
+test_that("independent Gaussian effects match the dense complete square", {
+  for (k in c(2L, 5L, 10L)) {
+    ans <- .s2z_independent_case(k, student = FALSE, center = TRUE)
+
+    expect_equal(colSums(ans$r_s2z), numeric(k), tolerance = 2e-14)
+    expect_equal(ans$dense_mode, ans$fast_mode, tolerance = 2e-13)
+    expect_equal(ans$dense_qhat, ans$fast_qhat, tolerance = 2e-13)
+    expect_equal(ans$dense_log, ans$fast_log, tolerance = 2e-10)
+    expect_gt(ans$rank1_info, 0)
+  }
+})
+
+test_that("independent Student effects match the weighted dense square", {
+  for (k in c(2L, 5L, 10L)) {
+    ans <- .s2z_independent_case(k, student = TRUE, center = TRUE)
+
+    # Unequal group scales make a physical zero-sum contrast have a nonzero
+    # precision-weighted sum; this is the term the Gaussian shortcut omits.
+    expect_gt(max(abs(ans$weighted_contrast)), 0.05)
+    expect_equal(ans$dense_mode, ans$fast_mode, tolerance = 2e-13)
+    expect_equal(ans$dense_qhat, ans$fast_qhat, tolerance = 2e-13)
+    expect_equal(ans$dense_log, ans$fast_log, tolerance = 2e-10)
+  }
+})
+
+test_that("rank-one generated-quantities covariance is exact", {
+  for (k in c(2L, 5L, 10L)) {
+    for (student in c(FALSE, TRUE)) {
+      ans <- .s2z_independent_case(k, student = student, center = TRUE)
+      expect_equal(
+        ans$gq_cov, ans$conditional_cov,
+        tolerance = 3e-14, scale = 1
+      )
+      expect_gt(min(eigen(ans$gq_cov, symmetric = TRUE)$values), 0)
+    }
+  }
+})
+
+test_that("independent no-intercept effects reduce to diagonal solves", {
+  for (k in c(2L, 5L, 10L)) {
+    for (student in c(FALSE, TRUE)) {
+      ans <- .s2z_independent_case(k, student = student, center = FALSE)
+      expect_equal(ans$rank1_info, 0)
+      expect_equal(ans$dense_mode, ans$fast_mode, tolerance = 2e-13)
+      expect_equal(ans$dense_log, ans$fast_log, tolerance = 2e-10)
+      expect_equal(
+        ans$gq_cov, ans$conditional_cov,
+        tolerance = 3e-14, scale = 1
+      )
+    }
+  }
 })
 
 test_that("scalar completed-square density is normalized exactly", {

--- a/tests/testthat/tests.s2z.R
+++ b/tests/testthat/tests.s2z.R
@@ -1,4 +1,4 @@
-context("Tests for marginalized sum-to-zero group-level effects")
+context("Tests for physical sum-to-zero group-level effects")
 
 # R mirror of inst/chunks/fun_sum_to_zero.stan. Keeping this small reference
 # implementation in the tests makes the geometry checks independent of Stan.

--- a/tests/testthat/tests.s2z.R
+++ b/tests/testthat/tests.s2z.R
@@ -1,0 +1,312 @@
+context("Tests for marginalized sum-to-zero group-level effects")
+
+# R mirror of inst/chunks/fun_sum_to_zero.stan. Keeping this small reference
+# implementation in the tests makes the geometry checks independent of Stan.
+.s2z_constrain_r <- function(y) {
+  n <- length(y)
+  z <- numeric(n + 1L)
+  sum_w <- 0
+  for (ii in seq_len(n)) {
+    i <- n - ii + 1L
+    w <- y[i] / sqrt(i * (i + 1))
+    sum_w <- sum_w + w
+    z[i] <- z[i] + sum_w
+    z[i + 1L] <- z[i + 1L] - i * w
+  }
+  z
+}
+
+.s2z_basis <- function(n) {
+  stopifnot(n >= 2L)
+  vapply(
+    seq_len(n - 1L),
+    function(j) .s2z_constrain_r(diag(n - 1L)[, j]),
+    numeric(n)
+  )
+}
+
+.s2z_log_mvn <- function(x, mean, sigma) {
+  R <- chol(sigma)
+  z <- forwardsolve(t(R), x - mean)
+  -0.5 * length(x) * log(2 * pi) - sum(log(diag(R))) -
+    0.5 * sum(z^2)
+}
+
+test_that("the physical sum-to-zero transform is orthonormal", {
+  for (n in c(2L, 3L, 7L)) {
+    basis <- .s2z_basis(n)
+    y <- (seq_len(n - 1L) - n / 3) / 2
+    z <- .s2z_constrain_r(y)
+
+    expect_equal(crossprod(basis), diag(n - 1L), tolerance = 1e-14)
+    expect_equal(
+      drop(crossprod(rep(1, n), basis)), numeric(n - 1L),
+      tolerance = 1e-14
+    )
+    expect_equal(z, drop(basis %*% y), tolerance = 1e-14)
+    expect_equal(sum(z), 0, tolerance = 1e-14)
+    expect_equal(sum(z^2), sum(y^2), tolerance = 1e-14)
+  }
+})
+
+test_that("Gaussian completed-square density is normalized in S2Z coordinates", {
+  n <- 5L
+  m <- 2L
+  q <- 3L
+  basis <- .s2z_basis(n)
+
+  # H is deliberately rectangular and non-identity. This exercises both a
+  # population coefficient shared by several group effects and a coefficient
+  # that is only partly shifted by the omitted group mean.
+  H <- matrix(c(1, 0.35, -0.2, -0.45, 0.8, 0.3), nrow = q)
+  prior_prec <- diag(c(0.8, 1.7, 2.4))
+  prior_cov <- solve(prior_prec)
+  prior_mean <- c(0.4, -0.7, 0.2)
+  Sigma <- matrix(c(1.3, 0.28, 0.28, 0.75), nrow = m)
+  Q_Sigma <- solve(Sigma)
+  theta_s2z <- c(1.2, -0.3, 0.9)
+  contrast <- matrix(
+    c(0.2, -0.4, 0.8, -0.6, 0.1, 0.35, -0.2, 0.5),
+    nrow = n - 1L
+  )
+  r_s2z <- basis %*% contrast
+
+  P <- t(H) %*% prior_prec %*% H + n * Q_Sigma
+  h <- t(H) %*% prior_prec %*% (theta_s2z - prior_mean) -
+    Q_Sigma %*% (t(r_s2z) %*% rep(1, n))
+  mhat <- drop(solve(P, h))
+  qhat <- drop(theta_s2z - H %*% mhat)
+
+  log_complete <- .s2z_log_mvn(qhat, prior_mean, prior_cov) +
+    sum(vapply(
+      seq_len(n),
+      function(j) {
+        .s2z_log_mvn(r_s2z[j, ] + mhat, numeric(m), Sigma)
+      },
+      numeric(1)
+    )) +
+    0.5 * m * log(2 * pi) - sum(log(diag(chol(P)))) +
+    0.5 * m * log(n)
+
+  # Independently derive the normalized Gaussian density of
+  # (theta_s2z, z_s2z)
+  # as a linear transformation of conventional coefficients and effects.
+  mean_map <- kronecker(
+    diag(m), matrix(rep(1 / n, n), nrow = 1L)
+  )
+  contrast_map <- kronecker(diag(m), t(basis))
+  transform <- rbind(
+    cbind(diag(q), H %*% mean_map),
+    cbind(matrix(0, m * (n - 1L), q), contrast_map)
+  )
+  conventional_cov <- matrix(0, q + n * m, q + n * m)
+  iq <- seq_len(q)
+  iu <- q + seq_len(n * m)
+  conventional_cov[iq, iq] <- prior_cov
+  conventional_cov[iu, iu] <- kronecker(Sigma, diag(n))
+  s2z_cov <- transform %*% conventional_cov %*% t(transform)
+  s2z_value <- c(theta_s2z, as.vector(t(basis) %*% r_s2z))
+  s2z_mean <- c(prior_mean, rep(0, m * (n - 1L)))
+  log_direct <- .s2z_log_mvn(s2z_value, s2z_mean, s2z_cov)
+
+  expect_equal(log_complete, log_direct, tolerance = 1e-10)
+  expect_equal(
+    log_direct - (log_complete - 0.5 * m * log(n)),
+    0.5 * m * log(n), tolerance = 1e-12
+  )
+})
+
+test_that("heterogeneous Student mixture scales obey the complete square", {
+  n <- 5L
+  m <- 2L
+  q <- 3L
+  basis <- .s2z_basis(n)
+  H <- matrix(c(1, 0.2, -0.35, -0.4, 0.75, 0.5), nrow = q)
+  prior_mean <- c(-0.2, 0.6, 0.1)
+  prior_sd <- c(0.7, 1.1, 1.6)
+  prior_prec <- diag(1 / prior_sd^2)
+  prior_cov <- diag(prior_sd^2)
+  Sigma <- matrix(c(0.9, -0.24, -0.24, 1.4), nrow = m)
+  Q_Sigma <- solve(Sigma)
+  theta_s2z <- c(0.8, -0.5, 1.1)
+  contrast <- matrix(
+    c(-0.4, 0.3, 0.9, -0.2, 0.5, -0.7, 0.1, 0.45),
+    nrow = n - 1L
+  )
+  r_s2z <- basis %*% contrast
+
+  # Conditional on the inverse-chi-square mixing variables, Student group
+  # effects are Gaussian with level-specific scales sqrt(df * udf).
+  df <- 4.5
+  udf <- c(0.13, 0.31, 0.8, 1.4, 0.22)
+  group_scale <- sqrt(df * udf)
+  group_prec <- 1 / group_scale^2
+  expect_gt(diff(range(group_prec)), 1)
+  expect_gt(sum(abs(drop(t(r_s2z) %*% group_prec))), 0.1)
+
+  P <- t(H) %*% prior_prec %*% H +
+    sum(group_prec) * Q_Sigma
+  h <- t(H) %*% prior_prec %*% (theta_s2z - prior_mean) -
+    Q_Sigma %*% (t(r_s2z) %*% group_prec)
+  mhat <- drop(solve(P, h))
+
+  log_joint_measure <- function(group_mean) {
+    q_value <- drop(theta_s2z - H %*% group_mean)
+    group_log <- sum(vapply(
+      seq_len(n),
+      function(j) {
+        .s2z_log_mvn(
+          r_s2z[j, ] + group_mean, numeric(m),
+          group_scale[j]^2 * Sigma
+        )
+      },
+      numeric(1)
+    ))
+    .s2z_log_mvn(q_value, prior_mean, prior_cov) + group_log +
+      0.5 * m * log(n)
+  }
+  log_marginal <- log_joint_measure(mhat) +
+    0.5 * m * log(2 * pi) - sum(log(diag(chol(P))))
+  conditional_cov <- solve(P)
+
+  # Removing the normalized conditional density of the omitted mean from the
+  # joint density must give the same marginal at every possible mean.
+  candidate_means <- list(
+    mhat,
+    mhat + c(0.3, -0.7),
+    c(-1.1, 0.4)
+  )
+  for (group_mean in candidate_means) {
+    by_identity <- log_joint_measure(group_mean) -
+      .s2z_log_mvn(group_mean, mhat, conditional_cov)
+    expect_equal(by_identity, log_marginal, tolerance = 1e-10)
+  }
+})
+
+test_that("centering preserves numeric and mixed-interaction predictors", {
+  dat <- data.frame(
+    x = c(-1.7, 0.2, 2.3, 1.1, -0.4, 3.2, 0.7, -2.1, 1.8),
+    f = factor(c("a", "b", "c", "a", "c", "b", "a", "b", "c")),
+    g = factor(c("g1", "g1", "g2", "g3", "g3", "g3", "g4", "g4", "g4"))
+  )
+  g_index <- match(dat$g, levels(dat$g))
+
+  for (form in list(~ x, ~ f * x)) {
+    X <- model.matrix(form, dat)
+    p <- ncol(X)
+    means_X <- colMeans(X[, -1L, drop = FALSE])
+    Xc <- sweep(X[, -1L, drop = FALSE], 2L, means_X)
+    q_value <- seq(-0.8, 0.7, length.out = p)
+    r <- matrix(seq_len(nlevels(dat$g) * p), nrow = nlevels(dat$g)) / 7
+    r <- sweep(r, 2L, seq_len(p) / 5)
+    group_mean <- colMeans(r)
+    r_s2z <- sweep(r, 2L, group_mean)
+
+    H <- diag(p)
+    H[1L, -1L] <- means_X
+    theta_s2z <- drop(q_value + H %*% group_mean)
+
+    eta_conventional <- q_value[1L] + drop(Xc %*% q_value[-1L]) +
+      rowSums(X * r[g_index, , drop = FALSE])
+    eta_s2z <- theta_s2z[1L] + drop(Xc %*% theta_s2z[-1L]) +
+      rowSums(X * r_s2z[g_index, , drop = FALSE])
+    raw_q <- c(
+      q_value[1L] - sum(means_X * q_value[-1L]), q_value[-1L]
+    )
+
+    expect_equal(colSums(r_s2z), numeric(p), tolerance = 1e-14)
+    expect_equal(drop(theta_s2z - H %*% group_mean), q_value,
+                 tolerance = 1e-14)
+    expect_equal(eta_s2z, eta_conventional, tolerance = 1e-13)
+    expect_equal(drop(X %*% raw_q),
+                 q_value[1L] + drop(Xc %*% q_value[-1L]),
+                 tolerance = 1e-14)
+  }
+
+  mixed_X <- model.matrix(~ f * x, dat)
+  expect_true(any(grepl(":", colnames(mixed_X), fixed = TRUE)))
+  expect_gt(max(abs(colMeans(mixed_X[, -1L, drop = FALSE]))), 0.1)
+})
+
+test_that("generated Stan code contains the S2Z algebra and measure", {
+  expect_match2 <- brms:::expect_match2
+  dat <- data.frame(
+    y = seq(-1, 1, length.out = 12),
+    x = c(-2, -1, 0.5, 1, 2, 3, -0.5, 1.5, 2.5, 0.25, 1.25, 3.25),
+    f = factor(rep(c("a", "b"), 6)),
+    g = factor(rep(letters[1:4], each = 3))
+  )
+  bprior <- prior(normal(0, 1), class = "Intercept") +
+    prior(normal(0, 1), class = "b")
+
+  gaussian_code <- stancode(
+    y ~ f * x + (1 + f * x | gr(g, s2z = TRUE)),
+    data = dat, prior = bprior, normalize = TRUE
+  )
+  expect_match2(
+    gaussian_code,
+    "array[M_1] vector[N_1 - 1] z_s2z_1;"
+  )
+  expect_match2(
+    gaussian_code,
+    "r_s2z_1[, k] = sum_to_zero_constrain_brms(z_s2z_1[k]);"
+  )
+  expect_match2(gaussian_code, "H_s2z_1[1, 2] = means_X[1];")
+  expect_match2(gaussian_code, "H_s2z_1[1, 4] = means_X[3];")
+  expect_match2(
+    gaussian_code,
+    "P_s2z_1 = crossprod(diag_pre_multiply(sqrt(prior_prec_s2z_1), H_s2z_1)) + sum(group_prec_s2z_1) * Q_Sigma_s2z_1;"
+  )
+  expect_match2(
+    gaussian_code,
+    "+ 0.5 * M_1 * log(1.0 * N_1)"
+  )
+  expect_match2(
+    gaussian_code,
+    "normal_id_glm_lpdf(Y | Xc, mu, tail(theta_s2z, 3), sigma)"
+  )
+
+  student_code <- stancode(
+    y ~ f * x +
+      (1 + f * x | gr(g, s2z = TRUE, dist = "student")),
+    data = dat, prior = bprior, normalize = TRUE
+  )
+  expect_match2(student_code, "group_scale_s2z_1 = dfm_1;")
+  expect_match2(
+    student_code,
+    "group_prec_s2z_1 = inv_square(group_scale_s2z_1);"
+  )
+  expect_match2(
+    student_code,
+    "r_s2z_1' * group_prec_s2z_1"
+  )
+  expect_match2(
+    student_code,
+    "- M_1 * sum(log(group_scale_s2z_1))"
+  )
+})
+
+test_that("save_pars(all = TRUE) keeps S2Z internals extractor-safe", {
+  dat <- data.frame(
+    y = seq_len(8),
+    x = seq(-1, 1, length.out = 8),
+    g = factor(rep(seq_len(4), each = 2))
+  )
+  fit <- brm(
+    y ~ x + (1 + x | gr(g, s2z = TRUE)), data = dat,
+    empty = TRUE, save_pars = save_pars(all = TRUE)
+  )
+  excluded <- unlist(brms:::exclude_pars(fit), use.names = FALSE)
+
+  # save_pars(all = TRUE) retains the internal parameter for operations such
+  # as bridge sampling, but its name must not look like a recovered b_* draw.
+  expect_false("theta_s2z" %in% excluded)
+  draw_names <- c(
+    "b_Intercept", "b_x", "theta_s2z", "theta_s2z[1]",
+    "theta_s2z[2]", "q_recovered_s2z_1[1]"
+  )
+  expect_identical(
+    draw_names[grepl(brms:::fixef_pars(), draw_names)],
+    c("b_Intercept", "b_x")
+  )
+})

--- a/tests/testthat/tests.s2z.R
+++ b/tests/testthat/tests.s2z.R
@@ -32,10 +32,76 @@ context("Tests for physical sum-to-zero group-level effects")
     0.5 * sum(z^2)
 }
 
+# Small dense-matrix helpers for multiblock reference calculations. These
+# deliberately do not call the production S2Z code.
+.s2z_block_diag <- function(blocks) {
+  stopifnot(length(blocks) >= 1L)
+  nr <- vapply(blocks, nrow, integer(1))
+  nc <- vapply(blocks, ncol, integer(1))
+  out <- matrix(0, nrow = sum(nr), ncol = sum(nc))
+  row_offset <- 0L
+  col_offset <- 0L
+  for (i in seq_along(blocks)) {
+    rows <- row_offset + seq_len(nr[i])
+    cols <- col_offset + seq_len(nc[i])
+    out[rows, cols] <- blocks[[i]]
+    row_offset <- row_offset + nr[i]
+    col_offset <- col_offset + nc[i]
+  }
+  out
+}
+
+# Dense transformation from conventional population and group effects to one
+# finite-population coefficient vector and orthonormal contrasts for every
+# independent grouping factor.
+.s2z_multiblock_dense_map <- function(prior_cov, H, groups, effect_cov) {
+  stopifnot(
+    is.matrix(prior_cov), nrow(prior_cov) == ncol(prior_cov),
+    length(H) == length(groups), length(H) == length(effect_cov)
+  )
+  q <- nrow(prior_cov)
+  m <- vapply(H, ncol, integer(1))
+  stopifnot(
+    all(vapply(H, nrow, integer(1)) == q),
+    all(groups >= 2L),
+    all(vapply(seq_along(H), function(i) {
+      all(dim(effect_cov[[i]]) == groups[i] * m[i])
+    }, logical(1)))
+  )
+  n_conventional <- q + sum(groups * m)
+  n_transformed <- q + sum((groups - 1L) * m)
+  transform <- matrix(
+    0, nrow = n_transformed, ncol = n_conventional
+  )
+  transform[seq_len(q), seq_len(q)] <- diag(q)
+  bases <- lapply(groups, .s2z_basis)
+  col_offset <- q
+  row_offset <- q
+  for (i in seq_along(H)) {
+    effect_columns <- col_offset + seq_len(groups[i] * m[i])
+    contrast_rows <- row_offset + seq_len((groups[i] - 1L) * m[i])
+    mean_map <- kronecker(
+      diag(m[i]), matrix(rep(1 / groups[i], groups[i]), nrow = 1L)
+    )
+    contrast_map <- kronecker(diag(m[i]), t(bases[[i]]))
+    transform[seq_len(q), effect_columns] <- H[[i]] %*% mean_map
+    transform[contrast_rows, effect_columns] <- contrast_map
+    col_offset <- col_offset + groups[i] * m[i]
+    row_offset <- row_offset + (groups[i] - 1L) * m[i]
+  }
+  conventional_cov <- .s2z_block_diag(c(list(prior_cov), effect_cov))
+  list(
+    transform = transform,
+    covariance = transform %*% conventional_cov %*% t(transform),
+    bases = bases
+  )
+}
+
 # Compare the component-wise diagonal-plus-rank-one implementation with the
 # dense complete square it replaces.  This deliberately mirrors the scaled
 # equations in .stan_re_s2z_independent without calling code under test.
-.s2z_independent_case <- function(k, student = FALSE, center = TRUE) {
+.s2z_independent_case <- function(k, student = FALSE,
+                                  has_intercept = TRUE) {
   n <- 11L
   basis <- .s2z_basis(n)
   contrast <- matrix(
@@ -49,13 +115,13 @@ context("Tests for physical sum-to-zero group-level effects")
   prior_sd <- seq(0.65, 1.55, length.out = k)
   prior_prec <- 1 / prior_sd^2
   group_sd <- seq(0.4, 1.25, length.out = k)
-  intercept_map <- if (center) {
+  intercept_map <- if (has_intercept) {
     c(1, seq(-0.55, 0.65, length.out = k - 1L))
   } else {
     numeric(k)
   }
   H <- diag(k)
-  if (center) {
+  if (has_intercept) {
     H[1L, ] <- intercept_map
   }
   group_scale <- if (student) {
@@ -79,7 +145,7 @@ context("Tests for physical sum-to-zero group-level effects")
   base_score <- prior_prec * (theta - prior_mean)
   coupling_prec <- 0
   coupling_resid <- 0
-  if (center) {
+  if (has_intercept) {
     base_info[1L] <- 0
     base_score[1L] <- 0
     coupling_prec <- prior_prec[1L]
@@ -246,7 +312,9 @@ test_that("Gaussian completed-square density is normalized in S2Z coordinates", 
 
 test_that("independent Gaussian effects match the dense complete square", {
   for (k in c(2L, 5L, 10L)) {
-    ans <- .s2z_independent_case(k, student = FALSE, center = TRUE)
+    ans <- .s2z_independent_case(
+      k, student = FALSE, has_intercept = TRUE
+    )
 
     expect_equal(colSums(ans$r_s2z), numeric(k), tolerance = 2e-14)
     expect_equal(ans$dense_mode, ans$fast_mode, tolerance = 2e-13)
@@ -258,7 +326,9 @@ test_that("independent Gaussian effects match the dense complete square", {
 
 test_that("independent Student effects match the weighted dense square", {
   for (k in c(2L, 5L, 10L)) {
-    ans <- .s2z_independent_case(k, student = TRUE, center = TRUE)
+    ans <- .s2z_independent_case(
+      k, student = TRUE, has_intercept = TRUE
+    )
 
     # Unequal group scales make a physical zero-sum contrast have a nonzero
     # precision-weighted sum; this is the term the Gaussian shortcut omits.
@@ -272,7 +342,9 @@ test_that("independent Student effects match the weighted dense square", {
 test_that("rank-one generated-quantities covariance is exact", {
   for (k in c(2L, 5L, 10L)) {
     for (student in c(FALSE, TRUE)) {
-      ans <- .s2z_independent_case(k, student = student, center = TRUE)
+      ans <- .s2z_independent_case(
+        k, student = student, has_intercept = TRUE
+      )
       expect_equal(
         ans$gq_cov, ans$conditional_cov,
         tolerance = 3e-14, scale = 1
@@ -285,7 +357,9 @@ test_that("rank-one generated-quantities covariance is exact", {
 test_that("independent no-intercept effects reduce to diagonal solves", {
   for (k in c(2L, 5L, 10L)) {
     for (student in c(FALSE, TRUE)) {
-      ans <- .s2z_independent_case(k, student = student, center = FALSE)
+      ans <- .s2z_independent_case(
+        k, student = student, has_intercept = FALSE
+      )
       expect_equal(ans$rank1_info, 0)
       expect_equal(ans$dense_mode, ans$fast_mode, tolerance = 2e-13)
       expect_equal(ans$dense_log, ans$fast_log, tolerance = 2e-10)
@@ -478,6 +552,293 @@ test_that("heterogeneous Student mixture scales obey the complete square", {
       .s2z_log_mvn(group_mean, mhat, conditional_cov)
     expect_equal(by_identity, log_marginal, tolerance = 1e-10)
   }
+})
+
+test_that("multiple scalar factor means match the closed-form recovery law", {
+  groups <- c(3L, 5L, 8L)
+  tau <- c(0.45, 1.10, 0.72)
+  n_block <- length(groups)
+  v <- tau^2 / groups
+  total_v <- sum(v)
+  alpha <- v / (1 + total_v)
+  expected_conditional_cov <- diag(v) - tcrossprod(v) / (1 + total_v)
+
+  # This is exactly the scalar formula in the multifactored derivation:
+  # theta = mu_pop + sum(m), mu_pop ~ N(0, 1), and m_k ~ N(0, v_k).
+  P <- diag(1 / v) + matrix(1, nrow = n_block, ncol = n_block)
+  conditional_cov <- solve(P)
+  theta <- 0.83
+  conditional_mean <- drop(conditional_cov %*% rep(theta, n_block))
+  expect_equal(conditional_mean, alpha * theta, tolerance = 2e-14)
+  expect_equal(
+    conditional_cov, expected_conditional_cov, tolerance = 2e-14
+  )
+  expect_true(all(conditional_cov[row(conditional_cov) !=
+                                   col(conditional_cov)] < 0))
+
+  # Jointly drawing theta and then the conditional means must recover the
+  # original mutually independent population mean and factor means.
+  joint_cov <- rbind(
+    c(1 + total_v, v),
+    cbind(v, diag(v))
+  )
+  recovery_map <- rbind(
+    c(1, rep(-1, n_block)),
+    cbind(rep(0, n_block), diag(n_block))
+  )
+  recovered_cov <- recovery_map %*% joint_cov %*% t(recovery_map)
+  expect_equal(recovered_cov, diag(c(1, v)), tolerance = 2e-14)
+
+  # Independently compare the integrated density with a dense transformation
+  # of all conventional raw effects. This also checks every sqrt(G_k) measure
+  # correction rather than only the conditional moments above.
+  H <- replicate(n_block, matrix(1, nrow = 1L), simplify = FALSE)
+  effect_cov <- Map(
+    function(n, scale) diag(scale^2, nrow = n), groups, tau
+  )
+  dense <- .s2z_multiblock_dense_map(
+    matrix(1, nrow = 1L), H, groups, effect_cov
+  )
+  r_s2z <- lapply(seq_along(groups), function(i) {
+    z <- matrix(
+      sin(seq_len(groups[i] - 1L) * (0.31 + 0.07 * i)),
+      ncol = 1L
+    )
+    dense$bases[[i]] %*% z
+  })
+  transformed_value <- c(
+    theta,
+    unlist(Map(
+      function(basis, r) as.vector(crossprod(basis, r)),
+      dense$bases, r_s2z
+    ))
+  )
+  transformed_mean <- drop(dense$transform %*% numeric(1L + sum(groups)))
+  log_direct <- .s2z_log_mvn(
+    transformed_value, transformed_mean, dense$covariance
+  )
+  mhat <- conditional_mean
+  log_joint_at_mode <- stats::dnorm(
+    theta - sum(mhat), 0, 1, log = TRUE
+  ) + sum(vapply(seq_along(groups), function(i) {
+    sum(stats::dnorm(
+      r_s2z[[i]][, 1L] + mhat[i], 0, tau[i], log = TRUE
+    ))
+  }, numeric(1))) + 0.5 * sum(log(groups))
+  log_integrated <- log_joint_at_mode +
+    0.5 * n_block * log(2 * pi) - sum(log(diag(chol(P))))
+  expect_equal(log_integrated, log_direct, tolerance = 2e-11)
+})
+
+test_that("multiple vector blocks use one overlapping completed square", {
+  q <- 4L
+  groups <- c(3L, 5L, 4L)
+  dimensions <- c(2L, 1L, 3L)
+  H <- list(
+    matrix(0, nrow = q, ncol = dimensions[1L]),
+    matrix(0, nrow = q, ncol = dimensions[2L]),
+    matrix(0, nrow = q, ncol = dimensions[3L])
+  )
+  H[[1L]][1L, 1L] <- 1
+  H[[1L]][c(1L, 2L), 2L] <- c(0.35, 1)
+  H[[2L]][c(1L, 2L), 1L] <- c(-0.20, 1)
+  H[[3L]][1L, 1L] <- 1
+  H[[3L]][c(1L, 2L), 2L] <- c(0.10, 1)
+  H[[3L]][c(1L, 4L), 3L] <- c(-0.30, 1)
+  A <- do.call(cbind, H)
+  expect_gte(sum(A[2L, ] != 0), 3L)
+
+  prior_mean <- c(0.30, -0.45, 0.15, 0.70)
+  prior_cov <- diag(c(0.75, 1.10, 0.90, 1.35)^2)
+  prior_prec <- solve(prior_cov)
+  L3 <- rbind(
+    c(0.80, 0, 0),
+    c(0.15, 0.65, 0),
+    c(-0.10, 0.12, 0.55)
+  )
+  Sigma <- list(
+    matrix(c(0.81, 0.18, 0.18, 0.49), nrow = 2L),
+    matrix(0.64, nrow = 1L),
+    tcrossprod(L3)
+  )
+  effect_cov <- Map(
+    function(n, sigma) kronecker(sigma, diag(n)), groups, Sigma
+  )
+  dense <- .s2z_multiblock_dense_map(
+    prior_cov, H, groups, effect_cov
+  )
+  r_s2z <- lapply(seq_along(groups), function(i) {
+    z <- matrix(
+      sin(seq_len((groups[i] - 1L) * dimensions[i]) *
+            (0.21 + 0.08 * i)) +
+        cos(seq_len((groups[i] - 1L) * dimensions[i]) * 0.17),
+      nrow = groups[i] - 1L, ncol = dimensions[i]
+    ) / 2
+    dense$bases[[i]] %*% z
+  })
+  expect_equal(
+    unlist(lapply(r_s2z, colSums)), numeric(sum(dimensions)),
+    tolerance = 2e-14
+  )
+  theta <- c(0.95, -0.20, 0.55, -0.65)
+
+  group_information <- Map(
+    function(n, sigma) n * solve(sigma), groups, Sigma
+  )
+  group_score <- Map(
+    function(r, sigma) solve(sigma, colSums(r)), r_s2z, Sigma
+  )
+  P <- crossprod(A, prior_prec %*% A) +
+    .s2z_block_diag(group_information)
+  h <- drop(crossprod(A, prior_prec %*% (theta - prior_mean))) -
+    unlist(group_score)
+  mhat <- drop(solve(P, h))
+
+  block_id <- rep(seq_along(dimensions), dimensions)
+  cross_block <- outer(block_id, block_id, `!=`)
+  expect_gt(max(abs(P[cross_block])), 0.1)
+
+  offsets <- cumsum(c(0L, dimensions))
+  log_joint_at_mode <- .s2z_log_mvn(
+    theta - A %*% mhat, prior_mean, prior_cov
+  )
+  for (i in seq_along(groups)) {
+    mi <- mhat[offsets[i] + seq_len(dimensions[i])]
+    log_joint_at_mode <- log_joint_at_mode + sum(vapply(
+      seq_len(groups[i]),
+      function(j) .s2z_log_mvn(
+        r_s2z[[i]][j, ] + mi, numeric(dimensions[i]), Sigma[[i]]
+      ),
+      numeric(1)
+    ))
+  }
+  log_integrated <- log_joint_at_mode +
+    0.5 * sum(dimensions * log(groups)) +
+    0.5 * sum(dimensions) * log(2 * pi) -
+    sum(log(diag(chol(P))))
+
+  transformed_value <- c(
+    theta,
+    unlist(Map(
+      function(basis, r) as.vector(crossprod(basis, r)),
+      dense$bases, r_s2z
+    ))
+  )
+  conventional_mean <- c(
+    prior_mean, numeric(sum(groups * dimensions))
+  )
+  transformed_mean <- drop(dense$transform %*% conventional_mean)
+  log_direct <- .s2z_log_mvn(
+    transformed_value, transformed_mean, dense$covariance
+  )
+  expect_equal(log_integrated, log_direct, tolerance = 3e-10)
+})
+
+test_that("shared-scale multiblock covariances share one exact integral", {
+  q <- 3L
+  groups <- c(4L, 3L, 5L)
+  dimensions <- c(2L, 1L, 2L)
+  H <- list(
+    matrix(c(1, 0, 0, 0.25, 1, 0), nrow = q),
+    matrix(c(-0.15, 1, 0), nrow = q),
+    matrix(c(1, 0, 0, -0.30, 0, 1), nrow = q)
+  )
+  A <- do.call(cbind, H)
+  prior_mean <- c(-0.20, 0.55, 0.10)
+  prior_cov <- diag(c(0.65, 1.20, 0.85)^2)
+  prior_prec <- solve(prior_cov)
+
+  cor_1 <- matrix(c(1, 0.35, 0.35, 1), nrow = 2L)
+  cor_3 <- matrix(c(1, -0.28, -0.28, 1), nrow = 2L)
+  Sigma <- list(
+    diag(c(0.64, 0.78)) %*% cor_1 %*% diag(c(0.64, 0.78)),
+    matrix(0.71^2, nrow = 1L),
+    diag(c(0.72, 0.59)) %*% cor_3 %*% diag(c(0.72, 0.59))
+  )
+  effect_cov <- Map(
+    function(n, sigma) kronecker(sigma, diag(n)), groups, Sigma
+  )
+  dense <- .s2z_multiblock_dense_map(
+    prior_cov, H, groups, effect_cov
+  )
+  r_s2z <- lapply(seq_along(groups), function(i) {
+    z <- matrix(
+      sin(seq_len((groups[i] - 1L) * dimensions[i]) *
+            (0.34 + 0.05 * i)) -
+        cos(seq_len((groups[i] - 1L) * dimensions[i]) * 0.29),
+      nrow = groups[i] - 1L, ncol = dimensions[i]
+    ) / 1.7
+    dense$bases[[i]] %*% z
+  })
+  expect_equal(
+    unlist(lapply(r_s2z, colSums)), numeric(sum(dimensions)),
+    tolerance = 2e-14
+  )
+
+  group_information <- vector("list", length(groups))
+  group_score <- vector("list", length(groups))
+  for (i in seq_along(groups)) {
+    precision <- solve(Sigma[[i]])
+    group_information[[i]] <- groups[i] * precision
+    group_score[[i]] <- precision %*% colSums(r_s2z[[i]])
+  }
+  expect_equal(
+    unlist(group_score), numeric(sum(dimensions)), tolerance = 2e-13
+  )
+
+  theta <- c(0.85, -0.35, 0.62)
+  P <- crossprod(A, prior_prec %*% A) +
+    .s2z_block_diag(group_information)
+  h <- drop(crossprod(A, prior_prec %*% (theta - prior_mean))) -
+    unlist(group_score)
+  mhat <- drop(solve(P, h))
+  conditional_cov <- solve(P)
+  offsets <- cumsum(c(0L, dimensions))
+  log_joint_measure <- function(group_mean) {
+    out <- .s2z_log_mvn(
+      theta - A %*% group_mean, prior_mean, prior_cov
+    )
+    for (i in seq_along(groups)) {
+      mi <- group_mean[offsets[i] + seq_len(dimensions[i])]
+      out <- out + sum(vapply(seq_len(groups[i]), function(j) {
+        .s2z_log_mvn(
+          r_s2z[[i]][j, ] + mi, numeric(dimensions[i]),
+          Sigma[[i]]
+        )
+      }, numeric(1)))
+    }
+    out + 0.5 * sum(dimensions * log(groups))
+  }
+  log_marginal <- log_joint_measure(mhat) +
+    0.5 * sum(dimensions) * log(2 * pi) -
+    sum(log(diag(chol(P))))
+
+  candidate_means <- list(
+    mhat,
+    mhat + seq(-0.30, 0.25, length.out = sum(dimensions)),
+    c(-0.80, 0.35, 0.20, -0.45, 0.70)
+  )
+  for (group_mean in candidate_means) {
+    by_identity <- log_joint_measure(group_mean) -
+      .s2z_log_mvn(group_mean, mhat, conditional_cov)
+    expect_equal(by_identity, log_marginal, tolerance = 3e-10)
+  }
+
+  transformed_value <- c(
+    theta,
+    unlist(Map(
+      function(basis, r) as.vector(crossprod(basis, r)),
+      dense$bases, r_s2z
+    ))
+  )
+  conventional_mean <- c(
+    prior_mean, numeric(sum(groups * dimensions))
+  )
+  transformed_mean <- drop(dense$transform %*% conventional_mean)
+  log_direct <- .s2z_log_mvn(
+    transformed_value, transformed_mean, dense$covariance
+  )
+  expect_equal(log_marginal, log_direct, tolerance = 4e-10)
 })
 
 test_that("centering preserves numeric and mixed-interaction predictors", {

--- a/tests/testthat/tests.s2z.R
+++ b/tests/testthat/tests.s2z.R
@@ -156,6 +156,66 @@ context("Tests for physical sum-to-zero group-level effects")
   out
 }
 
+# Independent density/Jacobian reference for the standardized explicit mean
+# v = sqrt(N) L^-1 m used when an active population prior is non-Gaussian.
+.s2z_explicit_mean_case <- function(level_scale = NULL) {
+  n <- 6L
+  m <- 2L
+  basis <- .s2z_basis(n)
+  L <- matrix(c(0.72, 0, -0.18, 1.07), nrow = m, byrow = TRUE)
+  z <- matrix(
+    sin(seq_len((n - 1L) * m) * 0.37) +
+      cos(seq_len((n - 1L) * m) * 0.19),
+    nrow = n - 1L, ncol = m
+  ) / 2.4
+  v <- c(-0.43, 0.68)
+  contrast <- basis %*% z
+  mean_effect <- drop(L %*% v / sqrt(n))
+  effects <- sweep(contrast, 2L, mean_effect, "+")
+  if (is.null(level_scale)) {
+    level_scale <- rep(1, n)
+  }
+  stopifnot(length(level_scale) == n, all(level_scale > 0))
+
+  # Construct the full square map from (vec(z), v) to vec(effects). The
+  # determinant is checked directly rather than assumed from the derivation.
+  transform <- function(value) {
+    z_value <- matrix(value[seq_len((n - 1L) * m)], nrow = n - 1L)
+    v_value <- value[(n - 1L) * m + seq_len(m)]
+    as.vector(sweep(
+      basis %*% z_value, 2L, drop(L %*% v_value / sqrt(n)), "+"
+    ))
+  }
+  dimension <- n * m
+  map <- vapply(seq_len(dimension), function(i) {
+    unit <- numeric(dimension)
+    unit[i] <- 1
+    transform(unit)
+  }, numeric(dimension))
+  log_jacobian <- as.numeric(
+    determinant(map, logarithm = TRUE)$modulus
+  )
+
+  Sigma <- tcrossprod(L)
+  conventional_log <- sum(vapply(seq_len(n), function(j) {
+    .s2z_log_mvn(
+      effects[j, ], numeric(m), level_scale[j]^2 * Sigma
+    )
+  }, numeric(1))) + log_jacobian
+  white_contrast <- t(forwardsolve(L, t(contrast)))
+  white_full <- sweep(white_contrast, 2L, v / sqrt(n), "+")
+  explicit_log <- -0.5 * sum(
+    sweep(white_full, 1L, level_scale, "/")^2
+  ) - (n - 1L) * sum(log(diag(L))) -
+    m * sum(log(level_scale)) - 0.5 * n * m * log(2 * pi)
+
+  list(
+    n = n, m = m, L = L, z = z, v = v, contrast = contrast,
+    effects = effects, map = map, log_jacobian = log_jacobian,
+    conventional_log = conventional_log, explicit_log = explicit_log
+  )
+}
+
 # Compare the component-wise diagonal-plus-rank-one implementation with the
 # dense complete square it replaces.  This deliberately mirrors the scaled
 # equations in .stan_re_s2z_independent without calling code under test.
@@ -300,6 +360,103 @@ test_that("the physical sum-to-zero transform is orthonormal", {
     expect_equal(sum(z), 0, tolerance = 1e-14)
     expect_equal(sum(z^2), sum(y^2), tolerance = 1e-14)
   }
+})
+
+test_that("standardized explicit means have the exact restricted Jacobian", {
+  for (level_scale in list(NULL, seq(0.55, 1.45, length.out = 6L))) {
+    ans <- .s2z_explicit_mean_case(level_scale)
+    expect_equal(
+      ans$log_jacobian, sum(log(diag(ans$L))), tolerance = 3e-14
+    )
+    expect_equal(
+      ans$explicit_log, ans$conventional_log, tolerance = 3e-12
+    )
+    expect_equal(colSums(ans$contrast), numeric(ans$m), tolerance = 2e-14)
+  }
+})
+
+test_that("explicit S2Z means preserve exact logistic population priors", {
+  ans <- .s2z_explicit_mean_case()
+  q <- 3L
+  H <- matrix(c(1, 0.25, -0.4, 0.8, 0.15, 1), nrow = q)
+  theta <- c(0.7, -0.35, 0.2)
+  location <- c(-0.2, 0.1, 0.4)
+  scale <- c(0.8, 1.3, 0.65)
+  mean_effect <- drop(ans$L %*% ans$v / sqrt(ans$n))
+  beta <- drop(theta - H %*% mean_effect)
+
+  # The joint map (z, v, theta) -> (full effects, beta) is block
+  # triangular. Verify its determinant directly, including the dependence of
+  # the conventional coefficients on the omitted group mean.
+  dimension <- ans$n * ans$m + q
+  transform <- function(value) {
+    z <- matrix(
+      value[seq_len((ans$n - 1L) * ans$m)],
+      nrow = ans$n - 1L
+    )
+    v <- value[(ans$n - 1L) * ans$m + seq_len(ans$m)]
+    theta_value <- value[ans$n * ans$m + seq_len(q)]
+    mean_value <- drop(ans$L %*% v / sqrt(ans$n))
+    effects <- sweep(.s2z_basis(ans$n) %*% z, 2L, mean_value, "+")
+    c(as.vector(effects), drop(theta_value - H %*% mean_value))
+  }
+  map <- vapply(seq_len(dimension), function(i) {
+    unit <- numeric(dimension)
+    unit[i] <- 1
+    transform(unit)
+  }, numeric(dimension))
+  log_jacobian <- as.numeric(
+    determinant(map, logarithm = TRUE)$modulus
+  )
+
+  conventional <- ans$conventional_log +
+    sum(dlogis(beta, location = location, scale = scale, log = TRUE))
+  explicit <- ans$explicit_log +
+    sum(dlogis(beta, location = location, scale = scale, log = TRUE))
+  expect_equal(
+    log_jacobian, sum(log(diag(ans$L))), tolerance = 4e-14
+  )
+  expect_equal(explicit, conventional, tolerance = 3e-12)
+})
+
+test_that("explicit means preserve the likelihood under overlapping maps", {
+  n <- c(5L, 7L)
+  group <- list(
+    rep(seq_len(n[1L]), length.out = 35L),
+    rep(seq_len(n[2L]), each = 5L)
+  )
+  H <- list(
+    matrix(c(1, 0.3, 0, 1), nrow = 2L),
+    matrix(c(-0.2, 1), nrow = 2L)
+  )
+  design <- cbind(
+    sin(seq_len(35L) * 0.21), cos(seq_len(35L) * 0.17)
+  )
+  beta <- c(0.45, -0.72)
+  means <- list(c(0.31, -0.28), 0.53)
+  contrasts <- list(
+    .s2z_basis(n[1L]) %*% matrix(
+      sin(seq_len((n[1L] - 1L) * 2L) * 0.39), ncol = 2L
+    ),
+    .s2z_basis(n[2L]) %*% matrix(
+      cos(seq_len(n[2L] - 1L) * 0.27), ncol = 1L
+    )
+  )
+  theta <- beta + H[[1L]] %*% means[[1L]] + H[[2L]] %*% means[[2L]]
+  conventional <- drop(design %*% beta)
+  finite <- drop(design %*% theta)
+  for (b in seq_along(H)) {
+    block_design <- design %*% H[[b]]
+    conventional <- conventional + rowSums(
+      block_design * sweep(
+        contrasts[[b]][group[[b]], , drop = FALSE], 2L, means[[b]], "+"
+      )
+    )
+    finite <- finite + rowSums(
+      block_design * contrasts[[b]][group[[b]], , drop = FALSE]
+    )
+  }
+  expect_equal(finite, conventional, tolerance = 3e-14)
 })
 
 test_that("Gaussian completed-square density is normalized in S2Z coordinates", {
@@ -1209,11 +1366,14 @@ test_that("generated Stan code contains the S2Z algebra and measure", {
   )
   expect_match2(
     gaussian_code,
-    "array[M_1] vector[N_1 - 1] z_s2z_1;"
+    "vector[M_1 * (N_1 - 1)] z_s2z_1;"
   )
   expect_match2(
     gaussian_code,
-    "r_s2z_1[, k] = sum_to_zero_constrain_brms(z_s2z_1[k]);"
+    paste0(
+      "r_s2z_1[, k] = sum_to_zero_constrain_brms(segment(z_s2z_1, ",
+      "(k - 1) * (N_1 - 1) + 1, N_1 - 1));"
+    )
   )
   expect_match2(gaussian_code, "H_s2z_1[1, 2] = means_X[1];")
   expect_match2(gaussian_code, "H_s2z_1[1, 4] = means_X[3];")

--- a/tests/testthat/tests.s2z.R
+++ b/tests/testthat/tests.s2z.R
@@ -97,6 +97,65 @@ context("Tests for physical sum-to-zero group-level effects")
   )
 }
 
+# Independent reference for the Gaussian Matheron shortcut with arbitrary
+# rectangular loading maps.  The implementation below deliberately forms the
+# full omitted-mean precision as a check on the lower-dimensional update; the
+# production fast path must not need this matrix.
+.s2z_matheron_case <- function(
+    theta, prior_mean, prior_cov, H, groups, covariance,
+    prior_draw = NULL) {
+  stopifnot(
+    length(H) == length(groups), length(H) == length(covariance),
+    length(theta) == length(prior_mean),
+    all(dim(prior_cov) == length(theta))
+  )
+  q <- length(theta)
+  dimensions <- vapply(H, ncol, integer(1))
+  stopifnot(
+    all(vapply(H, nrow, integer(1)) == q),
+    all(vapply(seq_along(H), function(i) {
+      all(dim(covariance[[i]]) == dimensions[i])
+    }, logical(1)))
+  )
+  A <- do.call(cbind, H)
+  S <- lapply(seq_along(H), function(i) covariance[[i]] / groups[i])
+  S_stack <- .s2z_block_diag(S)
+  W <- prior_cov + A %*% S_stack %*% t(A)
+  W_inv <- solve(W)
+  difference <- theta - prior_mean
+
+  # Dense completed-square reference in the stacked omitted means.
+  prior_prec <- solve(prior_cov)
+  P <- solve(S_stack) + crossprod(A, prior_prec %*% A)
+  h <- drop(crossprod(A, prior_prec %*% difference))
+  dense_mean <- drop(solve(P, h))
+  dense_cov <- solve(P)
+
+  # Matheron conditional moments use only the q by q induced covariance W.
+  fast_mean <- drop(S_stack %*% t(A) %*% W_inv %*% difference)
+  fast_cov <- S_stack -
+    S_stack %*% t(A) %*% W_inv %*% A %*% S_stack
+
+  out <- list(
+    A = A, S = S, S_stack = S_stack, W = W,
+    dense_mean = dense_mean, dense_cov = dense_cov,
+    fast_mean = fast_mean, fast_cov = fast_cov
+  )
+  if (!is.null(prior_draw)) {
+    stopifnot(length(prior_draw) == q + sum(dimensions))
+    beta_star <- prior_draw[seq_len(q)]
+    m_star <- prior_draw[q + seq_len(sum(dimensions))]
+    theta_star <- drop(beta_star + A %*% m_star)
+    delta <- drop(W_inv %*% (theta - theta_star))
+    beta_recovered <- drop(beta_star + prior_cov %*% delta)
+    m_recovered <- drop(m_star + S_stack %*% t(A) %*% delta)
+    out$beta_recovered <- beta_recovered
+    out$m_recovered <- m_recovered
+    out$theta_recovered <- drop(beta_recovered + A %*% m_recovered)
+  }
+  out
+}
+
 # Compare the component-wise diagonal-plus-rank-one implementation with the
 # dense complete square it replaces.  This deliberately mirrors the scaled
 # equations in .stan_re_s2z_independent without calling code under test.
@@ -628,6 +687,253 @@ test_that("multiple scalar factor means match the closed-form recovery law", {
   log_integrated <- log_joint_at_mode +
     0.5 * n_block * log(2 * pi) - sum(log(diag(chol(P))))
   expect_equal(log_integrated, log_direct, tolerance = 2e-11)
+})
+
+test_that("large scalar Gaussian systems have exact Matheron recovery", {
+  n_factor <- 31L
+  groups <- 2L + (seq_len(n_factor) %% 13L)
+  tau <- 0.25 + (seq_len(n_factor) %% 9L) / 8
+  H <- replicate(n_factor, matrix(1, nrow = 1L), simplify = FALSE)
+  covariance <- lapply(tau, function(x) matrix(x^2, nrow = 1L))
+  theta <- 0.87
+  prior_mean <- -0.23
+  prior_cov <- matrix(1.7^2, nrow = 1L)
+  v <- tau^2 / groups
+
+  beta_star <- 0.41
+  m_star <- sin(seq_len(n_factor) * 0.37) * sqrt(v)
+  ans <- .s2z_matheron_case(
+    theta, prior_mean, prior_cov, H, groups, covariance,
+    prior_draw = c(beta_star, m_star)
+  )
+  W <- drop(prior_cov) + sum(v)
+  expected_mean <- v / W * (theta - prior_mean)
+  expected_cov <- diag(v) - tcrossprod(v) / W
+
+  expect_equal(ans$W, matrix(W, nrow = 1L), tolerance = 2e-14)
+  expect_equal(ans$fast_mean, expected_mean, tolerance = 2e-13)
+  expect_equal(ans$dense_mean, expected_mean, tolerance = 2e-13)
+  expect_equal(ans$fast_cov, expected_cov, tolerance = 3e-13)
+  expect_equal(ans$dense_cov, expected_cov, tolerance = 3e-13)
+  expect_true(all(ans$fast_cov[row(ans$fast_cov) !=
+                                 col(ans$fast_cov)] < 0))
+  expect_equal(ans$theta_recovered, theta, tolerance = 3e-14)
+
+  # This explicit update is the scalar Matheron algorithm.  It needs only W,
+  # even though the omitted means have dimension 31.
+  theta_star <- beta_star + sum(m_star)
+  delta <- (theta - theta_star) / W
+  expect_equal(
+    ans$beta_recovered, beta_star + drop(prior_cov) * delta,
+    tolerance = 2e-14
+  )
+  expect_equal(ans$m_recovered, m_star + v * delta, tolerance = 2e-14)
+})
+
+test_that("rectangular overlapping blocks use exact Matheron moments and density", {
+  q <- 5L
+  groups <- c(3L, 8L, 5L, 11L)
+  dimensions <- c(2L, 1L, 3L, 2L)
+  H <- lapply(dimensions, function(m) matrix(0, nrow = q, ncol = m))
+  H[[1L]][cbind(c(1L, 2L, 1L), c(1L, 1L, 2L))] <- c(1, 1, 0.31)
+  H[[1L]][3L, 2L] <- 1
+  H[[2L]][c(1L, 2L), 1L] <- c(-0.27, 1)
+  H[[3L]][1L, ] <- c(1, 0.18, -0.22)
+  H[[3L]][cbind(c(2L, 4L, 5L), seq_len(3L))] <- 1
+  H[[4L]][1L, ] <- c(1, 0.36)
+  H[[4L]][cbind(c(3L, 5L), seq_len(2L))] <- 1
+  A <- do.call(cbind, H)
+  expect_gt(sum(rowSums(A != 0) > 1L), 2L)
+
+  prior_mean <- c(-0.4, 0.25, 0.15, -0.6, 0.75)
+  prior_cov <- diag(c(0.8, 1.1, 0.65, 1.35, 0.9)^2)
+  L <- list(
+    matrix(c(0.62, 0, 0.17, 0.91), nrow = 2L, byrow = TRUE),
+    matrix(0.73, nrow = 1L),
+    matrix(c(
+      0.55, 0, 0, -0.12, 0.84, 0, 0.20, 0.09, 0.68
+    ), nrow = 3L, byrow = TRUE),
+    matrix(c(1.02, 0, -0.23, 0.59), nrow = 2L, byrow = TRUE)
+  )
+  covariance <- lapply(L, tcrossprod)
+  theta <- c(0.95, -0.35, 0.57, 0.12, -0.81)
+  prior_draw <- c(
+    prior_mean + c(0.14, -0.31, 0.22, 0.17, -0.08),
+    sin(seq_len(sum(dimensions)) * 0.43) / 3
+  )
+  ans <- .s2z_matheron_case(
+    theta, prior_mean, prior_cov, H, groups, covariance,
+    prior_draw = prior_draw
+  )
+
+  expect_equal(ans$fast_mean, ans$dense_mean, tolerance = 3e-13)
+  expect_equal(ans$fast_cov, ans$dense_cov, tolerance = 4e-13)
+  expect_equal(ans$theta_recovered, theta, tolerance = 3e-14)
+
+  # Independently construct the covariance of the shared Matheron update.
+  C <- .s2z_block_diag(list(prior_cov, ans$S_stack))
+  B <- cbind(diag(q), A)
+  update <- diag(nrow(C)) - C %*% t(B) %*% solve(ans$W, B)
+  recovered_cov <- update %*% C %*% t(update)
+  expected_cov <- C - C %*% t(B) %*% solve(ans$W, B %*% C)
+  expect_equal(recovered_cov, expected_cov, tolerance = 5e-13)
+  expect_equal(
+    recovered_cov[q + seq_len(sum(dimensions)),
+                  q + seq_len(sum(dimensions))],
+    ans$dense_cov, tolerance = 5e-13
+  )
+  expect_equal(B %*% update, matrix(0, nrow = q, ncol = nrow(C)),
+               tolerance = 3e-14)
+
+  # The separated Matheron density equals the dense pushforward of ordinary
+  # Gaussian population and level effects, including unequal group sizes.
+  effect_cov <- Map(
+    function(n, sigma) kronecker(sigma, diag(n)), groups, covariance
+  )
+  dense <- .s2z_multiblock_dense_map(prior_cov, H, groups, effect_cov)
+  contrast <- lapply(seq_along(groups), function(i) {
+    matrix(
+      sin(seq_len((groups[i] - 1L) * dimensions[i]) *
+            (0.19 + 0.03 * i)),
+      nrow = groups[i] - 1L, ncol = dimensions[i]
+    ) / 2
+  })
+  transformed_value <- c(theta, unlist(contrast))
+  transformed_mean <- drop(dense$transform %*%
+    c(prior_mean, numeric(sum(groups * dimensions))))
+  log_dense <- .s2z_log_mvn(
+    transformed_value, transformed_mean, dense$covariance
+  )
+  log_fast <- .s2z_log_mvn(theta, prior_mean, ans$W) +
+    sum(vapply(seq_along(groups), function(i) {
+      .s2z_log_mvn(
+        as.vector(contrast[[i]]), numeric((groups[i] - 1L) * dimensions[i]),
+        kronecker(covariance[[i]], diag(groups[i] - 1L))
+      )
+    }, numeric(1)))
+  expect_equal(log_fast, log_dense, tolerance = 5e-10)
+})
+
+test_that("Matheron conditions only proper active population coordinates", {
+  groups <- c(4L, 7L, 5L)
+  dimensions <- c(2L, 1L, 2L)
+  H <- list(
+    matrix(c(1, 0.25, 1, 0, 0, 0, 0, -0.3, 0, 1), nrow = 5L),
+    matrix(c(-0.2, 1, 0, 0, 0), nrow = 5L),
+    matrix(c(0.4, 0, 0, 0, 1, -0.1, 0, 0, 0, 0.7), nrow = 5L)
+  )
+  A <- do.call(cbind, H)
+  covariance <- list(
+    matrix(c(0.64, 0.12, 0.12, 0.49), nrow = 2L),
+    matrix(0.81, nrow = 1L),
+    matrix(c(0.36, -0.08, -0.08, 0.72), nrow = 2L)
+  )
+  S <- .s2z_block_diag(Map(
+    function(sigma, n) sigma / n, covariance, groups
+  ))
+  # Rows 1 and 4 have proper priors, but row 4 is inactive. Rows 2 and 5
+  # are active and flat. Thus the shared conditioning system has rank one.
+  proper <- c(TRUE, FALSE, FALSE, TRUE, FALSE)
+  active_proper <- which(proper & rowSums(A != 0) > 0)
+  inactive_proper <- which(proper & rowSums(A != 0) == 0)
+  expect_identical(active_proper, 1L)
+  expect_identical(inactive_proper, 4L)
+  prior_mean <- c(-0.35, NA, NA, 0.42, NA)
+  prior_var <- c(1.3^2, NA, NA, 0.75^2, NA)
+  theta <- c(0.8, -0.2, 0.55, 0.1, -0.65)
+
+  A_active <- A[active_proper, , drop = FALSE]
+  W <- prior_var[active_proper] +
+    drop(A_active %*% S %*% t(A_active))
+  expected_mean <- drop(
+    S %*% t(A_active) / W *
+      (theta[active_proper] - prior_mean[active_proper])
+  )
+  expected_cov <- S -
+    S %*% t(A_active) %*% A_active %*% S / W
+
+  # Dense conditional reference excludes flat and proper-inactive rows.
+  P <- solve(S) + crossprod(A_active) / prior_var[active_proper]
+  h <- drop(t(A_active) *
+    (theta[active_proper] - prior_mean[active_proper]) /
+    prior_var[active_proper])
+  expect_equal(drop(solve(P, h)), expected_mean, tolerance = 2e-13)
+  expect_equal(solve(P), expected_cov, tolerance = 3e-13)
+
+  # The normalized density on the proper theta coordinates and every
+  # contrast agrees with direct integration over the omitted means. Flat
+  # active theta rows correctly contribute only their Lebesgue constant.
+  bases <- lapply(groups, .s2z_basis)
+  contrast <- lapply(seq_along(groups), function(i) {
+    matrix(
+      cos(seq_len((groups[i] - 1L) * dimensions[i]) *
+            (0.22 + 0.04 * i)),
+      nrow = groups[i] - 1L, ncol = dimensions[i]
+    ) / 2.4
+  })
+  r_s2z <- Map(`%*%`, bases, contrast)
+  mhat <- expected_mean
+  offsets <- cumsum(c(0L, dimensions))
+  log_joint_mode <- sum(stats::dnorm(
+    (theta - A %*% mhat)[proper], prior_mean[proper],
+    sqrt(prior_var[proper]), log = TRUE
+  ))
+  for (i in seq_along(groups)) {
+    mi <- mhat[offsets[i] + seq_len(dimensions[i])]
+    log_joint_mode <- log_joint_mode + sum(vapply(
+      seq_len(groups[i]),
+      function(j) .s2z_log_mvn(
+        r_s2z[[i]][j, ] + mi, numeric(dimensions[i]), covariance[[i]]
+      ),
+      numeric(1)
+    )) + 0.5 * dimensions[i] * log(groups[i])
+  }
+  log_integrated <- log_joint_mode +
+    0.5 * sum(dimensions) * log(2 * pi) -
+    0.5 * as.numeric(determinant(P, logarithm = TRUE)$modulus)
+  log_fast <- stats::dnorm(
+    theta[active_proper], prior_mean[active_proper], sqrt(W), log = TRUE
+  ) + stats::dnorm(
+    theta[inactive_proper], prior_mean[inactive_proper],
+    sqrt(prior_var[inactive_proper]), log = TRUE
+  ) + sum(vapply(seq_along(groups), function(i) {
+    .s2z_log_mvn(
+      as.vector(contrast[[i]]),
+      numeric((groups[i] - 1L) * dimensions[i]),
+      kronecker(covariance[[i]], diag(groups[i] - 1L))
+    )
+  }, numeric(1)))
+  expect_equal(log_fast, log_integrated, tolerance = 4e-10)
+
+  beta_star <- prior_mean[active_proper] + 0.27
+  m_star <- cos(seq_len(sum(dimensions)) * 0.31) / 4
+  theta_star <- beta_star + drop(A_active %*% m_star)
+  delta <- (theta[active_proper] - theta_star) / W
+  m_recovered <- drop(m_star + S %*% t(A_active) * delta)
+  beta_recovered <- theta - drop(A %*% m_recovered)
+  beta_recovered[active_proper] <- beta_star +
+    prior_var[active_proper] * delta
+  beta_recovered[inactive_proper] <- theta[inactive_proper]
+  expect_equal(
+    beta_recovered + drop(A %*% m_recovered), theta,
+    tolerance = 3e-14
+  )
+
+  # With no proper active coordinate, theta supplies no information about the
+  # omitted means: draw them directly and recover every active flat beta.
+  proper_r0 <- c(FALSE, FALSE, FALSE, TRUE, FALSE)
+  expect_length(which(proper_r0 & rowSums(A != 0) > 0), 0L)
+  no_active_proper <- which(proper_r0 & rowSums(A != 0) == 0)
+  expect_identical(no_active_proper, 4L)
+  P_r0 <- solve(S)
+  expect_equal(
+    drop(solve(P_r0, numeric(sum(dimensions)))),
+    numeric(sum(dimensions)), tolerance = 2e-14
+  )
+  expect_equal(solve(P_r0), S, tolerance = 2e-14)
+  beta_r0 <- theta - drop(A %*% m_star)
+  beta_r0[no_active_proper] <- theta[no_active_proper]
+  expect_equal(beta_r0 + drop(A %*% m_star), theta, tolerance = 3e-14)
 })
 
 test_that("multiple vector blocks use one overlapping completed square", {


### PR DESCRIPTION
## Summary

This PR adds an experimental, opt-in physical sum-to-zero (S2Z)
parameterization for ordinary group-level effects:

```r
y ~ x + (1 + x | gr(g, s2z = TRUE))
```

During sampling, each varying-coefficient vector is represented by deviations
that sum exactly to zero over the observed grouping levels. The omitted common
group-effect means are handled jointly with the matching population
coefficients. Conventional population coefficients and group effects are then
reconstructed in generated quantities, so the existing `fixef()`, `ranef()`,
`coef()`, prediction, and update interfaces retain their public meaning.

This is a separate, deliberately reduced foundation PR. It does not replace or
modify draft PR #1919. That branch retains the broader experiments with
group-varying scales, partial centering, and automatic Fisher centering; those
modes are intentionally absent here so the physical/shared-scale foundation
can be reviewed independently.

## Supported foundation

- matched varying intercepts, numeric and factor slopes, and interactions;
- Gaussian and Student-t group effects;
- correlated or independent coefficients;
- one or multiple predictor-local S2Z blocks;
- eligible location, distributional, nonlinear, categorical, multinomial, and
  multivariate predictors, with a separate S2Z ID in each linear predictor;
- coefficient-specific `sd` parameters shared across grouping levels;
- exact flat, normal, Student-t, Cauchy, and logistic priors with numeric
  constant arguments on S2Z-active population coordinates;
- conventional public draws reconstructed from the physical coordinates.

The implementation includes specialized scalar, diagonal, and Gaussian
Matheron paths, plus contextual capability diagnostics and a documented
support matrix.

## Deliberate exclusions

This foundation does not include centered, partially centered, or automatic
centering modes, group-varying scales, or priors on realized level-specific
scales. It also rejects currently unsupported structures such as `by`, `cov`,
`pw`, multi-membership and special group coefficients, cross-predictor IDs,
ordinal location predictors, and sparse or QR population designs.

In particular, `cov = A` phylogenetic or pedigree effects and a shared
multivariate `| q |` group-effect ID remain conventional-only features for now.
The resulting diagnostics identify the unsupported capability and give a
model-specific remedy.

## Validation

- Rebasing onto current `origin/master` completed without conflicts.
- `git range-diff` reports all 11 implementation/documentation patches as
  unchanged from the previously verified foundation series.
- Package installation succeeds.
- All focused `tests.s2z*` testthat files pass after the rebase.
- The committed fixtures cover Stan generation, exact transformation and
  Jacobian identities, capability boundaries, public reconstruction,
  allocation-safe specialized paths, and posterior-equivalence checks.

## AI and source-material disclosure

This PR was developed with assistance from OpenAI Codex under Sean Pinkney's
direction. It draws on issue #1916, Sean's mathematical derivations, prototype
Stan programs, recovery identities, and benchmark designs. The uncommitted
reference-only derivations and prototypes are not part of this PR; the
implementation, documentation, provenance manifest, and committed tests are
the reviewable record for the claims above.

Refs #1916.
