### PR TITLE
Include the lower bound in truncated discrete posterior_epred

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@ Thanks to Gidon Frischkorn. (#1450)
 
 ### Bug Fixes
 
+* Include the lower bound when computing `posterior_epred` for truncated
+discrete models, matching the generated Stan code and `log_lik`.
+Thanks to Ahmed Eldeeb. (#1923)
 * Normalize truncated `log_lik` by `P(lb <= Y <= ub)` for integer
 responses, matching the generated Stan code, so that `loo` and `waic`
 agree with the model that was fitted. Thanks to Ahmed Eldeeb. (#1903)

--- a/R/posterior_epred.R
+++ b/R/posterior_epred.R
@@ -905,18 +905,20 @@ posterior_epred_trunc_discrete <- function(dist, args, lb, ub) {
   vec_lb <- lb[1, ]
   vec_ub <- ub[1, ]
   min_lb <- min(vec_lb)
-  # array of dimension S x N x length((lb+1):ub)
-  mk <- lapply((min_lb + 1):max(vec_ub), mean_kernel, args = args)
+  # the bounds are inclusive for integer responses, as in the Stan code and
+  # in log_lik; see #1923
+  # array of dimension S x N x length(lb:ub)
+  mk <- lapply(min_lb:max(vec_ub), mean_kernel, args = args)
   mk <- do_call(abind, c(mk, along = 3))
   m1 <- vector("list", ncol(mk))
   for (n in seq_along(m1)) {
     # summarize only over non-truncated values for this observation
-    J <- (vec_lb[n] - min_lb + 1):(vec_ub[n] - min_lb)
+    J <- (vec_lb[n] - min_lb + 1):(vec_ub[n] - min_lb + 1)
     m1[[n]] <- rowSums(mk[, n, ][, J, drop = FALSE])
   }
   rm(mk)
   m1 <- do.call(cbind, m1)
-  m1 / (do.call(cdf, c(list(ub), args)) - do.call(cdf, c(list(lb), args)))
+  m1 / (do.call(cdf, c(list(ub), args)) - do.call(cdf, c(list(lb - 1), args)))
 }
 
 #' @export

--- a/R/posterior_epred.R
+++ b/R/posterior_epred.R
@@ -901,6 +901,11 @@ posterior_epred_trunc_discrete <- function(dist, args, lb, ub) {
   if (any(is.infinite(c(lb, ub)))) {
     stop("lb and ub must be finite")
   }
+  # integer responses admit ceiling(lb):floor(ub), and log_lik_truncate()
+  # rounds the same way; without this a single non-integer bound turns the
+  # whole kernel grid fractional and zeroes every observation
+  lb <- ceiling(lb)
+  ub <- floor(ub)
   # simplify lb and ub back to vector format
   vec_lb <- lb[1, ]
   vec_ub <- ub[1, ]

--- a/tests/testthat/tests.posterior_epred.R
+++ b/tests/testthat/tests.posterior_epred.R
@@ -276,6 +276,18 @@ test_that("truncated discrete posterior_epred keeps the lower bound", {
     sum((0:6) * dpois(0:6, lambda)) / ppois(6, lambda)
   )
 
+  # a non-integer bound rounds to the support it admits, as in log_lik.
+  # min_lb is a grid origin shared by all observations, so one fractional
+  # bound would otherwise zero every column
+  got <- suppressMessages(brms:::posterior_epred_trunc_poisson(
+    epred_prep(lambda, poisson()), lb = bnd(2.5), ub = bnd(6)
+  ))
+  expect_equal(
+    got[1],
+    sum((3:6) * dpois(3:6, lambda)) /
+      (ppois(6, lambda) - ppois(2, lambda))
+  )
+
   # negbinomial covers the other cdf shape in the affected set
   got <- suppressMessages(brms:::posterior_epred_trunc_negbinomial(
     epred_prep(lambda, negbinomial(), shape = matrix(2, nrow = 2, ncol = 1)),

--- a/tests/testthat/tests.posterior_epred.R
+++ b/tests/testthat/tests.posterior_epred.R
@@ -245,3 +245,45 @@ test_that("posterior_epred can be reproduced by using d<family>()", {
   expect_equivalent(epred4, epred4_ch)
 })
 
+
+test_that("truncated discrete posterior_epred keeps the lower bound", {
+  # the mean is taken over lb:ub and normalized by F(ub) - F(lb - 1), as in
+  # the generated Stan code and in log_lik; see #1923
+  epred_prep <- function(mu, family, ...) {
+    prep <- structure(list(ndraws = 2L, nobs = 1L), class = "brmsprep")
+    prep$dpars <- c(list(mu = matrix(mu, nrow = 2, ncol = 1)), list(...))
+    prep$family <- family
+    prep
+  }
+  bnd <- function(x) matrix(x, nrow = 2, ncol = 1)
+  lambda <- 3
+
+  got <- suppressMessages(brms:::posterior_epred_trunc_poisson(
+    epred_prep(lambda, poisson()), lb = bnd(2), ub = bnd(6)
+  ))
+  expect_equal(
+    got[1],
+    sum((2:6) * dpois(2:6, lambda)) /
+      (ppois(6, lambda) - ppois(1, lambda))
+  )
+
+  # a lower bound at the edge of the support sends lb - 1 outside it
+  got <- suppressMessages(brms:::posterior_epred_trunc_poisson(
+    epred_prep(lambda, poisson()), lb = bnd(0), ub = bnd(6)
+  ))
+  expect_equal(
+    got[1],
+    sum((0:6) * dpois(0:6, lambda)) / ppois(6, lambda)
+  )
+
+  # negbinomial covers the other cdf shape in the affected set
+  got <- suppressMessages(brms:::posterior_epred_trunc_negbinomial(
+    epred_prep(lambda, negbinomial(), shape = matrix(2, nrow = 2, ncol = 1)),
+    lb = bnd(2), ub = bnd(6)
+  ))
+  expect_equal(
+    got[1],
+    sum((2:6) * dnbinom(2:6, size = 2, mu = lambda)) /
+      (pnbinom(6, size = 2, mu = lambda) - pnbinom(1, size = 2, mu = lambda))
+  )
+})

--- a/tests/testthat/tests.posterior_epred.R
+++ b/tests/testthat/tests.posterior_epred.R
@@ -245,7 +245,6 @@ test_that("posterior_epred can be reproduced by using d<family>()", {
   expect_equivalent(epred4, epred4_ch)
 })
 
-
 test_that("truncated discrete posterior_epred keeps the lower bound", {
   # the mean is taken over lb:ub and normalized by F(ub) - F(lb - 1), as in
   # the generated Stan code and in log_lik; see #1923


### PR DESCRIPTION
Closes #1923. @florence-bockting as offered.

## Summary

`posterior_epred()` averaged over `(lb+1):ub` and normalized by `F(ub) - F(lb)` for truncated discrete models, so the lower bound carried no mass. Stan, `posterior_predict()` and `log_lik()` all include it.

## Problem

`poisson(3)` truncated to `[2, 6]`:

| | mean |
|---|---|
| `posterior_epred()` before | 3.958763 |
| `E[Y \| 2 <= Y <= 6]` | 3.386861 |
| `posterior_predict()`, 40k draws | 3.384 |

## Suggested solution

In `posterior_epred_trunc_discrete()`, sum the kernel from `min_lb`, shift the per-observation index, and normalize by `F(ub) - F(lb - 1)`. Affects binomial, poisson, negbinomial, negbinomial2 and geometric, so `fitted()` and `conditional_effects()` too.

## Note

`pp_cdf()`, `pp_density()`, `pp_quantile()` and `log_lik_com_poisson()` still need the same treatment; separate PRs to follow, as agreed in #1922.

## TODO

+ [x] inclusive bounds in `posterior_epred_trunc_discrete()`
+ [x] tests: poisson two-sided, `lb = 0`, negbinomial
