### PR TITLE
Align R-side COM-Poisson functions with Stan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@ Thanks to Gidon Frischkorn. (#1450)
 
 ### Bug Fixes
 
+* Align the R-side `com_poisson` distribution functions and mean with the
+  parameterization used by Stan. (#1927)
 * Normalize truncated `log_lik` by `P(lb <= Y <= ub)` for integer
 responses, matching the generated Stan code, so that `loo` and `waic`
 agree with the model that was fitted. Thanks to Ahmed Eldeeb. (#1903)
@@ -2295,5 +2297,4 @@ have proper priors by default.
 # brms 0.1.0
 
 * Initial release version
-
 

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1383,12 +1383,11 @@ mean_discrete_weibull <- function(mu, shape, M = 1000, thres = 0.001) {
 }
 
 # PDF of the COM-Poisson distribution
-# com_poisson in brms uses the mode parameterization
 dcom_poisson <- function(x, mu, shape, log = FALSE) {
   x <- round(x)
   log_mu <- log(mu)
   log_Z <- log_Z_com_poisson(log_mu, shape)
-  out <- shape * (x * log_mu - lgamma(x + 1)) - log_Z
+  out <- x * log_mu - shape * lgamma(x + 1) - log_Z
   if (!log) {
     out <- exp(out)
   }
@@ -1413,13 +1412,13 @@ pcom_poisson <- function(x, mu, shape, lower.tail = TRUE, log.p = FALSE) {
   log_Z <- log_Z_com_poisson(log_mu, shape)
   out <- rep(0, length(x))
   dim(out) <- attributes(args)$max_dim
-  out[x > 0] <- log1p_exp(shape * log_mu)
+  out[x > 0] <- log1p_exp(log_mu[x > 0])
   k <- 2
   lfac <- 0
   while (any(x >= k)) {
     lfac <- lfac + log(k)
-    term <- shape * (k * log_mu - lfac)
-    out[x >= k] <- log_sum_exp(out[x >= k], term)
+    term <- k * log_mu - shape * lfac
+    out[x >= k] <- log_sum_exp(out[x >= k], term[x >= k])
     k <- k + 1
   }
   out <- out - log_Z
@@ -1477,7 +1476,7 @@ qcom_poisson <- function(p, mu, shape, lower.tail = TRUE, log.p = FALSE,
     y <- y + 1
     out_t[not_found] <- y
     lfac <- lfac + log(y)
-    cdf <- cdf + exp(shape_t * (y * log_mu - lfac) - log_Z)
+    cdf <- cdf + exp(y * log_mu - shape_t * lfac - log_Z)
     not_found <- cdf < p_t
   }
 
@@ -1538,13 +1537,13 @@ log_Z_com_poisson <- function(log_mu, shape, M = 10000, thres = 1e-16,
     log_mu <- log_mu[use_exact]
     shape <- shape[use_exact]
     # first 2 terms of the series
-    out_exact <- log1p_exp(shape * log_mu)
+    out_exact <- log1p_exp(log_mu)
     lfac <- 0
     k <- 2
     converged <- FALSE
     while (!converged && k <= M) {
       lfac <- lfac + log(k)
-      term <- shape * (k * log_mu - lfac)
+      term <- k * log_mu - shape * lfac
       out_exact <- log_sum_exp(out_exact, term)
       converged <- all(term <= log_thres)
       k <- k + 1
@@ -1563,17 +1562,19 @@ log_Z_com_poisson <- function(log_mu, shape, M = 10000, thres = 1e-16,
 # approximate the log normalizing constant of the COM Poisson distribution
 # based on doi:10.1007/s10463-017-0629-6
 log_Z_com_poisson_approx <- function(log_mu, shape) {
-  shape_mu <- shape * exp(log_mu)
+  log_common <- log(shape) + log_mu / shape
+  shape_mu <- shape * exp(log_mu / shape)
   shape2 <- shape^2
   # first 4 terms of the residual series
   log_sum_resid <- log(
-    1 + shape_mu^(-1) * (shape2 - 1) / 24 +
-      shape_mu^(-2) * (shape2 - 1) / 1152 * (shape2 + 23) +
-      shape_mu^(-3) * (shape2 - 1) / 414720 *
+    1 + exp(-log_common) * (shape2 - 1) / 24 +
+      exp(-2 * log_common) * (shape2 - 1) / 1152 * (shape2 + 23) +
+      exp(-3 * log_common) * (shape2 - 1) / 414720 *
         (5 * shape2^2 - 298 * shape2 + 11237)
   )
   shape_mu + log_sum_resid -
-    ((log(2 * pi) + log_mu) * (shape - 1) / 2 + log(shape) / 2)
+    ((shape - 1) / (2 * shape) * log_mu +
+      (shape - 1) / 2 * log(2 * pi) + 0.5 * log(shape))
 }
 
 # compute the log mean of the COM Poisson distribution
@@ -1621,15 +1622,15 @@ mean_com_poisson <- function(mu, shape, M = 10000, thres = 1e-16,
     shape <- shape[use_exact]
     log_mu <- log(mu)
     # first 2 terms of the series
-    log_num <- shape * log_mu  # numerator
-    log_Z <- log1p_exp(shape * log_mu)  # denominator
+    log_num <- log_mu  # numerator
+    log_Z <- log1p_exp(log_mu)  # denominator
     lfac <- 0
     k <- 2
     converged <- FALSE
     while (!converged && k <= M) {
       log_k <- log(k)
       lfac <- lfac + log_k
-      term <- shape * (k * log_mu - lfac)
+      term <- k * log_mu - shape * lfac
       log_num <- log_sum_exp(log_num, log_k + term)
       log_Z <- log_sum_exp(log_Z, term)
       converged <- all(term <= log_thres)
@@ -1649,10 +1650,11 @@ mean_com_poisson <- function(mu, shape, M = 10000, thres = 1e-16,
 # approximate the mean of COM-Poisson distribution
 # based on doi:10.1007/s10463-017-0629-6
 mean_com_poisson_approx <- function(mu, shape) {
-  term <- 1 - (shape - 1) / (2 * shape) * mu^(-1) -
-    (shape^2 - 1) / (24 * shape^2) * mu^(-2) -
-    (shape^2 - 1) / (24 * shape^3) * mu^(-3)
-  mu * term
+  mu_root <- mu^(1 / shape)
+  term <- 1 - (shape - 1) / (2 * shape) * mu_root^(-1) -
+    (shape^2 - 1) / (24 * shape^2) * mu_root^(-2) -
+    (shape^2 - 1) / (24 * shape^3) * mu_root^(-3)
+  mu_root * term
 }
 
 #' The Dirichlet Distribution

--- a/tests/testthat/tests.distributions_analytical.R
+++ b/tests/testthat/tests.distributions_analytical.R
@@ -50,6 +50,49 @@ test_that("com_poisson reduces to Poisson when shape = 1", {
   )
 })
 
+test_that("com_poisson matches the Stan parameterization", {
+  mu <- 3
+  shape <- 2
+  x <- 0:100
+  log_Z <- brms:::log_Z_com_poisson(log(mu), shape)
+  log_pmf <- x * log(mu) - shape * lgamma(x + 1) - log_Z
+  pmf <- exp(log_pmf)
+
+  expect_equal(
+    brms:::dcom_poisson(x, mu = mu, shape = shape),
+    pmf,
+    tolerance = 1e-10
+  )
+
+  x_cdf <- c(0, 1, 3, 8)
+  expect_equal(
+    brms:::pcom_poisson(x_cdf, mu = mu, shape = shape),
+    vapply(x_cdf, function(x) min(1, sum(pmf[seq_len(x + 1)])), numeric(1)),
+    tolerance = 1e-10
+  )
+
+  p <- c(0.1, 0.5, 0.9)
+  expect_equal(
+    brms:::qcom_poisson(p, mu = mu, shape = shape),
+    vapply(p, function(p) which(cumsum(pmf) >= p)[1] - 1, numeric(1))
+  )
+
+  log_Z_exact <- brms:::log_Z_com_poisson(log(mu), shape, approx = FALSE)
+  log_pmf_exact <- x * log(mu) - shape * lgamma(x + 1) - log_Z_exact
+
+  expect_equal(
+    brms:::mean_com_poisson(mu, shape, approx = FALSE),
+    sum(x * exp(log_pmf_exact)),
+    tolerance = 1e-10
+  )
+
+  expect_equal(
+    brms:::mean_com_poisson(10, 2),
+    brms:::mean_com_poisson(10, 2, approx = FALSE),
+    tolerance = 1e-3
+  )
+})
+
 test_that("qexgaussian handles probabilities outside (0, 1)", {
   entry <- dist_registry_get("exgaussian")[[1]]
   res <- SW(call_dist(entry$q, c(-1, 0, 1, 1.5), entry$params))


### PR DESCRIPTION
## Summary
Align the R-side `com_poisson` distribution functions and mean with the parameterization used by Stan.

## Thanks to maintainers
Thanks to Paul and the brms maintainers for maintaining the package and for pointing out the preferred direction in the discussion of this issue.

## Issue or motivation
Fixes #1927. After #1765 changed the Stan implementation, the R-side density, CDF, quantile, normalizing constant, and mean calculations still used the previous parameterization.

## Root cause
The R functions multiplied the complete log-Poisson term by `shape`, whereas the updated Stan model applies `shape` only to the factorial term. The approximation formulas were also still expressed in terms of the previous parameterization.

## Change
- Align the exact R-side distribution and mean calculations with the current Stan formulas.
- Port the corresponding normalizing-constant and mean approximations.
- Keep vectorized CDF accumulation aligned for inputs with different cutoffs.
- Add regression coverage for density, CDF, quantile, and mean calculations.

## Tests
- `R CMD build --no-manual --no-build-vignettes .`
- `R CMD check --as-cran --no-manual --ignore-vignettes brms_2.23.1.tar.gz`: passed with the repository's existing two NOTES.
- Full `testthat.R` run: passed.

## Scope
This changes only the R-side calculations and regression coverage for `com_poisson`. It does not change the Stan implementation, the public function interface, or unrelated distributions and vignettes.