### PR TITLE
Restore mode parameterization of com_poisson on the Stan side

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,15 @@ such that `step(0) == 1` thanks to Daniel Sabanes Bov. (#1734)
 * Make `read_csv_as_stanfit()` store `adapt_delta` and `max_treedepth` values in
 `$control` so rstan can find these values. Thanks to Tristan Mahr (#1767).
 * Enable updating argument `data2` for `brmsfit_multiple` objects. (#1776)
+* Restore the mode parameterization of the `com_poisson` family on the Stan
+side, which had switched to the classical parameterization in #1765 while the
+R-side density functions did not, so that R-side post-processing no longer
+disagrees with the sampled density whenever `shape != 1`. Also correct the
+condition selecting the asymptotic normalizing constant, which was left
+unchanged by that switch and so no longer described the intended region.
+Models fitted with `com_poisson` and `shape != 1` using affected versions
+were sampled under the classical parameterization and should be
+refitted. (#1927)
 * Fix several other minor bugs.
 
 ### Other Changes

--- a/inst/chunks/fun_com_poisson.stan
+++ b/inst/chunks/fun_com_poisson.stan
@@ -1,13 +1,15 @@
   // log approximate normalizing constant of the COM poisson distribuion
   // based on equations (4) and (31) of doi:10.1007/s10463-017-0629-6
-  // Args: see log_Z_com_poisson()
-  real log_Z_com_poisson_approx(real log_mu, real nu) {
+  // Args:
+  //   log_lambda: log of the classical rate parameter, that is nu * log(mu)
+  //   nu: positive shape parameter
+  real log_Z_com_poisson_approx(real log_lambda, real nu) {
     real nu2 = nu^2;
-    real log_common = log(nu) + log_mu / nu;
+    real log_common = log(nu) + log_lambda / nu;
     array[4] real resids;
     real ans;
-    real lcte = (nu * exp(log_mu / nu)) -
-      ((nu - 1) / (2 * nu) * log_mu +
+    real lcte = (nu * exp(log_lambda / nu)) -
+      ((nu - 1) / (2 * nu) * log_lambda +
        (nu - 1) / 2 * log(2 * pi()) + 0.5 * log(nu));
     real c_1 = (nu2 - 1) / 24;
     real c_2 = (nu2 - 1) / 1152 * (nu2 + 23);
@@ -22,11 +24,11 @@
 
   // log of kth term of the normalizing series of the COM Poisson distribution
   // Args:
-  //   log_mu: log location parameter
-  //   shape: positive shape parameter
+  //   log_lambda: log of the classical rate parameter, that is nu * log(mu)
+  //   nu: positive shape parameter
   //   k: k-th term
-  real log_k_term(real log_mu, real nu, int k) {
-    return (k - 1) * log_mu - nu * lgamma(k);
+  real log_k_term(real log_lambda, real nu, int k) {
+    return (k - 1) * log_lambda - nu * lgamma(k);
   }
 
   // bound for the remainder of the normalizing series of the COM Poisson
@@ -54,10 +56,14 @@
   // log normalizing constant of the COM Poisson distribution
   // implementation inspired by code of Ben Goodrich
   // improved following suggestions of Sebastian Weber (#892)
+  // brms parameterizes com_poisson through the modal location mu, while the
+  // series below is evaluated in the classical parameterization lambda = mu^nu;
+  // convert internally to log_lambda = nu * log_mu
   // Args:
-  //   log_mu: log location parameter
-  //   shape: positive shape parameter
+  //   log_mu: log of the modal location parameter
+  //   nu: positive shape parameter
   real log_Z_com_poisson(real log_mu, real nu) {
+    real log_lambda = nu * log_mu;
     real log_Z;
     int k = 2;
     int M = 10000;
@@ -74,25 +80,27 @@
     if (nu == positive_infinity()) {
       reject("nu must be finite");
     }
-    if (log_mu * nu >= log(1.5) && log_mu >= log(1.5)) {
-      return log_Z_com_poisson_approx(log_mu, nu);
+    // use the same rule-of-thumb region as log_Z_com_poisson() in R:
+    // lambda >= 1.5 and mu = lambda^(1 / nu) >= 1.5
+    if (log_lambda >= log(1.5) && log_mu >= log(1.5)) {
+      return log_Z_com_poisson_approx(log_lambda, nu);
     }
     // direct computation of the truncated series
     // check if the Mth term of the series pass in the stopping criteria
-    if (bound_remainder(log_k_term(log_mu, nu, M),
-                        log_k_term(log_mu, nu, M - 1)) >= leps) {
+    if (bound_remainder(log_k_term(log_lambda, nu, M),
+                        log_k_term(log_lambda, nu, M - 1)) >= leps) {
       reject("nu is too close to zero.");
     }
 
     // first 2 terms of the series
-    log_Z_terms[1] = log_k_term(log_mu, nu, 1);
-    log_Z_terms[2] = log_k_term(log_mu, nu, 2);
+    log_Z_terms[1] = log_k_term(log_lambda, nu, 1);
+    log_Z_terms[2] = log_k_term(log_lambda, nu, 2);
 
     while (((log_Z_terms[k] >= log_Z_terms[k-1]) ||
       (stopping_criterio_bucket(log_Z_terms[k], log_Z_terms[k-1], k, leps))) &&
       k < M) {
       k += 1;
-      log_Z_terms[k] = log_k_term(log_mu, nu, k);
+      log_Z_terms[k] = log_k_term(log_lambda, nu, k);
     }
     log_Z = log_sum_exp(log_Z_terms[1:k]);
 
@@ -101,11 +109,12 @@
   // COM Poisson log-PMF for a single response (log parameterization)
   // Args:
   //   y: the response value
-  //   log_mu: log location parameter
-  //   shape: positive shape parameter
+  //   log_mu: log of the modal location parameter
+  //   nu: positive shape parameter
   real com_poisson_log_lpmf(int y, real log_mu, real nu) {
     if (nu == 1) return poisson_log_lpmf(y | log_mu);
-    return y * log_mu - nu * lgamma(y + 1) - log_Z_com_poisson(log_mu, nu);
+    return nu * (y * log_mu - lgamma(y + 1))
+           - log_Z_com_poisson(log_mu, nu);
   }
   // COM Poisson log-PMF for a single response
   real com_poisson_lpmf(int y, real mu, real nu) {
@@ -114,7 +123,8 @@
   }
   // COM Poisson log-CDF for a single response
   real com_poisson_lcdf(int y, real mu, real nu) {
-    real log_mu;
+    real log_mu = log(mu);
+    real log_lambda = nu * log_mu;
     real log_Z;  // log denominator
     vector[y] log_num_terms;  // terms of the log numerator
     if (nu == 1) {
@@ -130,8 +140,7 @@
     if (y > 10000) {
       reject("cannot handle y > 10000");
     }
-    log_mu = log(mu);
-    if (y * log_mu - nu * lgamma(y + 1) <= -36.0) {
+    if (y * log_lambda - nu * lgamma(y + 1) <= -36.0) {
       // y is large enough for the CDF to be very close to 1;
       return 0;
     }
@@ -140,10 +149,10 @@
       return -log_Z;
     }
     // first 2 terms of the series
-    log_num_terms[1] = log1p_exp(nu * log_mu);
+    log_num_terms[1] = log1p_exp(log_lambda);
     // remaining terms of the series until y
     for (k in 2:y) {
-      log_num_terms[k] = k * log_mu - nu * lgamma(k + 1);
+      log_num_terms[k] = k * log_lambda - nu * lgamma(k + 1);
     }
     return log_sum_exp(log_num_terms) - log_Z;
   }

--- a/tests/testthat/tests.distributions_analytical.R
+++ b/tests/testthat/tests.distributions_analytical.R
@@ -50,6 +50,95 @@ test_that("com_poisson reduces to Poisson when shape = 1", {
   )
 })
 
+test_that("com_poisson uses the mode parameterization", {
+  # mu is the modal location: p(y + 1) / p(y) = (mu / (y + 1))^shape,
+  # so the pmf is maximized at floor(mu) for non-integer mu. This holds
+  # independently of the normalizing constant and pins down the meaning
+  # of mu away from shape == 1, where the mode and classical
+  # parameterizations coincide.
+  for (mu in c(3.4, 7.6)) {
+    for (shape in c(0.5, 1.5, 3)) {
+      d <- brms:::dcom_poisson(0:200, mu = mu, shape = shape)
+      expect_equal(which.max(d) - 1, floor(mu), info = paste(mu, shape))
+    }
+  }
+})
+
+test_that("dcom_poisson matches the mode-parameterized series", {
+  # brute force reference: p(y) proportional to (mu^y / y!)^shape.
+  # mu = 1.2 keeps log_Z_com_poisson on the exact series rather than the
+  # asymptotic approximation, so agreement should be to machine precision.
+  log_sum_exp_ref <- function(x) {
+    m <- max(x)
+    m + log(sum(exp(x - m)))
+  }
+  ref <- function(y, mu, shape, K = 2000) {
+    j <- 0:K
+    lterms <- shape * (j * log(mu) - lgamma(j + 1))
+    exp(shape * (y * log(mu) - lgamma(y + 1)) - log_sum_exp_ref(lterms))
+  }
+  y <- 0:8
+  for (shape in c(0.5, 0.8, 1.5, 3)) {
+    expect_equal(
+      brms:::dcom_poisson(y, mu = 1.2, shape = shape),
+      ref(y, mu = 1.2, shape = shape),
+      tolerance = 1e-12
+    )
+  }
+})
+
+test_that("com_poisson Stan functions match the R implementation", {
+  # Regression test for #1927. The Stan chunk and the R density must agree
+  # away from shape == 1, where the mode and classical parameterizations
+  # coincide. mu = 1.2 stays on the exact series, mu = 3.4 takes the
+  # asymptotic branch; y = 1 exercises the first numerator term of the CDF.
+  skip_if_not_installed("cmdstanr")
+  skip_if(is.null(tryCatch(cmdstanr::cmdstan_path(), error = function(e) NULL)))
+
+  chunk <- system.file("chunks", "fun_com_poisson.stan", package = "brms")
+  skip_if(!nzchar(chunk))
+
+  code <- c(
+    "functions {", readLines(chunk), "}",
+    "data {",
+    "  int<lower=1> N;",
+    "  array[N] int y;",
+    "  vector[N] mu;",
+    "  vector[N] nu;",
+    "}",
+    "generated quantities {",
+    "  vector[N] lpmf;",
+    "  vector[N] lcdf;",
+    "  for (n in 1:N) {",
+    "    lpmf[n] = com_poisson_lpmf(y[n] | mu[n], nu[n]);",
+    "    lcdf[n] = com_poisson_lcdf(y[n] | mu[n], nu[n]);",
+    "  }",
+    "}"
+  )
+  sf <- file.path(tempdir(), "test_com_poisson.stan")
+  writeLines(code, sf)
+  mod <- cmdstanr::cmdstan_model(sf)
+
+  d <- expand.grid(y = c(0L, 1L, 4L), mu = c(1.2, 3.4), nu = c(0.6, 1.5))
+  fit <- mod$sample(
+    data = list(N = nrow(d), y = d$y, mu = d$mu, nu = d$nu),
+    fixed_param = TRUE, iter_sampling = 1, chains = 1,
+    refresh = 0, show_messages = FALSE, sig_figs = 18
+  )
+  draws <- posterior::as_draws_matrix(fit$draws())
+
+  expect_equal(
+    as.numeric(draws[1, sprintf("lpmf[%d]", seq_len(nrow(d)))]),
+    brms:::dcom_poisson(d$y, mu = d$mu, shape = d$nu, log = TRUE),
+    tolerance = 1e-8
+  )
+  expect_equal(
+    as.numeric(draws[1, sprintf("lcdf[%d]", seq_len(nrow(d)))]),
+    log(mapply(brms:::pcom_poisson, d$y, d$mu, d$nu)),
+    tolerance = 1e-8
+  )
+})
+
 test_that("qexgaussian handles probabilities outside (0, 1)", {
   entry <- dist_registry_get("exgaussian")[[1]]
   res <- SW(call_dist(entry$q, c(-1, 0, 1, 1.5), entry$params))


### PR DESCRIPTION
Closes #1927.

This restores the historical brms mode parameterization of `com_poisson` on the Stan side while retaining the numerical improvements introduced in #1765.

In the brms parameterization,

```text
p(y) ∝ (mu^y / y!)^nu
```

so the corresponding classical COM-Poisson rate is

```text
lambda = mu^nu
```

or, on the log scale,

```text
log_lambda = nu * log_mu
```

#1765 changed the Stan likelihood to use the classical parameterization directly, while the R-side distribution functions remained in the mode parameterization. The two therefore disagree whenever `shape != 1`.

## Changes

- Restore the mode-parameterized Stan log-PMF.
- Keep `log_Z_com_poisson()` explicitly parameterized in terms of the brms modal location `log_mu`, matching the R-side function.
- Convert internally with

  ```text
  log_lambda = nu * log_mu
  ```

  before calling the classical-series machinery introduced in #1765.
- Make the CDF use the same transformation consistently.
- Restore the intended rule-of-thumb region for selecting the asymptotic normalizer:

  ```text
  lambda >= 1.5
  lambda^(1 / nu) >= 1.5
  ```

The CDF and approximation-region changes were additional consequences of the same parameterization switch that I found while validating the original fix. They are not independent changes: the CDF contained a mixture of the two coordinate systems, and the approximation predicate had been left textually unchanged when the meaning of `log_mu` changed.

The lower-level helpers `log_k_term()` and `log_Z_com_poisson_approx()` remain expressed in terms of `log_lambda`. These are the classical-series computational helpers introduced in #1765 rather than user-facing distribution functions, and keeping them on that scale allows the computational improvements from #1765 to be retained essentially unchanged.

## R-side computation

I also looked at whether the #1765 stopping criterion should be ported to the R implementation.

The current R exact summation stops once the next log term is below `log(1e-16)`, whereas the Stan implementation uses the #1765 remainder bound with `leps = -23 * log(2)` and checks the stopping criterion in buckets.

On difficult exact-branch cases, the existing R implementation is actually more accurate. For example:

| `mu` | `nu` | R error | Stan error |
|---:|---:|---:|---:|
| 1.0 | 0.05 | 1.1e-14 | 5.2e-09 |
| 0.5 | 0.10 | 4.4e-16 | 5.2e-09 |

So I did not port the Stan stopping criterion to R, since doing so would reduce numerical accuracy rather than improve it.

## Verification

I compiled `fun_com_poisson.stan` with CmdStan and compared the Stan functions directly with the R implementation at `shape != 1`.

The regression grid covers:

- the exact normalizer branch;
- the asymptotic normalizer branch;
- both over- and under-dispersion;
- the CDF, including its first nontrivial terms.

I also checked the approximation boundary directly at `mu = 1.5`; Stan and R agree to numerical precision.

The analytical tests pass:

```text
FAIL 0 | WARN 0 | SKIP 0 | PASS 168
```

Additional tests pin down the meaning of `mu` independently of the normalizer and compare `dcom_poisson()` against a brute-force evaluation of

```text
(mu^y / y!)^nu
```

## Existing fits

Fits produced by affected versions with `shape != 1` were sampled under the classical parameterization. Updating brms cannot reinterpret those draws as mode-parameterized fits, so affected models should be refitted.

A NEWS entry documents this.