### PR TITLE
Include the lower bound in truncated discrete posterior_predict outputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@ Thanks to Gidon Frischkorn. (#1450)
 
 ### Bug Fixes
 
+* Stop rounding `posterior_predict` output to integers for discrete models
+unless `output` is `"random"`, which collapsed probabilities and densities
+to 0 or 1. Thanks to Ahmed Eldeeb. (#1923)
 * Include the lower bound in `posterior_predict` outputs `"probability"`,
 `"pit"`, `"density"` and `"quantile"` for truncated discrete models,
 matching the other post-processing methods. Thanks to Ahmed Eldeeb. (#1923)

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@ Thanks to Gidon Frischkorn. (#1450)
 
 ### Bug Fixes
 
+* Include the lower bound in `posterior_predict` outputs `"probability"`,
+`"pit"`, `"density"` and `"quantile"` for truncated discrete models,
+matching the other post-processing methods. Thanks to Ahmed Eldeeb. (#1923)
 * Normalize truncated `log_lik` by `P(lb <= Y <= ub)` for integer
 responses, matching the generated Stan code, so that `loo` and `waic`
 agree with the model that was fitted. Thanks to Ahmed Eldeeb. (#1903)

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -224,7 +224,10 @@ posterior_predict.brmsprep <- function(object, transform = NULL, sort = FALSE,
     out <- do_call(cbind, out)
   }
   colnames(out) <- rownames(out) <- NULL
-  if (use_int(object$family)) {
+  if (use_int(object$family) && output == "random") {
+    # the other outputs are probabilities, densities or quantiles rather
+    # than predicted responses, so neither the bounds check nor the
+    # rounding applies to them; see #1923
     out <- check_discrete_trunc_bounds(
       out, lb = object$data$lb, ub = object$data$ub
     )
@@ -1407,8 +1410,9 @@ pp_cdf <- function(q, distribution, lb, ub, randomized, lower.tail = TRUE,
   int_response <- as_one_logical(int_response)
   args <- validate_distribution_args(distribution, fun_prefix = "p", ...)
   pdist <- paste0("p", distribution)
-  # the lower bound is inclusive for integer responses; see #1923
-  lb_internal <- if (int_response && !is.null(lb)) lb - 1 else lb
+  # the lower bound is inclusive for integer responses, and ceiling() keeps
+  # a non-integer bound on the support it admits, as log_lik does; see #1923
+  lb_internal <- if (int_response && !is.null(lb)) ceiling(lb) - 1 else lb
   # prepare computation of (non-)truncated cdf
   F_internal <- function(q) {
     if (is.null(lb) && is.null(ub)) {
@@ -1463,8 +1467,8 @@ pp_density <- function(q, distribution, lb, ub, log = FALSE,
   if (is.null(lb)) {
     cdf_lb <- rep(0, length(q))
   } else {
-    # the lower bound is inclusive for integer responses; see #1923
-    lb_internal <- if (int_response) lb - 1 else lb
+    # see the note in pp_cdf() on ceiling(); #1923
+    lb_internal <- if (int_response) ceiling(lb) - 1 else lb
     cdf_lb <- do_call(pdist, c(list(lb_internal), pargs))
   }
   if (is.null(ub)) {
@@ -1512,8 +1516,8 @@ pp_quantile <- function(p, distribution, lb, ub, lower.tail = TRUE,
   if (is.null(lb)) {
     cdf_lb <- rep(0, length(p))
   } else {
-    # the lower bound is inclusive for integer responses; see #1923
-    lb_internal <- if (int_response) lb - 1 else lb
+    # see the note in pp_cdf() on ceiling(); #1923
+    lb_internal <- if (int_response) ceiling(lb) - 1 else lb
     cdf_lb <- do_call(pdist, c(list(lb_internal), pargs))
   }
   if (is.null(ub)) {
@@ -1529,7 +1533,12 @@ pp_quantile <- function(p, distribution, lb, ub, lower.tail = TRUE,
           "distribution.")
   }
   p_internal <- p * denom + cdf_lb
-  do_call(qdist, c(list(p_internal), qargs))
+  out <- do_call(qdist, c(list(p_internal), qargs))
+  if (int_response && !is.null(lb)) {
+    # p = 0 inverts to the bound below the support, as F(lb - 1) is attained
+    out <- pmax(out, ceiling(lb))
+  }
+  out
 }
 
 # ensure that only arguments that are accepted by distribution functions are passed

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -1369,17 +1369,19 @@ predict_discrete_helper <- function(i, prep, output, distribution, ntrys = 5,
     },
     "probability" = {
       pp_cdf(q = q, distribution = distribution, lb = lb, ub = ub,
-             randomized = FALSE, ...)
+             randomized = FALSE, int_response = TRUE, ...)
     },
     "pit" = {
       pp_cdf(q = q, distribution = distribution, lb = lb, ub = ub,
-             randomized = TRUE, ...)
+             randomized = TRUE, int_response = TRUE, ...)
     },
     "density" = {
-      pp_density(q = q, distribution = distribution, lb = lb, ub = ub, ...)
+      pp_density(q = q, distribution = distribution, lb = lb, ub = ub,
+                 int_response = TRUE, ...)
     },
     "quantile" = {
-      pp_quantile(p = p, distribution = distribution, lb = lb, ub = ub, ...)
+      pp_quantile(p = p, distribution = distribution, lb = lb, ub = ub,
+                  int_response = TRUE, ...)
     }
   )
 }
@@ -1398,25 +1400,30 @@ predict_discrete_helper <- function(i, prep, output, distribution, ntrys = 5,
 # @return a vector of probability values
 # @noRd
 pp_cdf <- function(q, distribution, lb, ub, randomized, lower.tail = TRUE,
-                   log.p = FALSE, ...) {
+                   log.p = FALSE, int_response = FALSE, ...) {
   randomized <- as_one_logical(randomized)
   lower.tail <- as_one_logical(lower.tail)
   log.p <- as_one_logical(log.p)
+  int_response <- as_one_logical(int_response)
   args <- validate_distribution_args(distribution, fun_prefix = "p", ...)
   pdist <- paste0("p", distribution)
+  # the lower bound is inclusive for integer responses; see #1923
+  lb_internal <- if (int_response && !is.null(lb)) lb - 1 else lb
   # prepare computation of (non-)truncated cdf
   F_internal <- function(q) {
     if (is.null(lb) && is.null(ub)) {
       out <- do_call(pdist, c(list(q), args))
     } else {
-      denom <- do_call(pdist, c(list(ub), args)) - do_call(pdist, c(list(lb), args))
+      denom <- do_call(pdist, c(list(ub), args)) -
+        do_call(pdist, c(list(lb_internal), args))
       if (any(denom == 0)) {
         stop2("Invalid truncation bounds: no probability mass ",
               "between 'lb' and 'ub'. Please check that the ",
               "truncation interval is valid for the response ",
               "distribution.")
       }
-      out <- (do_call(pdist, c(list(q), args)) - do_call(pdist, c(list(lb), args))) / denom
+      out <- (do_call(pdist, c(list(q), args)) -
+        do_call(pdist, c(list(lb_internal), args))) / denom
     }
     out
   }
@@ -1444,7 +1451,8 @@ pp_cdf <- function(q, distribution, lb, ub, randomized, lower.tail = TRUE,
 # @param ... additional arguments passed to the distribution functions
 # @return a vector of density values
 # @noRd
-pp_density <- function(q, distribution, lb, ub, log = FALSE, ...) {
+pp_density <- function(q, distribution, lb, ub, log = FALSE,
+                       int_response = FALSE, ...) {
   dargs <- validate_distribution_args(distribution, fun_prefix = "d", ...)
   pargs <- validate_distribution_args(distribution, fun_prefix = "p", ...)
   ddist <- paste0("d", distribution)
@@ -1455,7 +1463,9 @@ pp_density <- function(q, distribution, lb, ub, log = FALSE, ...) {
   if (is.null(lb)) {
     cdf_lb <- rep(0, length(q))
   } else {
-    cdf_lb <- do_call(pdist, c(list(lb), pargs))
+    # the lower bound is inclusive for integer responses; see #1923
+    lb_internal <- if (int_response) lb - 1 else lb
+    cdf_lb <- do_call(pdist, c(list(lb_internal), pargs))
   }
   if (is.null(ub)) {
     cdf_ub <- rep(1, length(q))
@@ -1488,7 +1498,7 @@ pp_density <- function(q, distribution, lb, ub, log = FALSE, ...) {
 # @return a vector of quantile values
 # @noRd
 pp_quantile <- function(p, distribution, lb, ub, lower.tail = TRUE,
-                        log.p = FALSE, ...) {
+                        log.p = FALSE, int_response = FALSE, ...) {
   qargs <- validate_distribution_args(distribution, fun_prefix = "q", ...)
   pargs <- validate_distribution_args(distribution, fun_prefix = "p", ...)
   qdist <- paste0("q", distribution)
@@ -1502,7 +1512,9 @@ pp_quantile <- function(p, distribution, lb, ub, lower.tail = TRUE,
   if (is.null(lb)) {
     cdf_lb <- rep(0, length(p))
   } else {
-    cdf_lb <- do_call(pdist, c(list(lb), pargs))
+    # the lower bound is inclusive for integer responses; see #1923
+    lb_internal <- if (int_response) lb - 1 else lb
+    cdf_lb <- do_call(pdist, c(list(lb_internal), pargs))
   }
   if (is.null(ub)) {
     cdf_ub <- rep(1, length(p))

--- a/load.R
+++ b/load.R
@@ -1,2 +1,0 @@
-.libPaths(c("/Users/deeb/src/OSS/brms/rlib", .libPaths()))
-suppressMessages(pkgload::load_all("/Users/deeb/src/OSS/brms/wt-pp", quiet = TRUE, export_all = TRUE))

--- a/load.R
+++ b/load.R
@@ -1,0 +1,2 @@
+.libPaths(c("/Users/deeb/src/OSS/brms/rlib", .libPaths()))
+suppressMessages(pkgload::load_all("/Users/deeb/src/OSS/brms/wt-pp", quiet = TRUE, export_all = TRUE))

--- a/tests/testthat/helper-distributions.R
+++ b/tests/testthat/helper-distributions.R
@@ -1669,16 +1669,21 @@ expect_truncated_cdf_density_quantile <- function(entry, lb, ub,
     return(invisible(TRUE))
   }
   if (is.null(q)) q <- entry$q_ref
+  # the lower bound is inclusive for integer responses, so the normalizer
+  # uses F(ceiling(lb) - 1). The rule is written out here rather than taken
+  # from brms, so that these checks pin the convention. See #1923
+  int_response <- isTRUE(entry$flags$discrete_support)
+  lb_norm <- if (int_response) ceiling(lb) - 1 else lb
   F <- function(x) as.numeric(call_dist(entry$p, x, entry$params))
-  denom <- F(ub) - F(lb)
+  denom <- F(ub) - F(lb_norm)
   testthat::expect_true(denom > 0, info = paste(entry$name, "trunc mass"))
 
   # truncated CDF (cheatsheet)
-  F_tr <- (F(q) - F(lb)) / denom
+  F_tr <- (F(q) - F(lb_norm)) / denom
   F_tr_pp <- do.call(
     brms:::pp_cdf,
     c(list(q = q, distribution = entry$backend, lb = lb, ub = ub,
-           randomized = FALSE), entry$params)
+           randomized = FALSE, int_response = int_response), entry$params)
   )
   testthat::expect_equal(as.numeric(F_tr_pp), F_tr, tolerance = tol,
                          info = paste(entry$name, "trunc CDF"))
@@ -1688,20 +1693,22 @@ expect_truncated_cdf_density_quantile <- function(entry, lb, ub,
     dens_tr <- if (q < lb || q > ub) 0 else dens / denom
     dens_pp <- do.call(
       brms:::pp_density,
-      c(list(q = q, distribution = entry$backend, lb = lb, ub = ub),
-        entry$params)
+      c(list(q = q, distribution = entry$backend, lb = lb, ub = ub,
+             int_response = int_response), entry$params)
     )
     testthat::expect_equal(as.numeric(dens_pp), dens_tr, tolerance = tol,
                            info = paste(entry$name, "trunc density"))
   }
 
   if (has_fun(entry, "q")) {
-    p_star <- p * denom + F(lb)
+    # p > 0 always inverts to at least ceiling(lb), so the floor that
+    # pp_quantile() applies for integer responses is inactive here
+    p_star <- p * denom + F(lb_norm)
     q_tr <- as.numeric(call_dist(entry$q, p_star, entry$params))
     q_pp <- do.call(
       brms:::pp_quantile,
-      c(list(p = p, distribution = entry$backend, lb = lb, ub = ub),
-        entry$params)
+      c(list(p = p, distribution = entry$backend, lb = lb, ub = ub,
+             int_response = int_response), entry$params)
     )
     testthat::expect_equal(as.numeric(q_pp), q_tr, tolerance = 1e-5,
                            info = paste(entry$name, "trunc quantile"))

--- a/tests/testthat/helper-posterior-predict.R
+++ b/tests/testthat/helper-posterior-predict.R
@@ -254,6 +254,8 @@ expect_pp_truncation <- function(entry, i = 1L, lb = NULL, ub = NULL,
   }
   prep <- entry$prep_builder(ns = 12, nobs = max(3, i), seed = seed)
   prep <- set_trunc_bounds(prep, lb = lb, ub = ub, i = i)
+  # integer responses treat the lower bound as inclusive; see #1923
+  int_response <- isTRUE(entry$flags$discrete_support)
   q <- entry$q_ref
   # clamp q into [lb, ub] for density/prob checks
   q_in <- min(max(q, lb), ub)
@@ -262,7 +264,7 @@ expect_pp_truncation <- function(entry, i = 1L, lb = NULL, ub = NULL,
   exp_p <- do.call(
     brms:::pp_cdf,
     c(list(q = q_in, distribution = entry$backend, lb = lb, ub = ub,
-           randomized = FALSE), entry$params)
+           randomized = FALSE, int_response = int_response), entry$params)
   )
   testthat::expect_equal(got_p, rep(as.numeric(exp_p), prep$ndraws),
                          tolerance = tol,
@@ -272,8 +274,8 @@ expect_pp_truncation <- function(entry, i = 1L, lb = NULL, ub = NULL,
     got_d <- entry$pp_fun(i, prep = prep, output = "density", q = q_in)
     exp_d <- do.call(
       brms:::pp_density,
-      c(list(q = q_in, distribution = entry$backend, lb = lb, ub = ub),
-        entry$params)
+      c(list(q = q_in, distribution = entry$backend, lb = lb, ub = ub,
+             int_response = int_response), entry$params)
     )
     testthat::expect_equal(got_d, rep(as.numeric(exp_d), prep$ndraws),
                            tolerance = tol,
@@ -284,8 +286,8 @@ expect_pp_truncation <- function(entry, i = 1L, lb = NULL, ub = NULL,
     got_q <- entry$pp_fun(i, prep = prep, output = "quantile", p = 0.4)
     exp_q <- do.call(
       brms:::pp_quantile,
-      c(list(p = 0.4, distribution = entry$backend, lb = lb, ub = ub),
-        entry$params)
+      c(list(p = 0.4, distribution = entry$backend, lb = lb, ub = ub,
+             int_response = int_response), entry$params)
     )
     testthat::expect_equal(got_q, rep(as.numeric(exp_q), prep$ndraws),
                            tolerance = 1e-5,

--- a/tests/testthat/tests.distributions_relations.R
+++ b/tests/testthat/tests.distributions_relations.R
@@ -46,6 +46,9 @@ test_that("truncation formulas match compute_* helpers", {
   for (entry in dist_active_entries(truncation = TRUE)) {
     if (isTRUE(entry$flags$discrete_support)) {
       expect_truncated_cdf_density_quantile(entry, lb = 1, ub = 6)
+      # a non-integer bound admits the same support as ceiling(lb), which
+      # separates ceiling(lb) - 1 from a plain lb - 1. See #1923
+      expect_truncated_cdf_density_quantile(entry, lb = 1.5, ub = 6)
     } else {
       qs <- as.numeric(call_dist(entry$q, c(0.2, 0.8), entry$params))
       expect_truncated_cdf_density_quantile(entry, lb = qs[1], ub = qs[2])

--- a/tests/testthat/tests.posterior_predict.R
+++ b/tests/testthat/tests.posterior_predict.R
@@ -692,9 +692,10 @@ test_that("randomized PIT is reproducible with the same seed", {
 
 test_that("truncated discrete pp_* helpers keep the lower bound", {
   # lb is inclusive for integer responses, as in the Stan code, log_lik and
-  # posterior_epred; the references below come from stats:: rather than from
-  # brms, so the convention is pinned rather than merely self-consistent.
-  # See #1923
+  # posterior_epred. The references come from stats:: rather than from brms,
+  # so these pin the convention inside the three helpers; the call sites that
+  # pass int_response are covered by expect_pp_truncation() and by the pit
+  # and rounding tests below. See #1923
   lam <- 3
   lb <- 2
   ub <- 6
@@ -725,5 +726,43 @@ test_that("truncated discrete pp_* helpers keep the lower bound", {
   expect_equal(
     brms:::pp_density(0.5, "norm", lb = 0, ub = 1, mean = 0, sd = 1),
     dnorm(0.5) / (pnorm(1) - pnorm(0))
+  )
+})
+
+test_that("randomized PIT respects the lower bound for truncated counts", {
+  # under the exclusive convention the PIT at y = lb is negative, and
+  # expect_pp_truncation() never exercises output = "pit"; see #1923
+  lam <- 3
+  prep <- structure(list(ndraws = 200L, nobs = 1L), class = "brmsprep")
+  prep$dpars <- list(mu = matrix(rep(lam, 200), ncol = 1))
+  prep$family <- poisson()
+  prep$data <- list(Y = 2, lb = 2, ub = 6)
+  set.seed(1234)
+  pit <- brms:::posterior_predict_poisson(1, prep, output = "pit")
+  expect_true(all(pit >= 0 & pit <= 1))
+
+  # the per-value intervals [F(y-1), F(y)] must tile [0, 1]
+  set.seed(1234)
+  cdf <- sapply(1:6, function(y) {
+    brms:::pp_cdf(y, "pois", lb = 2, ub = 6, randomized = FALSE,
+                  int_response = TRUE, lambda = lam)
+  })
+  expect_equal(cdf[1], 0)
+  expect_equal(cdf[6], 1)
+})
+
+test_that("non-random posterior_predict outputs are not rounded", {
+  # check_discrete_trunc_bounds() rounds predicted responses, which would
+  # collapse probabilities and densities to 0 or 1; see #1923
+  prep <- structure(list(ndraws = 4L, nobs = 2L), class = "brmsprep")
+  prep$dpars <- list(mu = matrix(3, nrow = 4, ncol = 2))
+  prep$family <- poisson()
+  prep$family$fun <- "poisson"
+  prep$data <- list(Y = c(2, 3), lb = c(2, 2), ub = c(6, 6))
+  dens <- brms:::posterior_predict.brmsprep(prep, output = "density")
+  expect_false(all(dens %in% c(0, 1)))
+  expect_equal(
+    dens[1, 1],
+    dpois(2, 3) / (ppois(6, 3) - ppois(1, 3))
   )
 })

--- a/tests/testthat/tests.posterior_predict.R
+++ b/tests/testthat/tests.posterior_predict.R
@@ -689,3 +689,41 @@ test_that("randomized PIT is reproducible with the same seed", {
   pit3 <- entry$pp_fun(1L, prep = prep, output = "pit", q = 3)
   expect_true(any(pit1 != pit3))
 })
+
+test_that("truncated discrete pp_* helpers keep the lower bound", {
+  # lb is inclusive for integer responses, as in the Stan code, log_lik and
+  # posterior_epred; the references below come from stats:: rather than from
+  # brms, so the convention is pinned rather than merely self-consistent.
+  # See #1923
+  lam <- 3
+  lb <- 2
+  ub <- 6
+  Z <- ppois(ub, lam) - ppois(lb - 1, lam)
+
+  dens <- sapply(lb:ub, function(y) {
+    brms:::pp_density(y, "pois", lb = lb, ub = ub,
+                      int_response = TRUE, lambda = lam)
+  })
+  expect_equal(sum(dens), 1)
+  expect_equal(dens, dpois(lb:ub, lam) / Z)
+
+  cdf <- sapply(lb:ub, function(y) {
+    brms:::pp_cdf(y, "pois", lb = lb, ub = ub, randomized = FALSE,
+                  int_response = TRUE, lambda = lam)
+  })
+  expect_equal(cdf, (ppois(lb:ub, lam) - ppois(lb - 1, lam)) / Z)
+  expect_equal(cdf[length(cdf)], 1)
+
+  # lb must be attainable, which it is not under the exclusive convention
+  expect_equal(
+    brms:::pp_quantile(0.001, "pois", lb = lb, ub = ub,
+                       int_response = TRUE, lambda = lam),
+    lb
+  )
+
+  # continuous responses are untouched
+  expect_equal(
+    brms:::pp_density(0.5, "norm", lb = 0, ub = 1, mean = 0, sd = 1),
+    dnorm(0.5) / (pnorm(1) - pnorm(0))
+  )
+})


### PR DESCRIPTION
Second follow-up from #1922, same convention as #1923. @florence-bockting — this one touches your `posterior_predict` work.

## Summary

`pp_cdf()`, `pp_density()` and `pp_quantile()` normalized by `F(ub) - F(lb)`, so the lower bound carried no mass, while `pp_random_discrete()` beside them includes it. `posterior_predict(output = "probability" | "pit" | "density" | "quantile")` therefore disagreed with `output = "random"`, with `log_lik()` and with the fitted model.

## Problem

`poisson(3)` truncated to `[2, 6]`, before:

- `pp_density()` over `2:6` summed to 1.4124
- `pp_cdf(2, randomized = FALSE)` was 0, so `lb` carried no mass
- `pp_quantile(0.001)` was 3, below the smallest value `posterior_predict()` can draw

Worse, the randomized PIT went negative: over 200k draws from the true truncated pmf, 29% of PIT values were below zero and KS gave `D = 0.292, p < 2e-16`. After, `D = 0.002, p = 0.36`.

## Suggested solution

An `int_response` flag, set by `predict_discrete_helper()`, moving the normalizer to `F(ub) - F(ceiling(lb) - 1)`. `ceiling()` matches `log_lik_truncate()`; plain `lb - 1` would regress non-integer bounds. `pp_quantile()` is floored at `ceiling(lb)`, since `p = 0` otherwise inverts to the value below the support. Continuous paths are untouched.

One thing beyond the title, without which the rest is invisible: `check_discrete_trunc_bounds()` ran for every `output` and ends in `round()`, so the corrected probabilities, PIT values and densities were collapsed to 0 or 1 before reaching the user, with a spurious `"% of all predicted values were invalid"` warning. It now runs only for `output = "random"`, the only one returning predicted responses. Happy to split that out if you would rather.

`expect_pp_truncation()` compared `pp_fun()` against these same functions, so it agreed with either convention. It now passes the flag, and a new test pins the convention against `stats::` references instead.

## TODO

+ [x] `int_response` in `pp_cdf`, `pp_density`, `pp_quantile`
+ [x] tests against `stats::` rather than self-consistency, plus the `"pit"` branch and the rounding
+ [ ] `log_lik_com_poisson()`, which ignores truncation entirely — last of the three
